### PR TITLE
Add history navigation support in PromptComposer component

### DIFF
--- a/packages/flashtype/src/views/agent-view/components/prompt-composer.test.tsx
+++ b/packages/flashtype/src/views/agent-view/components/prompt-composer.test.tsx
@@ -107,6 +107,30 @@ describe("PromptComposer", () => {
 		expect(textarea.value).toBe("message-5");
 	});
 
+	test("does not enter history navigation while editing a draft", async () => {
+		const onSendMessage = vi.fn().mockResolvedValue(undefined);
+		const { textarea, sendButton } = renderComposer({ onSendMessage });
+
+		await act(async () => {
+			fireEvent.change(textarea, { target: { value: "previous message" } });
+			fireEvent.click(sendButton);
+		});
+		await waitFor(() => {
+			expect(onSendMessage).toHaveBeenCalledWith("previous message");
+			expect(textarea.value).toBe("");
+		});
+
+		const draft = ["line one", "line two", "line three"].join("\n");
+		fireEvent.change(textarea, { target: { value: draft } });
+		textarea.setSelectionRange(draft.length, draft.length);
+
+		await act(async () => {
+			fireEvent.keyDown(textarea, { key: "ArrowUp" });
+		});
+
+		expect(textarea.value).toBe(draft);
+	});
+
 	test("auto accept toggle forwards next value", async () => {
 		const onAutoAcceptToggle = vi.fn().mockResolvedValue(undefined);
 		renderComposer({ onAutoAcceptToggle });


### PR DESCRIPTION
- Implemented functionality to navigate message history using ArrowUp key when the composer is empty.
- Updated tests to verify that editing a draft does not trigger history navigation.
- Refactored history index management to improve clarity and functionality.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds ArrowUp/Down message history navigation when the composer is empty and caret is at start, prevents entering history while editing drafts, and refactors history index handling.
> 
> - **PromptComposer**:
>   - Add ArrowUp/Down message history navigation with entry only when composer is empty and caret at start; navigate both directions and keep caret at end.
>   - Track `historyIdx` in state and include in hook deps; reset to `-1` on input change.
>   - Guard history logic using selection/caret checks and early returns when not applicable or no history.
> - **Tests**:
>   - Add test ensuring history navigation does not activate while editing a multi-line draft.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a0fbdb9e24478edb375b59c3d4893c0a401f6f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->