### PR TITLE
Temporarily disable broken ide extension e2e tests

### DIFF
--- a/.github/workflows/ide-extension-e2e-test.yml
+++ b/.github/workflows/ide-extension-e2e-test.yml
@@ -1,9 +1,7 @@
 name: Test ide-extension with E2E tests
 
 on:
-  pull_request:
-    branches:
-      - "main"
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
This PR disables the ide extension e2e workflow, unless it's manually triggered. 
No scripts/code is removed, as we will want to fix the tests in the future