### PR TITLE
Enhance SQL queries and tests for file-scoped unique constraints

### DIFF
--- a/packages/lix/sdk/src/engine/preprocessor/entity-views/__bench__/entity-view-select-all-rows.explain.txt
+++ b/packages/lix/sdk/src/engine/preprocessor/entity-views/__bench__/entity-view-select-all-rows.explain.txt
@@ -180,7 +180,7 @@ WHERE sa.schema_key = 'bench_entity_view' AND sa.version_id = 'boot_0000000000')
     "id": 66,
     "parent": 52,
     "notused": 62,
-    "detail": "SEARCH cache USING INDEX idx_lix_internal_state_cache_v1_bench_entity_view_pk_version_id_json_extract_snapsho_4h2kdb (version_id=?)"
+    "detail": "SEARCH cache USING INDEX idx_lix_internal_state_cache_v1_bench_entity_view_pk_version_id_json_extract_snapsho_file_id_b2i1mo (version_id=?)"
   },
   {
     "id": 88,

--- a/packages/lix/sdk/src/engine/preprocessor/entity-views/__bench__/entity-view-select-id-filter.explain.txt
+++ b/packages/lix/sdk/src/engine/preprocessor/entity-views/__bench__/entity-view-select-id-filter.explain.txt
@@ -183,7 +183,7 @@ WHERE id = ?
     "id": 66,
     "parent": 52,
     "notused": 62,
-    "detail": "SEARCH cache USING INDEX idx_lix_internal_state_cache_v1_bench_entity_view_pk_version_id_json_extract_snapsho_4h2kdb (version_id=?)"
+    "detail": "SEARCH cache USING INDEX idx_lix_internal_state_cache_v1_bench_entity_view_pk_version_id_json_extract_snapsho_file_id_b2i1mo (version_id=?)"
   },
   {
     "id": 88,

--- a/packages/lix/sdk/src/filesystem/__bench__/batch-file-reads-select-multiple-files.explain.txt
+++ b/packages/lix/sdk/src/filesystem/__bench__/batch-file-reads-select-multiple-files.explain.txt
@@ -362,7 +362,7 @@ WHERE "id" IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     "id": 48,
     "parent": 42,
     "notused": 62,
-    "detail": "SEARCH cache USING INDEX idx_lix_internal_state_cache_v1_lix_file_descriptor_unique_version_id_json_extract_snapsho_json_extract_snapsho_json_extract_snapsho_h3d0az (version_id=?)"
+    "detail": "SEARCH cache USING INDEX idx_lix_internal_state_cache_v1_lix_file_descriptor_unique_version_id_json_extract_snapsho_json_extract_snapsho_json_extract_snapsho_file_id_42p3je (version_id=?)"
   },
   {
     "id": 78,

--- a/packages/lix/sdk/src/filesystem/__bench__/file-read-by-exact-path.explain.txt
+++ b/packages/lix/sdk/src/filesystem/__bench__/file-read-by-exact-path.explain.txt
@@ -362,7 +362,7 @@ WHERE "path" = ?
     "id": 48,
     "parent": 42,
     "notused": 62,
-    "detail": "SEARCH cache USING INDEX idx_lix_internal_state_cache_v1_lix_file_descriptor_unique_version_id_json_extract_snapsho_json_extract_snapsho_json_extract_snapsho_h3d0az (version_id=?)"
+    "detail": "SEARCH cache USING INDEX idx_lix_internal_state_cache_v1_lix_file_descriptor_unique_version_id_json_extract_snapsho_json_extract_snapsho_json_extract_snapsho_file_id_42p3je (version_id=?)"
   },
   {
     "id": 78,

--- a/packages/lix/sdk/src/filesystem/__bench__/file-read-excluding-file-path-via-not-like.explain.txt
+++ b/packages/lix/sdk/src/filesystem/__bench__/file-read-excluding-file-path-via-not-like.explain.txt
@@ -333,7 +333,7 @@ WHERE "path" NOT LIKE ?
     "id": 48,
     "parent": 42,
     "notused": 62,
-    "detail": "SEARCH cache USING INDEX idx_lix_internal_state_cache_v1_lix_file_descriptor_unique_version_id_json_extract_snapsho_json_extract_snapsho_json_extract_snapsho_h3d0az (version_id=?)"
+    "detail": "SEARCH cache USING INDEX idx_lix_internal_state_cache_v1_lix_file_descriptor_unique_version_id_json_extract_snapsho_json_extract_snapsho_json_extract_snapsho_file_id_42p3je (version_id=?)"
   },
   {
     "id": 78,

--- a/packages/lix/sdk/src/filesystem/__bench__/file-read-with-path-based-like.explain.txt
+++ b/packages/lix/sdk/src/filesystem/__bench__/file-read-with-path-based-like.explain.txt
@@ -362,7 +362,7 @@ WHERE "path" LIKE ?
     "id": 48,
     "parent": 42,
     "notused": 62,
-    "detail": "SEARCH cache USING INDEX idx_lix_internal_state_cache_v1_lix_file_descriptor_unique_version_id_json_extract_snapsho_json_extract_snapsho_json_extract_snapsho_h3d0az (version_id=?)"
+    "detail": "SEARCH cache USING INDEX idx_lix_internal_state_cache_v1_lix_file_descriptor_unique_version_id_json_extract_snapsho_json_extract_snapsho_json_extract_snapsho_file_id_42p3je (version_id=?)"
   },
   {
     "id": 78,

--- a/packages/lix/sdk/src/filesystem/__bench__/file-reads-with-varying-sizes.explain.txt
+++ b/packages/lix/sdk/src/filesystem/__bench__/file-reads-with-varying-sizes.explain.txt
@@ -362,7 +362,7 @@ WHERE "id" = ?
     "id": 48,
     "parent": 42,
     "notused": 62,
-    "detail": "SEARCH cache USING INDEX idx_lix_internal_state_cache_v1_lix_file_descriptor_unique_version_id_json_extract_snapsho_json_extract_snapsho_json_extract_snapsho_h3d0az (version_id=?)"
+    "detail": "SEARCH cache USING INDEX idx_lix_internal_state_cache_v1_lix_file_descriptor_unique_version_id_json_extract_snapsho_json_extract_snapsho_json_extract_snapsho_file_id_42p3je (version_id=?)"
   },
   {
     "id": 78,

--- a/packages/lix/sdk/src/filesystem/__bench__/file-table-full-scan.explain.txt
+++ b/packages/lix/sdk/src/filesystem/__bench__/file-table-full-scan.explain.txt
@@ -361,7 +361,7 @@ WHERE lixcol_version_id IN ('boot_0000000000')) AS file
     "id": 48,
     "parent": 42,
     "notused": 62,
-    "detail": "SEARCH cache USING INDEX idx_lix_internal_state_cache_v1_lix_file_descriptor_unique_version_id_json_extract_snapsho_json_extract_snapsho_json_extract_snapsho_h3d0az (version_id=?)"
+    "detail": "SEARCH cache USING INDEX idx_lix_internal_state_cache_v1_lix_file_descriptor_unique_version_id_json_extract_snapsho_json_extract_snapsho_json_extract_snapsho_file_id_42p3je (version_id=?)"
   },
   {
     "id": 78,

--- a/packages/lix/sdk/src/filesystem/__bench__/mixed-file-read-pattern-80-20-distribution.explain.txt
+++ b/packages/lix/sdk/src/filesystem/__bench__/mixed-file-read-pattern-80-20-distribution.explain.txt
@@ -362,7 +362,7 @@ WHERE "id" = ?
     "id": 48,
     "parent": 42,
     "notused": 62,
-    "detail": "SEARCH cache USING INDEX idx_lix_internal_state_cache_v1_lix_file_descriptor_unique_version_id_json_extract_snapsho_json_extract_snapsho_json_extract_snapsho_h3d0az (version_id=?)"
+    "detail": "SEARCH cache USING INDEX idx_lix_internal_state_cache_v1_lix_file_descriptor_unique_version_id_json_extract_snapsho_json_extract_snapsho_json_extract_snapsho_file_id_42p3je (version_id=?)"
   },
   {
     "id": 78,

--- a/packages/lix/sdk/src/filesystem/__bench__/repeated-file-reads-same-file-cache-hit-scenario.explain.txt
+++ b/packages/lix/sdk/src/filesystem/__bench__/repeated-file-reads-same-file-cache-hit-scenario.explain.txt
@@ -362,7 +362,7 @@ WHERE "id" = ?
     "id": 48,
     "parent": 42,
     "notused": 62,
-    "detail": "SEARCH cache USING INDEX idx_lix_internal_state_cache_v1_lix_file_descriptor_unique_version_id_json_extract_snapsho_json_extract_snapsho_json_extract_snapsho_h3d0az (version_id=?)"
+    "detail": "SEARCH cache USING INDEX idx_lix_internal_state_cache_v1_lix_file_descriptor_unique_version_id_json_extract_snapsho_json_extract_snapsho_json_extract_snapsho_file_id_42p3je (version_id=?)"
   },
   {
     "id": 78,

--- a/packages/lix/sdk/src/filesystem/__bench__/sequential-file-reads-unique-files.explain.txt
+++ b/packages/lix/sdk/src/filesystem/__bench__/sequential-file-reads-unique-files.explain.txt
@@ -362,7 +362,7 @@ WHERE "id" = ?
     "id": 48,
     "parent": 42,
     "notused": 62,
-    "detail": "SEARCH cache USING INDEX idx_lix_internal_state_cache_v1_lix_file_descriptor_unique_version_id_json_extract_snapsho_json_extract_snapsho_json_extract_snapsho_h3d0az (version_id=?)"
+    "detail": "SEARCH cache USING INDEX idx_lix_internal_state_cache_v1_lix_file_descriptor_unique_version_id_json_extract_snapsho_json_extract_snapsho_json_extract_snapsho_file_id_42p3je (version_id=?)"
   },
   {
     "id": 78,

--- a/packages/lix/sdk/src/state/cache/create-schema-cache-table.ts
+++ b/packages/lix/sdk/src/state/cache/create-schema-cache-table.ts
@@ -78,6 +78,12 @@ export function createSchemaCacheTable(args: {
 		preprocessMode: "none",
 	});
 
+	// 2b) Fast lookups when queries omit file_id (entity+version filters)
+	engine.executeSync({
+		sql: `CREATE INDEX IF NOT EXISTS idx_${tableName}_ve ON ${tableName} (version_id, entity_id)`,
+		preprocessMode: "none",
+	});
+
 	// 3) Fast scans by file within a version
 	engine.executeSync({
 		sql: `CREATE INDEX IF NOT EXISTS idx_${tableName}_fv ON ${tableName} (file_id, version_id)`,

--- a/packages/lix/sdk/src/state/views/__bench__/state-select-tracked-entity.explain.txt
+++ b/packages/lix/sdk/src/state/views/__bench__/state-select-tracked-entity.explain.txt
@@ -219,7 +219,7 @@ WHERE schema_key = ? AND entity_id = ?
     "id": 132,
     "parent": 102,
     "notused": 27,
-    "detail": "SEARCH cache USING INDEX idx_lix_internal_state_cache_v1_bench_state_view_version_id (version_id=? AND entity_id=?)"
+    "detail": "SEARCH cache USING INDEX idx_lix_internal_state_cache_v1_bench_state_view_ve (version_id=? AND entity_id=?)"
   },
   {
     "id": 151,

--- a/packages/lix/sdk/src/state/views/__bench__/state-select-untracked-filter.explain.txt
+++ b/packages/lix/sdk/src/state/views/__bench__/state-select-untracked-filter.explain.txt
@@ -194,7 +194,7 @@ LIMIT 1
     "id": 67,
     "parent": 53,
     "notused": 62,
-    "detail": "SEARCH cache USING INDEX idx_lix_internal_state_cache_v1_bench_state_view_pk_version_id_json_extract_snapsho_4h2kdb (version_id=?)"
+    "detail": "SEARCH cache USING INDEX idx_lix_internal_state_cache_v1_bench_state_view_pk_version_id_json_extract_snapsho_file_id_b2i1mo (version_id=?)"
   },
   {
     "id": 90,

--- a/packages/lix/sdk/src/state/vtable/__bench__/inherited-cache-entity-version.explain.txt
+++ b/packages/lix/sdk/src/state/vtable/__bench__/inherited-cache-entity-version.explain.txt
@@ -278,7 +278,7 @@ WHERE schema_key = 'bench_vtable_schema' AND entity_id = ? AND version_id = ?
     "id": 152,
     "parent": 122,
     "notused": 27,
-    "detail": "SEARCH cache USING INDEX idx_lix_internal_state_cache_v1_bench_vtable_schema_version_id (version_id=? AND entity_id=?)"
+    "detail": "SEARCH cache USING INDEX idx_lix_internal_state_cache_v1_bench_vtable_schema_ve (version_id=? AND entity_id=?)"
   },
   {
     "id": 171,

--- a/packages/lix/sdk/src/state/vtable/__bench__/inherited-untracked-entity-version.explain.txt
+++ b/packages/lix/sdk/src/state/vtable/__bench__/inherited-untracked-entity-version.explain.txt
@@ -278,7 +278,7 @@ WHERE schema_key = 'bench_vtable_schema' AND entity_id = ? AND version_id = ?
     "id": 152,
     "parent": 122,
     "notused": 27,
-    "detail": "SEARCH cache USING INDEX idx_lix_internal_state_cache_v1_bench_vtable_schema_version_id (version_id=? AND entity_id=?)"
+    "detail": "SEARCH cache USING INDEX idx_lix_internal_state_cache_v1_bench_vtable_schema_ve (version_id=? AND entity_id=?)"
   },
   {
     "id": 171,

--- a/packages/lix/sdk/src/state/vtable/__playground__/validate-state-mutation.foreign-key.explain.txt
+++ b/packages/lix/sdk/src/state/vtable/__playground__/validate-state-mutation.foreign-key.explain.txt
@@ -1,11 +1,12 @@
 -- SQL (foreign-key)
-select "snapshot_content" from "lix_internal_state_vtable" where "schema_key" = ? and "snapshot_content" is not null and json_extract(snapshot_content, '$.id') = ? and "version_id" = ? and "inherited_from_version_id" is null
+select "snapshot_content" from "lix_internal_state_vtable" where "schema_key" = ? and "snapshot_content" is not null and json_extract(snapshot_content, '$.id') = ? and "version_id" = ? and "file_id" = ? and "inherited_from_version_id" is null
 
 -- parameters
 [
   "text_play_fk_target",
   "target-0",
-  "global"
+  "global",
+  "playground-file"
 ]
 
 -- rewritten SQL
@@ -16,7 +17,7 @@ WITH
     SELECT 'global' AS version_id
   )
 SELECT
-  "w"."snapshot_content" as "snapshot_content", "w"."schema_key" as "schema_key", "w"."version_id" as "version_id", "w"."inherited_from_version_id" as "inherited_from_version_id"
+  "w"."snapshot_content" as "snapshot_content", "w"."schema_key" as "schema_key", "w"."version_id" as "version_id", "w"."file_id" as "file_id", "w"."inherited_from_version_id" as "inherited_from_version_id"
 FROM (
   SELECT
     c.entity_id AS entity_id,
@@ -45,7 +46,7 @@ FROM (
         2 AS priority
       FROM lix_internal_state_all_untracked unt
       JOIN wanted_versions wv_unt ON wv_unt.version_id = unt.version_id
-      WHERE (unt.schema_key IN ('text_play_fk_target')) AND ((json_extract(unt.snapshot_content, '$.id') = 'target-0'))
+      WHERE (unt.schema_key IN ('text_play_fk_target')) AND (unt.file_id IN ('playground-file')) AND ((json_extract(unt.snapshot_content, '$.id') = 'target-0'))
 
           UNION ALL
 
@@ -61,7 +62,7 @@ FROM (
         3 AS priority
       FROM "lix_internal_state_cache_v1_text_play_fk_target" cache
       JOIN wanted_versions wv_cache ON wv_cache.version_id = cache.version_id
-      WHERE (cache.schema_key IN ('text_play_fk_target')) AND ((json_extract(cache.snapshot_content, '$.id') = 'target-0'))
+      WHERE (cache.schema_key IN ('text_play_fk_target')) AND (cache.file_id IN ('playground-file')) AND ((json_extract(cache.snapshot_content, '$.id') = 'target-0'))
   ) AS c
 ) AS w
 
@@ -69,7 +70,7 @@ FROM (
 
 WHERE w.rn = 1
 ) AS "lix_internal_state_vtable"
-WHERE "schema_key" = ? AND "snapshot_content" IS NOT NULL AND json_extract(snapshot_content, '$.id') = ? AND "version_id" = ? AND "inherited_from_version_id" IS NULL
+WHERE "schema_key" = ? AND "snapshot_content" IS NOT NULL AND json_extract(snapshot_content, '$.id') = ? AND "version_id" = ? AND "file_id" = ? AND "inherited_from_version_id" IS NULL
 
 -- query plan
 [
@@ -116,57 +117,57 @@ WHERE "schema_key" = ? AND "snapshot_content" IS NOT NULL AND json_extract(snaps
     "detail": "SCAN CONSTANT ROW"
   },
   {
-    "id": 27,
+    "id": 30,
     "parent": 9,
     "notused": 16,
     "detail": "SCAN wv_unt"
   },
   {
-    "id": 33,
+    "id": 36,
     "parent": 9,
-    "notused": 61,
-    "detail": "SEARCH unt USING INDEX idx_lix_internal_state_all_untracked_version_id (version_id=?)"
+    "notused": 60,
+    "detail": "SEARCH unt USING INDEX ix_unt_v_f_s_e (version_id=? AND file_id=? AND schema_key=?)"
   },
   {
-    "id": 58,
+    "id": 65,
     "parent": 8,
     "notused": 0,
     "detail": "UNION ALL"
   },
   {
-    "id": 66,
-    "parent": 58,
+    "id": 76,
+    "parent": 65,
     "notused": 47,
-    "detail": "SEARCH cache USING INDEX idx_lix_internal_state_cache_v1_text_play_fk_target_pk_version_id_json_extract_snapsho_4h2kdb (version_id=? AND <expr>=?)"
+    "detail": "SEARCH cache USING INDEX idx_lix_internal_state_cache_v1_text_play_fk_target_pk_version_id_json_extract_snapsho_file_id_b2i1mo (version_id=? AND <expr>=? AND file_id=?)"
   },
   {
-    "id": 79,
-    "parent": 58,
+    "id": 92,
+    "parent": 65,
     "notused": 216,
     "detail": "SCAN wv_cache"
   },
   {
-    "id": 100,
+    "id": 113,
     "parent": 5,
-    "notused": 195,
+    "notused": 194,
     "detail": "SCAN c"
   },
   {
-    "id": 134,
+    "id": 155,
     "parent": 5,
     "notused": 0,
-    "detail": "USE TEMP B-TREE FOR ORDER BY"
+    "detail": "USE TEMP B-TREE FOR LAST 9 TERMS OF ORDER BY"
   },
   {
-    "id": 167,
+    "id": 192,
     "parent": 2,
-    "notused": 175,
+    "notused": 174,
     "detail": "SCAN (subquery-7)"
   },
   {
-    "id": 235,
+    "id": 260,
     "parent": 0,
-    "notused": 175,
+    "notused": 174,
     "detail": "SCAN w"
   }
 ]

--- a/packages/lix/sdk/src/state/vtable/__playground__/validate-state-mutation.primary-key.explain.txt
+++ b/packages/lix/sdk/src/state/vtable/__playground__/validate-state-mutation.primary-key.explain.txt
@@ -1,10 +1,11 @@
 -- SQL (primary-key)
-select "snapshot_content" from "lix_internal_state_vtable" where "schema_key" = ? and "version_id" = ? and "inherited_from_version_id" is null and "snapshot_content" is not null and json_extract(snapshot_content, '$.code') = ?
+select "snapshot_content" from "lix_internal_state_vtable" where "schema_key" = ? and "version_id" = ? and "file_id" = ? and "inherited_from_version_id" is null and "snapshot_content" is not null and json_extract(snapshot_content, '$.code') = ?
 
 -- parameters
 [
   "text_play_pk",
   "global",
+  "playground-file",
   "code-new"
 ]
 
@@ -16,7 +17,7 @@ WITH
     SELECT 'global' AS version_id
   )
 SELECT
-  "w"."snapshot_content" as "snapshot_content", "w"."schema_key" as "schema_key", "w"."version_id" as "version_id", "w"."inherited_from_version_id" as "inherited_from_version_id"
+  "w"."snapshot_content" as "snapshot_content", "w"."schema_key" as "schema_key", "w"."version_id" as "version_id", "w"."file_id" as "file_id", "w"."inherited_from_version_id" as "inherited_from_version_id"
 FROM (
   SELECT
     c.entity_id AS entity_id,
@@ -45,7 +46,7 @@ FROM (
         2 AS priority
       FROM lix_internal_state_all_untracked unt
       JOIN wanted_versions wv_unt ON wv_unt.version_id = unt.version_id
-      WHERE (unt.schema_key IN ('text_play_pk')) AND ((json_extract(unt.snapshot_content, '$.code') = 'code-new'))
+      WHERE (unt.schema_key IN ('text_play_pk')) AND (unt.file_id IN ('playground-file')) AND ((json_extract(unt.snapshot_content, '$.code') = 'code-new'))
 
           UNION ALL
 
@@ -61,7 +62,7 @@ FROM (
         3 AS priority
       FROM "lix_internal_state_cache_v1_text_play_pk" cache
       JOIN wanted_versions wv_cache ON wv_cache.version_id = cache.version_id
-      WHERE (cache.schema_key IN ('text_play_pk')) AND ((json_extract(cache.snapshot_content, '$.code') = 'code-new'))
+      WHERE (cache.schema_key IN ('text_play_pk')) AND (cache.file_id IN ('playground-file')) AND ((json_extract(cache.snapshot_content, '$.code') = 'code-new'))
   ) AS c
 ) AS w
 
@@ -69,7 +70,7 @@ FROM (
 
 WHERE w.rn = 1
 ) AS "lix_internal_state_vtable"
-WHERE "schema_key" = ? AND "version_id" = ? AND "inherited_from_version_id" IS NULL AND "snapshot_content" IS NOT NULL AND json_extract(snapshot_content, '$.code') = ?
+WHERE "schema_key" = ? AND "version_id" = ? AND "file_id" = ? AND "inherited_from_version_id" IS NULL AND "snapshot_content" IS NOT NULL AND json_extract(snapshot_content, '$.code') = ?
 
 -- query plan
 [
@@ -116,57 +117,57 @@ WHERE "schema_key" = ? AND "version_id" = ? AND "inherited_from_version_id" IS N
     "detail": "SCAN CONSTANT ROW"
   },
   {
-    "id": 27,
+    "id": 30,
     "parent": 9,
     "notused": 16,
     "detail": "SCAN wv_unt"
   },
   {
-    "id": 33,
+    "id": 36,
     "parent": 9,
-    "notused": 61,
-    "detail": "SEARCH unt USING INDEX idx_lix_internal_state_all_untracked_version_id (version_id=?)"
+    "notused": 60,
+    "detail": "SEARCH unt USING INDEX ix_unt_v_f_s_e (version_id=? AND file_id=? AND schema_key=?)"
   },
   {
-    "id": 58,
+    "id": 65,
     "parent": 8,
     "notused": 0,
     "detail": "UNION ALL"
   },
   {
-    "id": 66,
-    "parent": 58,
+    "id": 76,
+    "parent": 65,
     "notused": 47,
-    "detail": "SEARCH cache USING INDEX idx_lix_internal_state_cache_v1_text_play_pk_pk_version_id_json_extract_snapsho_4h2kdb (version_id=? AND <expr>=?)"
+    "detail": "SEARCH cache USING INDEX idx_lix_internal_state_cache_v1_text_play_pk_pk_version_id_json_extract_snapsho_file_id_b2i1mo (version_id=? AND <expr>=? AND file_id=?)"
   },
   {
-    "id": 79,
-    "parent": 58,
+    "id": 92,
+    "parent": 65,
     "notused": 216,
     "detail": "SCAN wv_cache"
   },
   {
-    "id": 100,
+    "id": 113,
     "parent": 5,
-    "notused": 195,
+    "notused": 194,
     "detail": "SCAN c"
   },
   {
-    "id": 134,
+    "id": 155,
     "parent": 5,
     "notused": 0,
-    "detail": "USE TEMP B-TREE FOR ORDER BY"
+    "detail": "USE TEMP B-TREE FOR LAST 9 TERMS OF ORDER BY"
   },
   {
-    "id": 167,
+    "id": 192,
     "parent": 2,
-    "notused": 175,
+    "notused": 174,
     "detail": "SCAN (subquery-7)"
   },
   {
-    "id": 235,
+    "id": 260,
     "parent": 0,
-    "notused": 175,
+    "notused": 174,
     "detail": "SCAN w"
   }
 ]

--- a/packages/lix/sdk/src/state/vtable/__playground__/validate-state-mutation.unique-nested.explain.txt
+++ b/packages/lix/sdk/src/state/vtable/__playground__/validate-state-mutation.unique-nested.explain.txt
@@ -1,10 +1,11 @@
 -- SQL (unique-nested)
-select "snapshot_content" from "lix_internal_state_vtable" where "schema_key" = ? and "version_id" = ? and "inherited_from_version_id" is null and "snapshot_content" is not null and json_extract(snapshot_content, '$.details.slug') = ?
+select "snapshot_content" from "lix_internal_state_vtable" where "schema_key" = ? and "version_id" = ? and "file_id" = ? and "inherited_from_version_id" is null and "snapshot_content" is not null and json_extract(snapshot_content, '$.details.slug') = ?
 
 -- parameters
 [
   "text_play_unique",
   "global",
+  "playground-file",
   "slug-new"
 ]
 
@@ -16,7 +17,7 @@ WITH
     SELECT 'global' AS version_id
   )
 SELECT
-  "w"."snapshot_content" as "snapshot_content", "w"."schema_key" as "schema_key", "w"."version_id" as "version_id", "w"."inherited_from_version_id" as "inherited_from_version_id"
+  "w"."snapshot_content" as "snapshot_content", "w"."schema_key" as "schema_key", "w"."version_id" as "version_id", "w"."file_id" as "file_id", "w"."inherited_from_version_id" as "inherited_from_version_id"
 FROM (
   SELECT
     c.entity_id AS entity_id,
@@ -45,7 +46,7 @@ FROM (
         2 AS priority
       FROM lix_internal_state_all_untracked unt
       JOIN wanted_versions wv_unt ON wv_unt.version_id = unt.version_id
-      WHERE (unt.schema_key IN ('text_play_unique')) AND ((json_extract(unt.snapshot_content, '$.details.slug') = 'slug-new'))
+      WHERE (unt.schema_key IN ('text_play_unique')) AND (unt.file_id IN ('playground-file')) AND ((json_extract(unt.snapshot_content, '$.details.slug') = 'slug-new'))
 
           UNION ALL
 
@@ -61,7 +62,7 @@ FROM (
         3 AS priority
       FROM "lix_internal_state_cache_v1_text_play_unique" cache
       JOIN wanted_versions wv_cache ON wv_cache.version_id = cache.version_id
-      WHERE (cache.schema_key IN ('text_play_unique')) AND ((json_extract(cache.snapshot_content, '$.details.slug') = 'slug-new'))
+      WHERE (cache.schema_key IN ('text_play_unique')) AND (cache.file_id IN ('playground-file')) AND ((json_extract(cache.snapshot_content, '$.details.slug') = 'slug-new'))
   ) AS c
 ) AS w
 
@@ -69,7 +70,7 @@ FROM (
 
 WHERE w.rn = 1
 ) AS "lix_internal_state_vtable"
-WHERE "schema_key" = ? AND "version_id" = ? AND "inherited_from_version_id" IS NULL AND "snapshot_content" IS NOT NULL AND json_extract(snapshot_content, '$.details.slug') = ?
+WHERE "schema_key" = ? AND "version_id" = ? AND "file_id" = ? AND "inherited_from_version_id" IS NULL AND "snapshot_content" IS NOT NULL AND json_extract(snapshot_content, '$.details.slug') = ?
 
 -- query plan
 [
@@ -116,57 +117,57 @@ WHERE "schema_key" = ? AND "version_id" = ? AND "inherited_from_version_id" IS N
     "detail": "SCAN CONSTANT ROW"
   },
   {
-    "id": 27,
+    "id": 30,
     "parent": 9,
     "notused": 16,
     "detail": "SCAN wv_unt"
   },
   {
-    "id": 33,
+    "id": 36,
     "parent": 9,
-    "notused": 61,
-    "detail": "SEARCH unt USING INDEX idx_lix_internal_state_all_untracked_version_id (version_id=?)"
+    "notused": 60,
+    "detail": "SEARCH unt USING INDEX ix_unt_v_f_s_e (version_id=? AND file_id=? AND schema_key=?)"
   },
   {
-    "id": 58,
+    "id": 65,
     "parent": 8,
     "notused": 0,
     "detail": "UNION ALL"
   },
   {
-    "id": 66,
-    "parent": 58,
+    "id": 76,
+    "parent": 65,
     "notused": 47,
-    "detail": "SEARCH cache USING INDEX idx_lix_internal_state_cache_v1_text_play_unique_unique_version_id_json_extract_snapsho_c3jqlx (version_id=? AND <expr>=?)"
+    "detail": "SEARCH cache USING INDEX idx_lix_internal_state_cache_v1_text_play_unique_unique_version_id_json_extract_snapsho_file_id_b04j56 (version_id=? AND <expr>=? AND file_id=?)"
   },
   {
-    "id": 79,
-    "parent": 58,
+    "id": 92,
+    "parent": 65,
     "notused": 216,
     "detail": "SCAN wv_cache"
   },
   {
-    "id": 100,
+    "id": 113,
     "parent": 5,
-    "notused": 195,
+    "notused": 194,
     "detail": "SCAN c"
   },
   {
-    "id": 134,
+    "id": 155,
     "parent": 5,
     "notused": 0,
-    "detail": "USE TEMP B-TREE FOR ORDER BY"
+    "detail": "USE TEMP B-TREE FOR LAST 9 TERMS OF ORDER BY"
   },
   {
-    "id": 167,
+    "id": 192,
     "parent": 2,
-    "notused": 175,
+    "notused": 174,
     "detail": "SCAN (subquery-7)"
   },
   {
-    "id": 235,
+    "id": 260,
     "parent": 0,
-    "notused": 175,
+    "notused": 174,
     "detail": "SCAN w"
   }
 ]

--- a/packages/lix/sdk/src/state/vtable/validate-state-mutation.playground.test.ts
+++ b/packages/lix/sdk/src/state/vtable/validate-state-mutation.playground.test.ts
@@ -283,6 +283,7 @@ test("validateStateMutation explain plans", async () => {
 						},
 						entity_id: `${PK_SCHEMA["x-lix-key"]}-entity-new`,
 						version_id: VERSION_ID,
+						file_id: FILE_ID,
 						operation: "insert",
 					});
 				},
@@ -343,6 +344,7 @@ test("validateStateMutation explain plans", async () => {
 						},
 						entity_id: `${UNIQUE_SCHEMA["x-lix-key"]}-entity-new`,
 						version_id: VERSION_ID,
+						file_id: FILE_ID,
 						operation: "insert",
 					});
 				},
@@ -442,6 +444,7 @@ test("validateStateMutation explain plans", async () => {
 						},
 						entity_id: "source-new",
 						version_id: VERSION_ID,
+						file_id: FILE_ID,
 						operation: "insert",
 					});
 				},

--- a/packages/lix/sdk/src/version/select-version-diff.playground-plan.txt
+++ b/packages/lix/sdk/src/version/select-version-diff.playground-plan.txt
@@ -946,7 +946,7 @@ WHERE "diff"."status" != ?
     "id": 63,
     "parent": 52,
     "notused": 62,
-    "detail": "SEARCH lix_internal_state_cache_v1_lix_version_descriptor USING INDEX idx_lix_internal_state_cache_v1_lix_version_descriptor_pk_version_id_json_extract_snapsho_4h2kdb (version_id=?)"
+    "detail": "SEARCH lix_internal_state_cache_v1_lix_version_descriptor USING INDEX idx_lix_internal_state_cache_v1_lix_version_descriptor_pk_version_id_json_extract_snapsho_file_id_b2i1mo (version_id=?)"
   },
   {
     "id": 84,
@@ -964,7 +964,7 @@ WHERE "diff"."status" != ?
     "id": 95,
     "parent": 84,
     "notused": 62,
-    "detail": "SEARCH lix_internal_state_cache_v1_lix_stored_schema USING INDEX idx_lix_internal_state_cache_v1_lix_stored_schema_pk_version_id_json_extract_snapsho_json_extract_snapsho_r7zrf9 (version_id=?)"
+    "detail": "SEARCH lix_internal_state_cache_v1_lix_stored_schema USING INDEX idx_lix_internal_state_cache_v1_lix_stored_schema_pk_version_id_json_extract_snapsho_json_extract_snapsho_file_id_l1xg3a (version_id=?)"
   },
   {
     "id": 116,
@@ -982,7 +982,7 @@ WHERE "diff"."status" != ?
     "id": 127,
     "parent": 116,
     "notused": 62,
-    "detail": "SEARCH lix_internal_state_cache_v1_lix_key_value USING INDEX idx_lix_internal_state_cache_v1_lix_key_value_pk_version_id_json_extract_snapsho_4h2kdb (version_id=?)"
+    "detail": "SEARCH lix_internal_state_cache_v1_lix_key_value USING INDEX idx_lix_internal_state_cache_v1_lix_key_value_pk_version_id_json_extract_snapsho_file_id_b2i1mo (version_id=?)"
   },
   {
     "id": 148,
@@ -1000,7 +1000,7 @@ WHERE "diff"."status" != ?
     "id": 159,
     "parent": 148,
     "notused": 62,
-    "detail": "SEARCH lix_internal_state_cache_v1_lix_active_account USING INDEX idx_lix_internal_state_cache_v1_lix_active_account_foreign_version_id_inherited_from_versi_json_extract_snapsho_79rox8 (version_id=?)"
+    "detail": "SEARCH lix_internal_state_cache_v1_lix_active_account USING INDEX idx_lix_internal_state_cache_v1_lix_active_account_foreign_version_id_inherited_from_versi_json_extract_snapsho_file_id_76oyad (version_id=?)"
   },
   {
     "id": 180,
@@ -1018,7 +1018,7 @@ WHERE "diff"."status" != ?
     "id": 191,
     "parent": 180,
     "notused": 62,
-    "detail": "SEARCH lix_internal_state_cache_v1_lix_commit USING INDEX idx_lix_internal_state_cache_v1_lix_commit_pk_version_id_json_extract_snapsho_4h2kdb (version_id=?)"
+    "detail": "SEARCH lix_internal_state_cache_v1_lix_commit USING INDEX idx_lix_internal_state_cache_v1_lix_commit_pk_version_id_json_extract_snapsho_file_id_b2i1mo (version_id=?)"
   },
   {
     "id": 212,
@@ -1036,7 +1036,7 @@ WHERE "diff"."status" != ?
     "id": 223,
     "parent": 212,
     "notused": 62,
-    "detail": "SEARCH lix_internal_state_cache_v1_lix_commit_edge USING INDEX idx_lix_internal_state_cache_v1_lix_commit_edge_foreign_version_id_inherited_from_versi_json_extract_snapsho_79rox8 (version_id=?)"
+    "detail": "SEARCH lix_internal_state_cache_v1_lix_commit_edge USING INDEX idx_lix_internal_state_cache_v1_lix_commit_edge_foreign_version_id_inherited_from_versi_json_extract_snapsho_file_id_76oyad (version_id=?)"
   },
   {
     "id": 244,
@@ -1054,7 +1054,7 @@ WHERE "diff"."status" != ?
     "id": 255,
     "parent": 244,
     "notused": 62,
-    "detail": "SEARCH lix_internal_state_cache_v1_lix_version_tip USING INDEX idx_lix_internal_state_cache_v1_lix_version_tip_unique_version_id_json_extract_snapsho_c3jqlx (version_id=?)"
+    "detail": "SEARCH lix_internal_state_cache_v1_lix_version_tip USING INDEX idx_lix_internal_state_cache_v1_lix_version_tip_unique_version_id_json_extract_snapsho_file_id_b04j56 (version_id=?)"
   },
   {
     "id": 276,
@@ -1072,7 +1072,7 @@ WHERE "diff"."status" != ?
     "id": 287,
     "parent": 276,
     "notused": 62,
-    "detail": "SEARCH lix_internal_state_cache_v1_lix_change_set USING INDEX idx_lix_internal_state_cache_v1_lix_change_set_pk_version_id_json_extract_snapsho_4h2kdb (version_id=?)"
+    "detail": "SEARCH lix_internal_state_cache_v1_lix_change_set USING INDEX idx_lix_internal_state_cache_v1_lix_change_set_pk_version_id_json_extract_snapsho_file_id_b2i1mo (version_id=?)"
   },
   {
     "id": 308,
@@ -1090,7 +1090,7 @@ WHERE "diff"."status" != ?
     "id": 319,
     "parent": 308,
     "notused": 62,
-    "detail": "SEARCH lix_internal_state_cache_v1_lix_change_set_element USING INDEX idx_lix_internal_state_cache_v1_lix_change_set_element_foreign_version_id_inherited_from_versi_json_extract_snapsho_79rox8 (version_id=?)"
+    "detail": "SEARCH lix_internal_state_cache_v1_lix_change_set_element USING INDEX idx_lix_internal_state_cache_v1_lix_change_set_element_foreign_version_id_inherited_from_versi_json_extract_snapsho_file_id_76oyad (version_id=?)"
   },
   {
     "id": 340,
@@ -1108,7 +1108,7 @@ WHERE "diff"."status" != ?
     "id": 351,
     "parent": 340,
     "notused": 62,
-    "detail": "SEARCH lix_internal_state_cache_v1_lix_label USING INDEX idx_lix_internal_state_cache_v1_lix_label_pk_version_id_json_extract_snapsho_4h2kdb (version_id=?)"
+    "detail": "SEARCH lix_internal_state_cache_v1_lix_label USING INDEX idx_lix_internal_state_cache_v1_lix_label_pk_version_id_json_extract_snapsho_file_id_b2i1mo (version_id=?)"
   },
   {
     "id": 372,
@@ -1126,7 +1126,7 @@ WHERE "diff"."status" != ?
     "id": 383,
     "parent": 372,
     "notused": 62,
-    "detail": "SEARCH lix_internal_state_cache_v1_test_bench_diff_entity USING INDEX idx_lix_internal_state_cache_v1_test_bench_diff_entity_vfe (version_id=?)"
+    "detail": "SEARCH lix_internal_state_cache_v1_test_bench_diff_entity USING INDEX idx_lix_internal_state_cache_v1_test_bench_diff_entity_ve (version_id=?)"
   },
   {
     "id": 404,
@@ -1678,7 +1678,7 @@ WHERE "diff"."status" != ?
     "id": 1182,
     "parent": 1171,
     "notused": 62,
-    "detail": "SEARCH lix_internal_state_cache_v1_lix_version_descriptor USING INDEX idx_lix_internal_state_cache_v1_lix_version_descriptor_pk_version_id_json_extract_snapsho_4h2kdb (version_id=?)"
+    "detail": "SEARCH lix_internal_state_cache_v1_lix_version_descriptor USING INDEX idx_lix_internal_state_cache_v1_lix_version_descriptor_pk_version_id_json_extract_snapsho_file_id_b2i1mo (version_id=?)"
   },
   {
     "id": 1203,
@@ -1696,7 +1696,7 @@ WHERE "diff"."status" != ?
     "id": 1214,
     "parent": 1203,
     "notused": 62,
-    "detail": "SEARCH lix_internal_state_cache_v1_lix_stored_schema USING INDEX idx_lix_internal_state_cache_v1_lix_stored_schema_pk_version_id_json_extract_snapsho_json_extract_snapsho_r7zrf9 (version_id=?)"
+    "detail": "SEARCH lix_internal_state_cache_v1_lix_stored_schema USING INDEX idx_lix_internal_state_cache_v1_lix_stored_schema_pk_version_id_json_extract_snapsho_json_extract_snapsho_file_id_l1xg3a (version_id=?)"
   },
   {
     "id": 1235,
@@ -1714,7 +1714,7 @@ WHERE "diff"."status" != ?
     "id": 1246,
     "parent": 1235,
     "notused": 62,
-    "detail": "SEARCH lix_internal_state_cache_v1_lix_key_value USING INDEX idx_lix_internal_state_cache_v1_lix_key_value_pk_version_id_json_extract_snapsho_4h2kdb (version_id=?)"
+    "detail": "SEARCH lix_internal_state_cache_v1_lix_key_value USING INDEX idx_lix_internal_state_cache_v1_lix_key_value_pk_version_id_json_extract_snapsho_file_id_b2i1mo (version_id=?)"
   },
   {
     "id": 1267,
@@ -1732,7 +1732,7 @@ WHERE "diff"."status" != ?
     "id": 1278,
     "parent": 1267,
     "notused": 62,
-    "detail": "SEARCH lix_internal_state_cache_v1_lix_active_account USING INDEX idx_lix_internal_state_cache_v1_lix_active_account_foreign_version_id_inherited_from_versi_json_extract_snapsho_79rox8 (version_id=?)"
+    "detail": "SEARCH lix_internal_state_cache_v1_lix_active_account USING INDEX idx_lix_internal_state_cache_v1_lix_active_account_foreign_version_id_inherited_from_versi_json_extract_snapsho_file_id_76oyad (version_id=?)"
   },
   {
     "id": 1299,
@@ -1750,7 +1750,7 @@ WHERE "diff"."status" != ?
     "id": 1310,
     "parent": 1299,
     "notused": 62,
-    "detail": "SEARCH lix_internal_state_cache_v1_lix_commit USING INDEX idx_lix_internal_state_cache_v1_lix_commit_pk_version_id_json_extract_snapsho_4h2kdb (version_id=?)"
+    "detail": "SEARCH lix_internal_state_cache_v1_lix_commit USING INDEX idx_lix_internal_state_cache_v1_lix_commit_pk_version_id_json_extract_snapsho_file_id_b2i1mo (version_id=?)"
   },
   {
     "id": 1331,
@@ -1768,7 +1768,7 @@ WHERE "diff"."status" != ?
     "id": 1342,
     "parent": 1331,
     "notused": 62,
-    "detail": "SEARCH lix_internal_state_cache_v1_lix_commit_edge USING INDEX idx_lix_internal_state_cache_v1_lix_commit_edge_foreign_version_id_inherited_from_versi_json_extract_snapsho_79rox8 (version_id=?)"
+    "detail": "SEARCH lix_internal_state_cache_v1_lix_commit_edge USING INDEX idx_lix_internal_state_cache_v1_lix_commit_edge_foreign_version_id_inherited_from_versi_json_extract_snapsho_file_id_76oyad (version_id=?)"
   },
   {
     "id": 1363,
@@ -1786,7 +1786,7 @@ WHERE "diff"."status" != ?
     "id": 1374,
     "parent": 1363,
     "notused": 62,
-    "detail": "SEARCH lix_internal_state_cache_v1_lix_version_tip USING INDEX idx_lix_internal_state_cache_v1_lix_version_tip_unique_version_id_json_extract_snapsho_c3jqlx (version_id=?)"
+    "detail": "SEARCH lix_internal_state_cache_v1_lix_version_tip USING INDEX idx_lix_internal_state_cache_v1_lix_version_tip_unique_version_id_json_extract_snapsho_file_id_b04j56 (version_id=?)"
   },
   {
     "id": 1395,
@@ -1804,7 +1804,7 @@ WHERE "diff"."status" != ?
     "id": 1406,
     "parent": 1395,
     "notused": 62,
-    "detail": "SEARCH lix_internal_state_cache_v1_lix_change_set USING INDEX idx_lix_internal_state_cache_v1_lix_change_set_pk_version_id_json_extract_snapsho_4h2kdb (version_id=?)"
+    "detail": "SEARCH lix_internal_state_cache_v1_lix_change_set USING INDEX idx_lix_internal_state_cache_v1_lix_change_set_pk_version_id_json_extract_snapsho_file_id_b2i1mo (version_id=?)"
   },
   {
     "id": 1427,
@@ -1822,7 +1822,7 @@ WHERE "diff"."status" != ?
     "id": 1438,
     "parent": 1427,
     "notused": 62,
-    "detail": "SEARCH lix_internal_state_cache_v1_lix_change_set_element USING INDEX idx_lix_internal_state_cache_v1_lix_change_set_element_foreign_version_id_inherited_from_versi_json_extract_snapsho_79rox8 (version_id=?)"
+    "detail": "SEARCH lix_internal_state_cache_v1_lix_change_set_element USING INDEX idx_lix_internal_state_cache_v1_lix_change_set_element_foreign_version_id_inherited_from_versi_json_extract_snapsho_file_id_76oyad (version_id=?)"
   },
   {
     "id": 1459,
@@ -1840,7 +1840,7 @@ WHERE "diff"."status" != ?
     "id": 1470,
     "parent": 1459,
     "notused": 62,
-    "detail": "SEARCH lix_internal_state_cache_v1_lix_label USING INDEX idx_lix_internal_state_cache_v1_lix_label_pk_version_id_json_extract_snapsho_4h2kdb (version_id=?)"
+    "detail": "SEARCH lix_internal_state_cache_v1_lix_label USING INDEX idx_lix_internal_state_cache_v1_lix_label_pk_version_id_json_extract_snapsho_file_id_b2i1mo (version_id=?)"
   },
   {
     "id": 1491,
@@ -1858,7 +1858,7 @@ WHERE "diff"."status" != ?
     "id": 1502,
     "parent": 1491,
     "notused": 62,
-    "detail": "SEARCH lix_internal_state_cache_v1_test_bench_diff_entity USING INDEX idx_lix_internal_state_cache_v1_test_bench_diff_entity_vfe (version_id=?)"
+    "detail": "SEARCH lix_internal_state_cache_v1_test_bench_diff_entity USING INDEX idx_lix_internal_state_cache_v1_test_bench_diff_entity_ve (version_id=?)"
   },
   {
     "id": 1523,
@@ -2434,7 +2434,7 @@ WHERE "diff"."status" != ?
     "id": 2427,
     "parent": 2416,
     "notused": 62,
-    "detail": "SEARCH lix_internal_state_cache_v1_lix_version_descriptor USING INDEX idx_lix_internal_state_cache_v1_lix_version_descriptor_pk_version_id_json_extract_snapsho_4h2kdb (version_id=?)"
+    "detail": "SEARCH lix_internal_state_cache_v1_lix_version_descriptor USING INDEX idx_lix_internal_state_cache_v1_lix_version_descriptor_pk_version_id_json_extract_snapsho_file_id_b2i1mo (version_id=?)"
   },
   {
     "id": 2448,
@@ -2452,7 +2452,7 @@ WHERE "diff"."status" != ?
     "id": 2459,
     "parent": 2448,
     "notused": 62,
-    "detail": "SEARCH lix_internal_state_cache_v1_lix_stored_schema USING INDEX idx_lix_internal_state_cache_v1_lix_stored_schema_pk_version_id_json_extract_snapsho_json_extract_snapsho_r7zrf9 (version_id=?)"
+    "detail": "SEARCH lix_internal_state_cache_v1_lix_stored_schema USING INDEX idx_lix_internal_state_cache_v1_lix_stored_schema_pk_version_id_json_extract_snapsho_json_extract_snapsho_file_id_l1xg3a (version_id=?)"
   },
   {
     "id": 2480,
@@ -2470,7 +2470,7 @@ WHERE "diff"."status" != ?
     "id": 2491,
     "parent": 2480,
     "notused": 62,
-    "detail": "SEARCH lix_internal_state_cache_v1_lix_key_value USING INDEX idx_lix_internal_state_cache_v1_lix_key_value_pk_version_id_json_extract_snapsho_4h2kdb (version_id=?)"
+    "detail": "SEARCH lix_internal_state_cache_v1_lix_key_value USING INDEX idx_lix_internal_state_cache_v1_lix_key_value_pk_version_id_json_extract_snapsho_file_id_b2i1mo (version_id=?)"
   },
   {
     "id": 2512,
@@ -2488,7 +2488,7 @@ WHERE "diff"."status" != ?
     "id": 2523,
     "parent": 2512,
     "notused": 62,
-    "detail": "SEARCH lix_internal_state_cache_v1_lix_active_account USING INDEX idx_lix_internal_state_cache_v1_lix_active_account_foreign_version_id_inherited_from_versi_json_extract_snapsho_79rox8 (version_id=?)"
+    "detail": "SEARCH lix_internal_state_cache_v1_lix_active_account USING INDEX idx_lix_internal_state_cache_v1_lix_active_account_foreign_version_id_inherited_from_versi_json_extract_snapsho_file_id_76oyad (version_id=?)"
   },
   {
     "id": 2544,
@@ -2506,7 +2506,7 @@ WHERE "diff"."status" != ?
     "id": 2555,
     "parent": 2544,
     "notused": 62,
-    "detail": "SEARCH lix_internal_state_cache_v1_lix_commit USING INDEX idx_lix_internal_state_cache_v1_lix_commit_pk_version_id_json_extract_snapsho_4h2kdb (version_id=?)"
+    "detail": "SEARCH lix_internal_state_cache_v1_lix_commit USING INDEX idx_lix_internal_state_cache_v1_lix_commit_pk_version_id_json_extract_snapsho_file_id_b2i1mo (version_id=?)"
   },
   {
     "id": 2576,
@@ -2524,7 +2524,7 @@ WHERE "diff"."status" != ?
     "id": 2587,
     "parent": 2576,
     "notused": 62,
-    "detail": "SEARCH lix_internal_state_cache_v1_lix_commit_edge USING INDEX idx_lix_internal_state_cache_v1_lix_commit_edge_foreign_version_id_inherited_from_versi_json_extract_snapsho_79rox8 (version_id=?)"
+    "detail": "SEARCH lix_internal_state_cache_v1_lix_commit_edge USING INDEX idx_lix_internal_state_cache_v1_lix_commit_edge_foreign_version_id_inherited_from_versi_json_extract_snapsho_file_id_76oyad (version_id=?)"
   },
   {
     "id": 2608,
@@ -2542,7 +2542,7 @@ WHERE "diff"."status" != ?
     "id": 2619,
     "parent": 2608,
     "notused": 62,
-    "detail": "SEARCH lix_internal_state_cache_v1_lix_version_tip USING INDEX idx_lix_internal_state_cache_v1_lix_version_tip_unique_version_id_json_extract_snapsho_c3jqlx (version_id=?)"
+    "detail": "SEARCH lix_internal_state_cache_v1_lix_version_tip USING INDEX idx_lix_internal_state_cache_v1_lix_version_tip_unique_version_id_json_extract_snapsho_file_id_b04j56 (version_id=?)"
   },
   {
     "id": 2640,
@@ -2560,7 +2560,7 @@ WHERE "diff"."status" != ?
     "id": 2651,
     "parent": 2640,
     "notused": 62,
-    "detail": "SEARCH lix_internal_state_cache_v1_lix_change_set USING INDEX idx_lix_internal_state_cache_v1_lix_change_set_pk_version_id_json_extract_snapsho_4h2kdb (version_id=?)"
+    "detail": "SEARCH lix_internal_state_cache_v1_lix_change_set USING INDEX idx_lix_internal_state_cache_v1_lix_change_set_pk_version_id_json_extract_snapsho_file_id_b2i1mo (version_id=?)"
   },
   {
     "id": 2672,
@@ -2578,7 +2578,7 @@ WHERE "diff"."status" != ?
     "id": 2683,
     "parent": 2672,
     "notused": 62,
-    "detail": "SEARCH lix_internal_state_cache_v1_lix_change_set_element USING INDEX idx_lix_internal_state_cache_v1_lix_change_set_element_foreign_version_id_inherited_from_versi_json_extract_snapsho_79rox8 (version_id=?)"
+    "detail": "SEARCH lix_internal_state_cache_v1_lix_change_set_element USING INDEX idx_lix_internal_state_cache_v1_lix_change_set_element_foreign_version_id_inherited_from_versi_json_extract_snapsho_file_id_76oyad (version_id=?)"
   },
   {
     "id": 2704,
@@ -2596,7 +2596,7 @@ WHERE "diff"."status" != ?
     "id": 2715,
     "parent": 2704,
     "notused": 62,
-    "detail": "SEARCH lix_internal_state_cache_v1_lix_label USING INDEX idx_lix_internal_state_cache_v1_lix_label_pk_version_id_json_extract_snapsho_4h2kdb (version_id=?)"
+    "detail": "SEARCH lix_internal_state_cache_v1_lix_label USING INDEX idx_lix_internal_state_cache_v1_lix_label_pk_version_id_json_extract_snapsho_file_id_b2i1mo (version_id=?)"
   },
   {
     "id": 2736,
@@ -2614,7 +2614,7 @@ WHERE "diff"."status" != ?
     "id": 2747,
     "parent": 2736,
     "notused": 62,
-    "detail": "SEARCH lix_internal_state_cache_v1_test_bench_diff_entity USING INDEX idx_lix_internal_state_cache_v1_test_bench_diff_entity_vfe (version_id=?)"
+    "detail": "SEARCH lix_internal_state_cache_v1_test_bench_diff_entity USING INDEX idx_lix_internal_state_cache_v1_test_bench_diff_entity_ve (version_id=?)"
   },
   {
     "id": 2768,
@@ -3166,7 +3166,7 @@ WHERE "diff"."status" != ?
     "id": 3546,
     "parent": 3535,
     "notused": 62,
-    "detail": "SEARCH lix_internal_state_cache_v1_lix_version_descriptor USING INDEX idx_lix_internal_state_cache_v1_lix_version_descriptor_pk_version_id_json_extract_snapsho_4h2kdb (version_id=?)"
+    "detail": "SEARCH lix_internal_state_cache_v1_lix_version_descriptor USING INDEX idx_lix_internal_state_cache_v1_lix_version_descriptor_pk_version_id_json_extract_snapsho_file_id_b2i1mo (version_id=?)"
   },
   {
     "id": 3567,
@@ -3184,7 +3184,7 @@ WHERE "diff"."status" != ?
     "id": 3578,
     "parent": 3567,
     "notused": 62,
-    "detail": "SEARCH lix_internal_state_cache_v1_lix_stored_schema USING INDEX idx_lix_internal_state_cache_v1_lix_stored_schema_pk_version_id_json_extract_snapsho_json_extract_snapsho_r7zrf9 (version_id=?)"
+    "detail": "SEARCH lix_internal_state_cache_v1_lix_stored_schema USING INDEX idx_lix_internal_state_cache_v1_lix_stored_schema_pk_version_id_json_extract_snapsho_json_extract_snapsho_file_id_l1xg3a (version_id=?)"
   },
   {
     "id": 3599,
@@ -3202,7 +3202,7 @@ WHERE "diff"."status" != ?
     "id": 3610,
     "parent": 3599,
     "notused": 62,
-    "detail": "SEARCH lix_internal_state_cache_v1_lix_key_value USING INDEX idx_lix_internal_state_cache_v1_lix_key_value_pk_version_id_json_extract_snapsho_4h2kdb (version_id=?)"
+    "detail": "SEARCH lix_internal_state_cache_v1_lix_key_value USING INDEX idx_lix_internal_state_cache_v1_lix_key_value_pk_version_id_json_extract_snapsho_file_id_b2i1mo (version_id=?)"
   },
   {
     "id": 3631,
@@ -3220,7 +3220,7 @@ WHERE "diff"."status" != ?
     "id": 3642,
     "parent": 3631,
     "notused": 62,
-    "detail": "SEARCH lix_internal_state_cache_v1_lix_active_account USING INDEX idx_lix_internal_state_cache_v1_lix_active_account_foreign_version_id_inherited_from_versi_json_extract_snapsho_79rox8 (version_id=?)"
+    "detail": "SEARCH lix_internal_state_cache_v1_lix_active_account USING INDEX idx_lix_internal_state_cache_v1_lix_active_account_foreign_version_id_inherited_from_versi_json_extract_snapsho_file_id_76oyad (version_id=?)"
   },
   {
     "id": 3663,
@@ -3238,7 +3238,7 @@ WHERE "diff"."status" != ?
     "id": 3674,
     "parent": 3663,
     "notused": 62,
-    "detail": "SEARCH lix_internal_state_cache_v1_lix_commit USING INDEX idx_lix_internal_state_cache_v1_lix_commit_pk_version_id_json_extract_snapsho_4h2kdb (version_id=?)"
+    "detail": "SEARCH lix_internal_state_cache_v1_lix_commit USING INDEX idx_lix_internal_state_cache_v1_lix_commit_pk_version_id_json_extract_snapsho_file_id_b2i1mo (version_id=?)"
   },
   {
     "id": 3695,
@@ -3256,7 +3256,7 @@ WHERE "diff"."status" != ?
     "id": 3706,
     "parent": 3695,
     "notused": 62,
-    "detail": "SEARCH lix_internal_state_cache_v1_lix_commit_edge USING INDEX idx_lix_internal_state_cache_v1_lix_commit_edge_foreign_version_id_inherited_from_versi_json_extract_snapsho_79rox8 (version_id=?)"
+    "detail": "SEARCH lix_internal_state_cache_v1_lix_commit_edge USING INDEX idx_lix_internal_state_cache_v1_lix_commit_edge_foreign_version_id_inherited_from_versi_json_extract_snapsho_file_id_76oyad (version_id=?)"
   },
   {
     "id": 3727,
@@ -3274,7 +3274,7 @@ WHERE "diff"."status" != ?
     "id": 3738,
     "parent": 3727,
     "notused": 62,
-    "detail": "SEARCH lix_internal_state_cache_v1_lix_version_tip USING INDEX idx_lix_internal_state_cache_v1_lix_version_tip_unique_version_id_json_extract_snapsho_c3jqlx (version_id=?)"
+    "detail": "SEARCH lix_internal_state_cache_v1_lix_version_tip USING INDEX idx_lix_internal_state_cache_v1_lix_version_tip_unique_version_id_json_extract_snapsho_file_id_b04j56 (version_id=?)"
   },
   {
     "id": 3759,
@@ -3292,7 +3292,7 @@ WHERE "diff"."status" != ?
     "id": 3770,
     "parent": 3759,
     "notused": 62,
-    "detail": "SEARCH lix_internal_state_cache_v1_lix_change_set USING INDEX idx_lix_internal_state_cache_v1_lix_change_set_pk_version_id_json_extract_snapsho_4h2kdb (version_id=?)"
+    "detail": "SEARCH lix_internal_state_cache_v1_lix_change_set USING INDEX idx_lix_internal_state_cache_v1_lix_change_set_pk_version_id_json_extract_snapsho_file_id_b2i1mo (version_id=?)"
   },
   {
     "id": 3791,
@@ -3310,7 +3310,7 @@ WHERE "diff"."status" != ?
     "id": 3802,
     "parent": 3791,
     "notused": 62,
-    "detail": "SEARCH lix_internal_state_cache_v1_lix_change_set_element USING INDEX idx_lix_internal_state_cache_v1_lix_change_set_element_foreign_version_id_inherited_from_versi_json_extract_snapsho_79rox8 (version_id=?)"
+    "detail": "SEARCH lix_internal_state_cache_v1_lix_change_set_element USING INDEX idx_lix_internal_state_cache_v1_lix_change_set_element_foreign_version_id_inherited_from_versi_json_extract_snapsho_file_id_76oyad (version_id=?)"
   },
   {
     "id": 3823,
@@ -3328,7 +3328,7 @@ WHERE "diff"."status" != ?
     "id": 3834,
     "parent": 3823,
     "notused": 62,
-    "detail": "SEARCH lix_internal_state_cache_v1_lix_label USING INDEX idx_lix_internal_state_cache_v1_lix_label_pk_version_id_json_extract_snapsho_4h2kdb (version_id=?)"
+    "detail": "SEARCH lix_internal_state_cache_v1_lix_label USING INDEX idx_lix_internal_state_cache_v1_lix_label_pk_version_id_json_extract_snapsho_file_id_b2i1mo (version_id=?)"
   },
   {
     "id": 3855,
@@ -3346,7 +3346,7 @@ WHERE "diff"."status" != ?
     "id": 3866,
     "parent": 3855,
     "notused": 62,
-    "detail": "SEARCH lix_internal_state_cache_v1_test_bench_diff_entity USING INDEX idx_lix_internal_state_cache_v1_test_bench_diff_entity_vfe (version_id=?)"
+    "detail": "SEARCH lix_internal_state_cache_v1_test_bench_diff_entity USING INDEX idx_lix_internal_state_cache_v1_test_bench_diff_entity_ve (version_id=?)"
   },
   {
     "id": 3887,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds file-aware PK/unique indexing and configurable foreign-key scope, plus a new `(version_id, entity_id)` index; updates tests and bench plans accordingly.
> 
> - **Indexes/Schema Cache**:
>   - Add `idx_<table>_ve` on `(version_id, entity_id)` in `create-schema-cache-table.ts`.
>   - Update `buildSchemaIndexSpecs` to include `file_id` in PK/unique index expressions and support configurable FK `scope` (default `version_id,file_id`).
>   - Generate index names accordingly in `schema-indexes.ts`; add normalization for FK scope.
> - **Tests**:
>   - Adjust index expectations to include `file_id` and new column orders; add test ensuring FK respects custom scope.
>   - Add simulation validating file-scoped unique constraints allow duplicates across files via `lix_internal_state_vtable`.
> - **Bench/Plans**:
>   - Update explain plans to reflect new/renamed indexes (e.g., `..._ve`, file-scoped index suffixes) and added `file_id` predicates in validation queries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 334f40452ea67ed8eeb676c55336a8adcb3326c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->