### PR TITLE
pushdown entity_id

### DIFF
--- a/packages/lix/sdk/src/engine/preprocessor/entity-views/insert.ts
+++ b/packages/lix/sdk/src/engine/preprocessor/entity-views/insert.ts
@@ -602,6 +602,8 @@ function buildStateRowExpressions(args: {
 		return undefined;
 	};
 
+	const resolvedDefaults = new Map<string, unknown>();
+
 	const renderPrimaryKeyExpr = (
 		descriptor: PrimaryKeyDescriptor
 	): string | null => {
@@ -637,7 +639,7 @@ function buildStateRowExpressions(args: {
 			literal,
 			cel: args.celEnvironment,
 			context: args.celContext,
-			resolvedDefaults: new Map(),
+			resolvedDefaults,
 		});
 		if (!defaultExpr || defaultExpr === "NULL") {
 			return null;
@@ -736,7 +738,6 @@ function buildStateRowExpressions(args: {
 	const untrackedExpr: ExpressionLike =
 		expressionFor("lixcol_untracked") ?? literal(untrackedValue);
 
-	const resolvedDefaults = new Map<string, unknown>();
 	const snapshotContentExpr = buildSnapshotObjectExpression({
 		schema: args.schema,
 		columnMap,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Pushes an `entity_id` predicate into rewritten DELETE/UPDATE statements when WHERE matches schema primary key(s), with shared helpers and tests; minor insert default-resolution refactor.
> 
> - **Entity view rewriting**:
>   - DELETE: add `state_by_version.entity_id` condition when WHERE includes primary key equality; respects absence of PK.
>   - UPDATE: compute and add `state_by_version.entity_id` condition from PK equality in WHERE.
> - **Shared utilities**:
>   - Add `collectPrimaryKeyEqualityExpressions` and `buildEntityIdExpressionFromEquality` to derive `entity_id` SQL from PK filters.
>   - Extend equality collection and value serialization; pointer alias matching for PKs.
> - **Tests**:
>   - New/updated tests for DELETE and UPDATE to assert `entity_id` predicate presence/omission and behavior across base/_by_version variants.
> - **Insert minor change**:
>   - Reuse a shared `resolvedDefaults` map when rendering defaults.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dba08b5a0910e1da58a2a55d2482275aaa6ec064. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->