### PR TITLE
fix deployment

### DIFF
--- a/packages/lix/react-utils/package.json
+++ b/packages/lix/react-utils/package.json
@@ -34,8 +34,8 @@
 		"jsdom": "^26.1.0",
 		"oxlint": "^1.14.0",
 		"prettier": "^3.3.3",
-		"react": "19.1.1",
-		"react-dom": "19.1.1",
+		"react": "19.2.0",
+		"react-dom": "19.2.0",
 		"typescript": "^5.5.4",
 		"vitest": "^3.2.4"
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1574,7 +1574,7 @@ importers:
     devDependencies:
       '@nx/storybook':
         specifier: ^18.0.4
-        version: 18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(js-yaml@4.1.0)(nx@18.3.5)(typescript@5.8.3)
+        version: 18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(js-yaml@4.1.0)(nx@21.4.1)(typescript@5.8.3)
       '@opral/tsconfig':
         specifier: workspace:*
         version: link:../../../../packages/tsconfig
@@ -1659,7 +1659,7 @@ importers:
         version: link:../../sdk
       '@nx/storybook':
         specifier: ^18.0.4
-        version: 18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(js-yaml@4.1.0)(nx@21.4.1)(typescript@5.4.5)
+        version: 18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(js-yaml@4.1.0)(nx@18.3.5)(typescript@5.4.5)
       '@opral/tsconfig':
         specifier: workspace:*
         version: link:../../../../packages/tsconfig
@@ -1850,8 +1850,6 @@ importers:
       vitest:
         specifier: 2.1.8
         version: 2.1.8(@types/node@20.5.9)(@vitest/browser@2.1.8)(happy-dom@18.0.1)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.10.2(@types/node@20.5.9)(typescript@5.8.3))(sass-embedded@1.89.2)(terser@5.36.0)
-
-  inlang/packages/website/dist/server: {}
 
   inlang/packages/website/tailwind-color-plugin:
     dependencies:
@@ -2525,25 +2523,25 @@ importers:
         version: link:../react-utils
       '@tanstack/react-table':
         specifier: ^8.21.2
-        version: 8.21.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 8.21.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@types/dagre':
         specifier: ^0.7.52
         version: 0.7.53
       '@xyflow/react':
         specifier: ^12.3.4
-        version: 12.7.1(@types/react@19.1.8)(immer@10.1.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 12.7.1(@types/react@19.1.8)(immer@10.1.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
       lucide-react:
         specifier: ^0.483.0
-        version: 0.483.0(react@19.1.0)
+        version: 0.483.0(react@19.2.0)
       react:
         specifier: ^19.0.0
-        version: 19.1.0
+        version: 19.2.0
       react-dom:
         specifier: ^19.0.0
-        version: 19.1.0(react@19.1.0)
+        version: 19.2.0(react@19.2.0)
     devDependencies:
       '@lix-js/sdk':
         specifier: workspace:*
@@ -2860,7 +2858,7 @@ importers:
         version: link:../../tsconfig
       '@testing-library/react':
         specifier: ^16.3.0
-        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@types/react':
         specifier: ^19.1.8
         version: 19.1.12
@@ -2880,11 +2878,11 @@ importers:
         specifier: ^3.3.3
         version: 3.6.2
       react:
-        specifier: 19.1.1
-        version: 19.1.1
+        specifier: 19.2.0
+        version: 19.2.0
       react-dom:
-        specifier: 19.1.1
-        version: 19.1.1(react@19.1.1)
+        specifier: 19.2.0
+        version: 19.2.0(react@19.2.0)
       typescript:
         specifier: ^5.5.4
         version: 5.9.2
@@ -24185,9 +24183,9 @@ snapshots:
     dependencies:
       which: 3.0.1
 
-  '@nrwl/cypress@18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(js-yaml@4.1.0)(nx@18.3.5)(typescript@5.8.3)':
+  '@nrwl/cypress@18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(js-yaml@4.1.0)(nx@18.3.5)(typescript@5.4.5)':
     dependencies:
-      '@nx/cypress': 18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(js-yaml@4.1.0)(nx@18.3.5)(typescript@5.8.3)
+      '@nx/cypress': 18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(js-yaml@4.1.0)(nx@18.3.5)(typescript@5.4.5)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -24202,9 +24200,9 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nrwl/cypress@18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(js-yaml@4.1.0)(nx@21.4.1)(typescript@5.4.5)':
+  '@nrwl/cypress@18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(js-yaml@4.1.0)(nx@21.4.1)(typescript@5.8.3)':
     dependencies:
-      '@nx/cypress': 18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(js-yaml@4.1.0)(nx@21.4.1)(typescript@5.4.5)
+      '@nx/cypress': 18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(js-yaml@4.1.0)(nx@21.4.1)(typescript@5.8.3)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -24246,9 +24244,9 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nrwl/js@18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(nx@18.3.5)(typescript@5.8.3)':
+  '@nrwl/js@18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(nx@21.4.1)(typescript@5.4.5)':
     dependencies:
-      '@nx/js': 18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(nx@18.3.5)(typescript@5.8.3)
+      '@nx/js': 18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(nx@21.4.1)(typescript@5.4.5)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -24261,9 +24259,9 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nrwl/js@18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(nx@21.4.1)(typescript@5.4.5)':
+  '@nrwl/js@18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(nx@21.4.1)(typescript@5.8.3)':
     dependencies:
-      '@nx/js': 18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(nx@21.4.1)(typescript@5.4.5)
+      '@nx/js': 18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(nx@21.4.1)(typescript@5.8.3)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -24282,9 +24280,9 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@nrwl/storybook@18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(js-yaml@4.1.0)(nx@18.3.5)(typescript@5.8.3)':
+  '@nrwl/storybook@18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(js-yaml@4.1.0)(nx@18.3.5)(typescript@5.4.5)':
     dependencies:
-      '@nx/storybook': 18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(js-yaml@4.1.0)(nx@18.3.5)(typescript@5.8.3)
+      '@nx/storybook': 18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(js-yaml@4.1.0)(nx@18.3.5)(typescript@5.4.5)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -24299,9 +24297,9 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nrwl/storybook@18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(js-yaml@4.1.0)(nx@21.4.1)(typescript@5.4.5)':
+  '@nrwl/storybook@18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(js-yaml@4.1.0)(nx@21.4.1)(typescript@5.8.3)':
     dependencies:
-      '@nx/storybook': 18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(js-yaml@4.1.0)(nx@21.4.1)(typescript@5.4.5)
+      '@nx/storybook': 18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(js-yaml@4.1.0)(nx@21.4.1)(typescript@5.8.3)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -24333,13 +24331,13 @@ snapshots:
       - '@swc/core'
       - debug
 
-  '@nx/cypress@18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(js-yaml@4.1.0)(nx@18.3.5)(typescript@5.8.3)':
+  '@nx/cypress@18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(js-yaml@4.1.0)(nx@18.3.5)(typescript@5.4.5)':
     dependencies:
-      '@nrwl/cypress': 18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(js-yaml@4.1.0)(nx@18.3.5)(typescript@5.8.3)
+      '@nrwl/cypress': 18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(js-yaml@4.1.0)(nx@18.3.5)(typescript@5.4.5)
       '@nx/devkit': 18.3.5(nx@18.3.5)
       '@nx/eslint': 18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(js-yaml@4.1.0)(nx@18.3.5)
-      '@nx/js': 18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(nx@18.3.5)(typescript@5.8.3)
-      '@phenomnomnominal/tsquery': 5.0.1(typescript@5.8.3)
+      '@nx/js': 18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(nx@18.3.5)(typescript@5.4.5)
+      '@phenomnomnominal/tsquery': 5.0.1(typescript@5.4.5)
       detect-port: 1.6.1
       semver: 7.7.2
       tslib: 2.8.1
@@ -24356,13 +24354,13 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/cypress@18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(js-yaml@4.1.0)(nx@21.4.1)(typescript@5.4.5)':
+  '@nx/cypress@18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(js-yaml@4.1.0)(nx@21.4.1)(typescript@5.8.3)':
     dependencies:
-      '@nrwl/cypress': 18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(js-yaml@4.1.0)(nx@21.4.1)(typescript@5.4.5)
+      '@nrwl/cypress': 18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(js-yaml@4.1.0)(nx@21.4.1)(typescript@5.8.3)
       '@nx/devkit': 18.3.5(nx@21.4.1)
       '@nx/eslint': 18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(js-yaml@4.1.0)(nx@21.4.1)
-      '@nx/js': 18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(nx@21.4.1)(typescript@5.4.5)
-      '@phenomnomnominal/tsquery': 5.0.1(typescript@5.4.5)
+      '@nx/js': 18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(nx@21.4.1)(typescript@5.8.3)
+      '@phenomnomnominal/tsquery': 5.0.1(typescript@5.8.3)
       detect-port: 1.6.1
       semver: 7.7.2
       tslib: 2.8.1
@@ -24488,49 +24486,6 @@ snapshots:
       - supports-color
       - typescript
 
-  '@nx/js@18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(nx@18.3.5)(typescript@5.8.3)':
-    dependencies:
-      '@babel/core': 7.28.3
-      '@babel/plugin-proposal-decorators': 7.25.9(@babel/core@7.28.3)
-      '@babel/plugin-transform-class-properties': 7.25.9(@babel/core@7.28.3)
-      '@babel/plugin-transform-runtime': 7.25.9(@babel/core@7.28.3)
-      '@babel/preset-env': 7.26.0(@babel/core@7.28.3)
-      '@babel/preset-typescript': 7.26.0(@babel/core@7.28.3)
-      '@babel/runtime': 7.28.3
-      '@nrwl/js': 18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(nx@18.3.5)(typescript@5.8.3)
-      '@nx/devkit': 18.3.5(nx@18.3.5)
-      '@nx/workspace': 18.3.5
-      '@phenomnomnominal/tsquery': 5.0.1(typescript@5.8.3)
-      babel-plugin-const-enum: 1.2.0(@babel/core@7.28.3)
-      babel-plugin-macros: 2.8.0
-      babel-plugin-transform-typescript-metadata: 0.3.2(@babel/core@7.28.3)(@babel/traverse@7.28.3)
-      chalk: 4.1.2
-      columnify: 1.6.0
-      detect-port: 1.6.1
-      fast-glob: 3.2.7
-      fs-extra: 11.3.1
-      ignore: 5.3.2
-      js-tokens: 4.0.0
-      minimatch: 9.0.3
-      npm-package-arg: 11.0.1
-      npm-run-path: 4.0.1
-      ora: 5.3.0
-      semver: 7.7.2
-      source-map-support: 0.5.19
-      ts-node: 10.9.1(@types/node@24.10.0)(typescript@5.8.3)
-      tsconfig-paths: 4.2.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - '@babel/traverse'
-      - '@swc-node/register'
-      - '@swc/core'
-      - '@swc/wasm'
-      - '@types/node'
-      - debug
-      - nx
-      - supports-color
-      - typescript
-
   '@nx/js@18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(nx@21.4.1)(typescript@5.4.5)':
     dependencies:
       '@babel/core': 7.28.3
@@ -24561,6 +24516,49 @@ snapshots:
       semver: 7.7.2
       source-map-support: 0.5.19
       ts-node: 10.9.1(@types/node@24.10.0)(typescript@5.4.5)
+      tsconfig-paths: 4.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@babel/traverse'
+      - '@swc-node/register'
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - debug
+      - nx
+      - supports-color
+      - typescript
+
+  '@nx/js@18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(nx@21.4.1)(typescript@5.8.3)':
+    dependencies:
+      '@babel/core': 7.28.3
+      '@babel/plugin-proposal-decorators': 7.25.9(@babel/core@7.28.3)
+      '@babel/plugin-transform-class-properties': 7.25.9(@babel/core@7.28.3)
+      '@babel/plugin-transform-runtime': 7.25.9(@babel/core@7.28.3)
+      '@babel/preset-env': 7.26.0(@babel/core@7.28.3)
+      '@babel/preset-typescript': 7.26.0(@babel/core@7.28.3)
+      '@babel/runtime': 7.28.3
+      '@nrwl/js': 18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(nx@21.4.1)(typescript@5.8.3)
+      '@nx/devkit': 18.3.5(nx@21.4.1)
+      '@nx/workspace': 18.3.5
+      '@phenomnomnominal/tsquery': 5.0.1(typescript@5.8.3)
+      babel-plugin-const-enum: 1.2.0(@babel/core@7.28.3)
+      babel-plugin-macros: 2.8.0
+      babel-plugin-transform-typescript-metadata: 0.3.2(@babel/core@7.28.3)(@babel/traverse@7.28.3)
+      chalk: 4.1.2
+      columnify: 1.6.0
+      detect-port: 1.6.1
+      fast-glob: 3.2.7
+      fs-extra: 11.3.1
+      ignore: 5.3.2
+      js-tokens: 4.0.0
+      minimatch: 9.0.3
+      npm-package-arg: 11.0.1
+      npm-run-path: 4.0.1
+      ora: 5.3.0
+      semver: 7.7.2
+      source-map-support: 0.5.19
+      ts-node: 10.9.1(@types/node@24.10.0)(typescript@5.8.3)
       tsconfig-paths: 4.2.0
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -24664,14 +24662,14 @@ snapshots:
   '@nx/nx-win32-x64-msvc@21.4.1':
     optional: true
 
-  '@nx/storybook@18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(js-yaml@4.1.0)(nx@18.3.5)(typescript@5.8.3)':
+  '@nx/storybook@18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(js-yaml@4.1.0)(nx@18.3.5)(typescript@5.4.5)':
     dependencies:
-      '@nrwl/storybook': 18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(js-yaml@4.1.0)(nx@18.3.5)(typescript@5.8.3)
-      '@nx/cypress': 18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(js-yaml@4.1.0)(nx@18.3.5)(typescript@5.8.3)
+      '@nrwl/storybook': 18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(js-yaml@4.1.0)(nx@18.3.5)(typescript@5.4.5)
+      '@nx/cypress': 18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(js-yaml@4.1.0)(nx@18.3.5)(typescript@5.4.5)
       '@nx/devkit': 18.3.5(nx@18.3.5)
       '@nx/eslint': 18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(js-yaml@4.1.0)(nx@18.3.5)
-      '@nx/js': 18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(nx@18.3.5)(typescript@5.8.3)
-      '@phenomnomnominal/tsquery': 5.0.1(typescript@5.8.3)
+      '@nx/js': 18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(nx@18.3.5)(typescript@5.4.5)
+      '@phenomnomnominal/tsquery': 5.0.1(typescript@5.4.5)
       semver: 7.7.2
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -24688,14 +24686,14 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/storybook@18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(js-yaml@4.1.0)(nx@21.4.1)(typescript@5.4.5)':
+  '@nx/storybook@18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(js-yaml@4.1.0)(nx@21.4.1)(typescript@5.8.3)':
     dependencies:
-      '@nrwl/storybook': 18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(js-yaml@4.1.0)(nx@21.4.1)(typescript@5.4.5)
-      '@nx/cypress': 18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(js-yaml@4.1.0)(nx@21.4.1)(typescript@5.4.5)
+      '@nrwl/storybook': 18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(js-yaml@4.1.0)(nx@21.4.1)(typescript@5.8.3)
+      '@nx/cypress': 18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(js-yaml@4.1.0)(nx@21.4.1)(typescript@5.8.3)
       '@nx/devkit': 18.3.5(nx@21.4.1)
       '@nx/eslint': 18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(js-yaml@4.1.0)(nx@21.4.1)
-      '@nx/js': 18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(nx@21.4.1)(typescript@5.4.5)
-      '@phenomnomnominal/tsquery': 5.0.1(typescript@5.4.5)
+      '@nx/js': 18.3.5(@babel/traverse@7.28.3)(@types/node@24.10.0)(nx@21.4.1)(typescript@5.8.3)
+      '@phenomnomnominal/tsquery': 5.0.1(typescript@5.8.3)
       semver: 7.7.2
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -28121,11 +28119,11 @@ snapshots:
       tailwindcss: 4.1.10
       vite: 7.1.3(@types/node@24.10.0)(jiti@2.5.1)(lightningcss@1.30.1)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1)
 
-  '@tanstack/react-table@8.21.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@tanstack/react-table@8.21.3(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@tanstack/table-core': 8.21.3
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
 
   '@tanstack/react-virtual@3.10.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -28165,12 +28163,12 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  '@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.2(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.28.3
       '@testing-library/dom': 10.4.1
-      react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.1.12
       '@types/react-dom': 19.2.2(@types/react@19.1.12)
@@ -31003,13 +31001,13 @@ snapshots:
       - '@types/react'
       - immer
 
-  '@xyflow/react@12.7.1(@types/react@19.1.8)(immer@10.1.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@xyflow/react@12.7.1(@types/react@19.1.8)(immer@10.1.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@xyflow/system': 0.0.63
       classcat: 5.0.5
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-      zustand: 4.5.5(@types/react@19.1.8)(immer@10.1.1)(react@19.1.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+      zustand: 4.5.5(@types/react@19.1.8)(immer@10.1.1)(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - immer
@@ -36440,13 +36438,13 @@ snapshots:
     dependencies:
       react: 19.1.1
 
-  lucide-react@0.483.0(react@19.1.0):
-    dependencies:
-      react: 19.1.0
-
   lucide-react@0.483.0(react@19.1.1):
     dependencies:
       react: 19.1.1
+
+  lucide-react@0.483.0(react@19.2.0):
+    dependencies:
+      react: 19.2.0
 
   lucide-react@0.542.0(react@19.2.0):
     dependencies:
@@ -42472,13 +42470,13 @@ snapshots:
     dependencies:
       react: 18.3.1
 
-  use-sync-external-store@1.2.2(react@19.1.0):
-    dependencies:
-      react: 19.1.0
-
   use-sync-external-store@1.2.2(react@19.1.1):
     dependencies:
       react: 19.1.1
+
+  use-sync-external-store@1.2.2(react@19.2.0):
+    dependencies:
+      react: 19.2.0
 
   use-sync-external-store@1.5.0(react@18.3.1):
     dependencies:
@@ -44513,12 +44511,12 @@ snapshots:
       immer: 10.1.1
       react: 19.1.1
 
-  zustand@4.5.5(@types/react@19.1.8)(immer@10.1.1)(react@19.1.0):
+  zustand@4.5.5(@types/react@19.1.8)(immer@10.1.1)(react@19.2.0):
     dependencies:
-      use-sync-external-store: 1.2.2(react@19.1.0)
+      use-sync-external-store: 1.2.2(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.1.8
       immer: 10.1.1
-      react: 19.1.0
+      react: 19.2.0
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
Vite bundled different versions of react which led to a crash in prod.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns React and React DOM to 19.2.0 across packages and updates the lockfile to eliminate mixed React versions.
> 
> - **Dependencies**:
>   - Bump `react` and `react-dom` in `packages/lix/react-utils/package.json` from `19.1.1` to `19.2.0`.
>   - Update `pnpm-lock.yaml` to resolve all React-related entries to `19.2.0`, affecting consumers like `packages/lix/inspector` (e.g., `@tanstack/react-table`, `@xyflow/react`, `lucide-react`, `zustand`, `use-sync-external-store`).
>   - Reconcile Nx/Storybook/Cypress lockfile entries with Typescript peer versions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8167aa0a78aed9a6e2b318930204ed4c78682b30. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->