### PR TITLE
fix: fix eslint incorrectly linting generated files

### DIFF
--- a/.changeset/nasty-otters-greet.md
+++ b/.changeset/nasty-otters-greet.md
@@ -1,0 +1,15 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+fix: fix eslint incorrectly linting generated files
+
+closes https://github.com/opral/inlang-paraglide-js/issues/558
+
+eslint ignores single-line 'eslint-disable' comments at the start of a file.
+Using a block comment without a closing one instead will prompt eslint to ignore it.
+
+```diff
+-	output[filename] = `// eslint-disable\n${content}`;
++	output[filename] = `/* eslint-disable */\n${content}`;
+```

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/compile-project.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/compile-project.ts
@@ -94,7 +94,7 @@ export const compileProject = async (args: {
 	for (const [filename, content] of Object.entries(output)) {
 		if (optionsWithDefaults.includeEslintDisableComment) {
 			if (filename.endsWith(".js")) {
-				output[filename] = `// eslint-disable\n${content}`;
+				output[filename] = `/* eslint-disable */\n${content}`;
 			}
 		}
 	}

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/compile.test.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/compile.test.ts
@@ -309,7 +309,7 @@ test("includes eslint-disable comment", async () => {
 
 	const messages = await fs.promises.readFile("/output/messages.js", "utf8");
 
-	expect(messages).toContain("// eslint-disable");
+	expect(messages).toContain("/* eslint-disable */");
 
 	await compile({
 		project: "/project.inlang",
@@ -323,7 +323,7 @@ test("includes eslint-disable comment", async () => {
 		"utf8"
 	);
 
-	expect(messagesWithoutComment).not.toContain("// eslint-disable");
+	expect(messagesWithoutComment).not.toContain("/* eslint-disable */");
 });
 
 test("default compiler options should include cookied, variable and baseLocale to ensure easy try out of paraglide js, working both in server and browser environemnts", () => {


### PR DESCRIPTION
closes https://github.com/opral/inlang-paraglide-js/issues/558

eslint ignores single-line 'eslint-disable' comments at the start of a file.
Using a block comment without a closing one instead will prompt eslint to ignore it.

```diff
-	output[filename] = `// eslint-disable\n${content}`;
+	output[filename] = `/* eslint-disable */\n${content}`;
```