### PR TITLE
Fix ProseMirror showcase image on docs landing page

### DIFF
--- a/packages/lix/docs/docs/components/landing-page.tsx
+++ b/packages/lix/docs/docs/components/landing-page.tsx
@@ -1,11 +1,6 @@
 import { useState } from "react";
 import type { SyntheticEvent } from "react";
 
-const prosemirrorScreenshot = new URL(
-  "../../../plugin-prosemirror/assets/prosemirror.png",
-  import.meta.url,
-).href;
-
 /**
  * Copy icon used for the install command interaction.
  *
@@ -356,7 +351,7 @@ function LandingPage() {
       category: "Real-time editors",
       description:
         "Collaborative publishing UI with branching proposals, inline reviews, and one-click merges.",
-      screenshot: prosemirrorScreenshot,
+      screenshot: "/prosemirror.png",
       fallback: "ProseMirror Demo",
       href: "https://github.com/opral/monorepo/tree/main/packages/lix/plugin-prosemirror",
       ctaLabel: "View code →",


### PR DESCRIPTION
## Summary
- update the docs landing page so the ProseMirror showcase screenshot loads from the public assets and renders correctly

## Testing
- not run (docs change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914b6c0d3508326bab4838edc7f74c1)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches the ProseMirror showcase screenshot to a public asset path for correct rendering.
> 
> - **Docs landing page (`packages/lix/docs/docs/components/landing-page.tsx`)**:
>   - Update ProseMirror showcase `screenshot` to `"/prosemirror.png"`.
>   - Remove unused `prosemirrorScreenshot` asset import.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e56b35c26ee6b58473ccbe0e0f5f0d2eff77352a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->