### PR TITLE
add default timeouts because lix file deletions are slow at the moment

### DIFF
--- a/inlang/packages/paraglide/paraglide-js/vitest.config.ts
+++ b/inlang/packages/paraglide/paraglide-js/vitest.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
 	test: {
 		// default timeout
-		testTimeout: 20000,
+		testTimeout: 30000,
 		coverage: {
 			include: ["src/**/*"],
 			exclude: ["src/cli/**/*", "src/bundler-plugins/**/*"],

--- a/inlang/packages/sdk/vitest.config.ts
+++ b/inlang/packages/sdk/vitest.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
 	test: {
 		// default timeout
-		testTimeout: 20000,
+		testTimeout: 30000,
 		globals: true,
 		environment: "node",
 		server: {


### PR DESCRIPTION
Lix file selections and deletions are not cached at the moment. To make CI pass, we need to add a higher test default timeout.