### PR TITLE
docs: clarify nested key guidance in paraglide docs

### DIFF
--- a/inlang/packages/paraglide/paraglide-js/docs/message-keys.md
+++ b/inlang/packages/paraglide/paraglide-js/docs/message-keys.md
@@ -10,7 +10,7 @@ imports:
 Paraglide JS supports nested keys through bracket notation syntax `m["something.nested"]()`, which simulates nesting without actually creating nested JavaScript objects. This approach leverages TypeScript's template literal types to provide type safety while maintaining the flat structure that enables tree-shaking.
 
 <doc-callout type="warning">
-  While nested keys are supported, we strongly recommend using flat keys instead. The flat structure is what databases, applications, and compilers naturally work with.
+  While nested keys are supported, we still recommend using flat keys. Flat keys align better with how databases, applications, and compilers naturally work — even though the bracket notation keeps the generated modules tree-shakeable.
 </doc-callout>
 
 ## Why we recommend flat keys
@@ -27,8 +27,8 @@ While nested keys might seem nice for developers initially, they create pain for
 
 - **Translators**: Have to understand hierarchical structures instead of simple key-value pairs
 - **Build tools**: Need to parse and transform nested structures into flat lists
-- **Runtime performance**: Simulated nesting through bracket notation prevents some optimizations
-- **Type safety**: While TypeScript template literals provide types, direct function names offer better IDE support
+- **Developer experience**: Flat keys compile to direct function names, which provide richer IDE support such as go-to-definition and auto-imports
+- **Consistency across tooling**: Flat keys mirror how translators, design tools, and message catalogs typically represent content
 
 ## How to use nested keys (if you must)
 


### PR DESCRIPTION
## Summary
- clarify that bracket notation for nested keys remains tree-shakeable
- adjust rationale for preferring flat keys to focus on developer experience and tooling consistency

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_690b63892a3c8326a2e7f0e0bfeb56b8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies nested vs flat key guidance, noting bracket-notation remains tree-shakeable and refocusing rationale on DX and tooling consistency.
> 
> - **Docs** (`inlang/packages/paraglide/paraglide-js/docs/message-keys.md`):
>   - **Guidance update**: Revised warning to note bracket-notation nested keys remain tree-shakeable while still recommending flat keys.
>   - **Rationale tweaks**: Replaced bullets on runtime performance/type-safety with emphasis on developer experience and tooling consistency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e4f14922a8733ee16a0338df3eca2b5b90d9a0c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->