### PR TITLE
Fix invalid arrow function syntax in docs

### DIFF
--- a/inlang/packages/paraglide/paraglide-js/examples/react-router/README.md
+++ b/inlang/packages/paraglide/paraglide-js/examples/react-router/README.md
@@ -50,7 +50,7 @@ const localeMiddleware: Route.unstable_MiddlewareFunction = async (
 ) => {
   return await paraglideMiddleware(request, () => {
     return next();
-  }, { onRedirect: (response) => throw response });
+  }, { onRedirect: (response) => { throw response } });
 };
 
 export { localeMiddleware };


### PR DESCRIPTION
Added curly braces to arrow function using throw to correct JavaScript syntax.