### PR TITLE
fix: make locale matching case-insensitive

### DIFF
--- a/.changeset/eleven-rats-tap.md
+++ b/.changeset/eleven-rats-tap.md
@@ -1,0 +1,16 @@
+---
+"@inlang/paraglide-js": patch
+---
+
+fix: make locale matching case-insensitive
+
+Closes https://github.com/opral/inlang-paraglide-js/issues/549
+
+This fixes an issue that locales containing uppercase characters like `pt-BR` failed to load when using `extractLocaleFromNavigator` or `extractLocaleFromHeader`.
+
+The issue occurred because these functions converted locales to lowercase, while the comparison logic inside `assertIsLocale` and `isLocale` wasn't case-sensitive.
+
+List of changes:
+- Ensured locale comparisons in `assertIsLocale()` and `isLocale()` are fully case-insensitive.
+- Made `assertIsLocale()` return the canonical-cased locale from `locales` instead of the raw input.
+- Added new test coverage for case-insensitive behavior in `assertIsLocale()` and `isLocale()`.

--- a/inlang/packages/paraglide/paraglide-js/docs-api/runtime/type/-internal-.md
+++ b/inlang/packages/paraglide/paraglide-js/docs-api/runtime/type/-internal-.md
@@ -353,7 +353,7 @@ The used URL patterns.
 
 > **assertIsLocale**(`input`): `any`
 
-Defined in: [runtime/assert-is-locale.js:11](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/assert-is-locale.js)
+Defined in: [runtime/assert-is-locale.js:10](https://github.com/opral/monorepo/tree/main/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/assert-is-locale.js)
 
 Asserts that the input is a locale.
 

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/assert-is-locale.js
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/assert-is-locale.js
@@ -1,4 +1,3 @@
-import { isLocale } from "./is-locale.js";
 import { locales } from "./variables.js";
 
 /**
@@ -9,10 +8,17 @@ import { locales } from "./variables.js";
  * @throws {Error} If the input is not a locale.
  */
 export function assertIsLocale(input) {
-	if (isLocale(input) === false) {
+	if (typeof input !== "string") {
+		throw new Error(`Invalid locale: ${input}. Expected a string.`);
+	}
+	const lowerInput = input.toLowerCase();
+	const matchedLocale = locales.find(
+		(item) => item.toLowerCase() === lowerInput
+	);
+	if (!matchedLocale) {
 		throw new Error(
 			`Invalid locale: ${input}. Expected one of: ${locales.join(", ")}`
 		);
 	}
-	return input;
+	return matchedLocale;
 }

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/assert-is-locale.test.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/assert-is-locale.test.ts
@@ -1,6 +1,6 @@
-import { test, expect } from "vitest";
-import { createParaglide } from "../create-paraglide.js";
 import { newProject } from "@inlang/sdk";
+import { expect, test } from "vitest";
+import { createParaglide } from "../create-paraglide.js";
 
 test("throws if the locale is not available", async () => {
 	const runtime = await createParaglide({
@@ -13,6 +13,23 @@ test("throws if the locale is not available", async () => {
 	});
 
 	expect(() => runtime.assertIsLocale("es")).toThrow();
+});
+
+test("throws for non-string inputs", async () => {
+	const runtime = await createParaglide({
+		blob: await newProject({
+			settings: {
+				baseLocale: "en",
+				locales: ["en", "de"],
+			},
+		}),
+	});
+
+	expect(() => runtime.assertIsLocale(null)).toThrow();
+	expect(() => runtime.assertIsLocale(undefined)).toThrow();
+	expect(() => runtime.assertIsLocale(123)).toThrow();
+	expect(() => runtime.assertIsLocale({})).toThrow();
+	expect(() => runtime.assertIsLocale([])).toThrow();
 });
 
 test("passes if the locale is available", async () => {
@@ -42,4 +59,23 @@ test("the return value is a Locale", async () => {
 	// a bit of a wacky test given that locale is `any`
 	// in the ambient type definition
 	locale satisfies Locale;
+});
+
+test("is case-insensitive", async () => {
+	const runtime = await createParaglide({
+		blob: await newProject({
+			settings: {
+				baseLocale: "en",
+				locales: ["en", "pt-BR", "de-ch"],
+			},
+		}),
+	});
+
+	expect(() => runtime.assertIsLocale("EN")).not.toThrow();
+	expect(() => runtime.assertIsLocale("pt-br")).not.toThrow();
+	expect(() => runtime.assertIsLocale("de-CH")).not.toThrow();
+
+	expect(runtime.assertIsLocale("EN")).toBe("en");
+	expect(runtime.assertIsLocale("pT-bR")).toBe("pt-BR");
+	expect(runtime.assertIsLocale("de-CH")).toBe("de-ch");
 });

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/is-locale.js
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/is-locale.js
@@ -14,5 +14,8 @@ import { locales } from "./variables.js";
  * @returns {locale is Locale}
  */
 export function isLocale(locale) {
-	return !locale ? false : locales.includes(locale);
+	if (typeof locale !== "string") return false;
+	return !locale
+		? false
+		: locales.some((item) => item.toLowerCase() === locale.toLowerCase());
 }

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/is-locale.test.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/is-locale.test.ts
@@ -1,0 +1,36 @@
+import { newProject } from "@inlang/sdk";
+import { expect, test } from "vitest";
+import { createParaglide } from "../create-paraglide.js";
+
+const runtime = await createParaglide({
+	blob: await newProject({
+		settings: {
+			baseLocale: "en",
+			locales: ["en", "pt-BR", "de-ch"],
+		},
+	}),
+});
+
+test("returns true for exact matches", () => {
+	expect(runtime.isLocale("pt-BR")).toBe(true);
+});
+
+test("is case-insensitive", () => {
+	expect(runtime.isLocale("EN")).toBe(true);
+	expect(runtime.isLocale("pt-br")).toBe(true);
+	expect(runtime.isLocale("de-CH")).toBe(true);
+});
+
+test("returns false for non-existent locales", () => {
+	expect(runtime.isLocale("es")).toBe(false);
+	expect(runtime.isLocale("xx")).toBe(false);
+	expect(runtime.isLocale("")).toBe(false);
+});
+
+test("returns false for non-string inputs", () => {
+	expect(runtime.isLocale(null)).toBe(false);
+	expect(runtime.isLocale(undefined)).toBe(false);
+	expect(runtime.isLocale(123)).toBe(false);
+	expect(runtime.isLocale({})).toBe(false);
+	expect(runtime.isLocale([])).toBe(false);
+});


### PR DESCRIPTION
This PR fixes https://github.com/opral/inlang-paraglide-js/issues/549 which reported that locales containing uppercase characters like `pt-BR` failed to load when using `extractLocaleFromNavigator` or `extractLocaleFromHeader`.

The issue occurred because these functions converted locales to lowercase, while the comparison logic inside `assertIsLocale` and `isLocale` wasn't case-sensitive.

List of changes:
- Ensured locale comparisons in `assertIsLocale()` and `isLocale()` are fully case-insensitive.
- Made `assertIsLocale()` return the canonical-cased locale from `locales` instead of the raw input.
- Added new test coverage for case-insensitive behavior in `assertIsLocale()` and `isLocale()`.