### PR TITLE
refactor: update README and code for Google Translate API key handling; add RPC fallback

### DIFF
--- a/inlang/packages/cli/README.md
+++ b/inlang/packages/cli/README.md
@@ -137,7 +137,7 @@ High-level steps:
 1. Create or select a Google Cloud project.
 2. Enable the **Cloud Translation API (Basic)** for the project.
 3. Generate a credential of type **API key** under *APIs & Services → Credentials*.
-4. Copy the key and assign it to `INLANG_GOOGLE_TRANSLATE_API_KEY`.
+4. Copy the key and expose it as `INLANG_GOOGLE_TRANSLATE_API_KEY` env variable.
 
 **Migration**
 

--- a/inlang/packages/cli/package.json
+++ b/inlang/packages/cli/package.json
@@ -40,8 +40,9 @@
     "clean": "rm -rf ./dist ./node_modules"
   },
   "dependencies": {
-    "esbuild-wasm": "^0.19.2",
-    "@inlang/sdk": "workspace:*"
+    "@inlang/rpc": "workspace:*",
+    "@inlang/sdk": "workspace:*",
+    "esbuild-wasm": "^0.19.2"
   },
   "devDependencies": {
     "@sentry/node": "^7.64.0",

--- a/inlang/packages/cli/src/commands/machine/machineTranslateBundle.ts
+++ b/inlang/packages/cli/src/commands/machine/machineTranslateBundle.ts
@@ -16,7 +16,7 @@ type MachineTranslateArgs = {
   googleApiKey?: string;
 };
 
-type MachineTranslateResult = {
+export type MachineTranslateResult = {
   data?: NewBundleNested;
   error?: string;
 };

--- a/inlang/packages/rpc/src/services/env-variables/createIndexFile.js
+++ b/inlang/packages/rpc/src/services/env-variables/createIndexFile.js
@@ -20,7 +20,7 @@ await fs.writeFile(
 	dirname + "/index.js",
 	`
 export const PUBLIC_ENV_VARIABLES = {
-	PUBLIC_SERVER_BASE_URL: ${ifDefined(process.env.PUBLIC_SERVER_BASE_URL)},
+	PUBLIC_SERVER_BASE_URL: "https://inlang.com",
 	PUBLIC_ALLOWED_AUTH_URLS: ${ifDefined(process.env.PUBLIC_ALLOWED_AUTH_URLS)},
 }
 `

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
 
   inlang/packages/cli:
     dependencies:
+      '@inlang/rpc':
+        specifier: workspace:*
+        version: link:../rpc
       '@inlang/sdk':
         specifier: workspace:*
         version: link:../sdk


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds RPC fallback to `machine translate` when no Google API key is set, updates README env instructions, exports result type, and defaults RPC public base URL to `https://inlang.com`.
> 
> - **CLI**
>   - **Machine translation**: Fallback to `@inlang/rpc.machineTranslateBundle` when `INLANG_GOOGLE_TRANSLATE_API_KEY` is missing, with warning logs.
>   - Export `MachineTranslateResult` from `machineTranslateBundle.ts` and use it in `translate.ts`.
>   - Add `@inlang/rpc` as a dependency in `inlang/packages/cli/package.json`.
> - **RPC**
>   - Set `PUBLIC_SERVER_BASE_URL` default to `"https://inlang.com"` in `inlang/packages/rpc/src/services/env-variables/createIndexFile.js`.
> - **Docs**
>   - README: clarify step to expose Google API key as `INLANG_GOOGLE_TRANSLATE_API_KEY` env variable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e44413e15c557a0b2115c755a9e88a8ebd7004b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->