### PR TITLE
always show welcome screen

### DIFF
--- a/packages/flashtype/src/app/central-panel.test.tsx
+++ b/packages/flashtype/src/app/central-panel.test.tsx
@@ -1,6 +1,6 @@
 import { Suspense, act, type ReactNode } from "react";
 import { DndContext } from "@dnd-kit/core";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
 import { CentralPanel } from "./central-panel";
 import type { PanelState, ViewContext } from "./types";
@@ -84,30 +84,6 @@ const createViewContext = (
 });
 
 describe("CentralPanel", () => {
-	test("shows the landing or welcome screen when no views are open", async () => {
-		const emptyPanel: PanelState = { views: [], activeInstance: null };
-
-		await renderWithProviders(
-			<DndContext>
-				<CentralPanel
-					panel={emptyPanel}
-					onSelectView={() => {}}
-					onRemoveView={() => {}}
-					viewContext={createViewContext()}
-					isFocused={false}
-					onFocusPanel={vi.fn()}
-				/>
-			</DndContext>,
-		);
-
-		// Should show either landing screen (no files) or welcome screen (files exist)
-		await waitFor(() => {
-			const landingScreen = screen.queryByTestId("landing-screen");
-			const welcomeScreen = screen.queryByTestId("welcome-screen");
-			expect(landingScreen || welcomeScreen).toBeInTheDocument();
-		});
-	});
-
 	test("renders the active view and wires tab selection", async () => {
 		const panelState: PanelState = {
 			views: [{ instance: "search-1", kind: SEARCH_VIEW_KIND }],

--- a/packages/flashtype/src/app/central-panel.tsx
+++ b/packages/flashtype/src/app/central-panel.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from "react";
-import { LixProvider, useQueryTakeFirst } from "@lix-js/react-utils";
+import { LixProvider } from "@lix-js/react-utils";
 import type {
 	PanelState,
 	PanelSide,
@@ -7,7 +7,6 @@ import type {
 	ViewDefinition,
 } from "./types";
 import { PanelV2 } from "./panel-v2";
-import { WelcomeScreen } from "./welcome-screen";
 import { LandingScreen } from "./landing-screen";
 
 type CentralPanelProps = {
@@ -19,8 +18,6 @@ type CentralPanelProps = {
 	readonly isFocused: boolean;
 	readonly onFocusPanel: (side: PanelSide) => void;
 	readonly onFinalizePendingView?: (key: string) => void;
-	readonly leftPanel?: PanelState;
-	readonly rightPanel?: PanelState;
 };
 
 /**
@@ -43,8 +40,6 @@ export function CentralPanel({
 	onFocusPanel,
 	onFinalizePendingView,
 	onCreateNewFile,
-	leftPanel,
-	rightPanel,
 }: CentralPanelProps) {
 	const finalizePendingIfNeeded = useCallback(
 		(key: string) => {
@@ -62,9 +57,7 @@ export function CentralPanel({
 			<EmptyStateContent
 				viewContext={viewContext}
 				onCreateNewFile={onCreateNewFile}
-				leftPanel={leftPanel}
-				rightPanel={rightPanel}
-				centralPanel={panel}
+				isFocused={isFocused}
 			/>
 		</LixProvider>
 	);
@@ -93,43 +86,22 @@ export function CentralPanel({
 }
 
 /**
- * Content component that checks for files and conditionally renders landing or welcome screen.
+ * Empty central panel content that renders the landing screen.
  */
 function EmptyStateContent({
 	viewContext,
 	onCreateNewFile,
-	leftPanel,
-	rightPanel,
-	centralPanel,
+	isFocused,
 }: {
 	viewContext: ViewContext;
 	onCreateNewFile?: () => void | Promise<void>;
-	leftPanel?: PanelState;
-	rightPanel?: PanelState;
-	centralPanel: PanelState;
+	isFocused: boolean;
 }) {
-	// Check if files exist in lix (excluding AGENTS.md, same query as top bar alpha warning)
-	const fileCount = useQueryTakeFirst(({ lix }) =>
-		lix.db
-			.selectFrom("file")
-			.select(({ fn }) => [fn.count<number>("id").as("count")])
-			.where("path", "is not", "/AGENTS.md"),
-	);
-
-	const hasFiles = (fileCount?.count ?? 0) > 0;
-
-	if (hasFiles) {
-		return (
-			<WelcomeScreen
-				viewContext={viewContext}
-				onCreateNewFile={onCreateNewFile}
-				leftPanel={leftPanel}
-				rightPanel={rightPanel}
-				centralPanel={centralPanel}
-			/>
-		);
-	}
 	return (
-		<LandingScreen context={viewContext} onCreateNewFile={onCreateNewFile} />
+		<LandingScreen
+			context={viewContext}
+			onCreateNewFile={onCreateNewFile}
+			isPanelFocused={isFocused}
+		/>
 	);
 }

--- a/packages/flashtype/src/app/layout-shell.tsx
+++ b/packages/flashtype/src/app/layout-shell.tsx
@@ -1196,8 +1196,6 @@ function LayoutShellContent() {
 								}
 								viewContext={centralViewContext}
 								onCreateNewFile={handleCreateNewFile}
-								leftPanel={leftPanel}
-								rightPanel={rightPanel}
 							/>
 						</Panel>
 						<PanelResizeHandle className="relative w-1 flex items-center justify-center group">

--- a/packages/flashtype/src/views/agent-view/components/prompt-composer.tsx
+++ b/packages/flashtype/src/views/agent-view/components/prompt-composer.tsx
@@ -1,7 +1,9 @@
 import {
+	forwardRef,
 	useCallback,
 	useEffect,
 	useId,
+	useImperativeHandle,
 	useLayoutEffect,
 	useMemo,
 	useRef,
@@ -93,21 +95,27 @@ type PromptComposerProps = {
 /**
  * Prompt composer textarea with slash-command support.
  */
-export function PromptComposer({
-	hasKey,
-	models,
-	modelId,
-	onModelChange,
-	autoAcceptEnabled,
-	onAutoAcceptToggle,
-	commands,
-	files,
-	pending,
-	onNotice,
-	onSlashCommand,
-	onSendMessage,
-	placeholderText: customPlaceholderText,
-}: PromptComposerProps) {
+export const PromptComposer = forwardRef<
+	HTMLTextAreaElement | null,
+	PromptComposerProps
+>(function PromptComposer(
+	{
+		hasKey,
+		models,
+		modelId,
+		onModelChange,
+		autoAcceptEnabled,
+		onAutoAcceptToggle,
+		commands,
+		files,
+		pending,
+		onNotice,
+		onSlashCommand,
+		onSendMessage,
+		placeholderText: customPlaceholderText,
+	}: PromptComposerProps,
+	forwardedRef,
+) {
 	const textAreaId = useId();
 	const textAreaRef = useRef<HTMLTextAreaElement | null>(null);
 	const [value, setValue] = useState("");
@@ -157,6 +165,16 @@ export function PromptComposer({
 	useEffect(() => {
 		updateMentions(textAreaRef.current);
 	}, [value, updateMentions]);
+
+	useImperativeHandle<HTMLTextAreaElement | null, HTMLTextAreaElement | null>(
+		forwardedRef,
+		() => textAreaRef.current,
+	);
+
+	useEffect(() => {
+		if (pending) return;
+		moveCaretToEnd(textAreaRef.current);
+	}, [pending]);
 
 	const insertMention = useCallback(
 		(path: string) => {
@@ -536,7 +554,7 @@ export function PromptComposer({
 			</div>
 		</div>
 	);
-}
+});
 
 function ModelSelector({
 	options,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Always show `LandingScreen` as the central empty state with focus-aware placeholder animation, refactor `PromptComposer` to use forwardRef and improved focus, and update related layout and tests.
> 
> - **Central Panel / Empty State**:
>   - Always render `LandingScreen`; remove conditional `WelcomeScreen` logic and related DB query.
>   - Simplify props; drop `leftPanel`/`rightPanel`; pass `isFocused` to empty state and through to `LandingScreen` as `isPanelFocused`.
> - **Landing Screen**:
>   - Add `isPanelFocused` prop; implement focus-aware animated placeholder with fallback `DEFAULT_PLACEHOLDER` when unfocused.
>   - Update branding header to an external link with “powered by” badge.
>   - Wire animated placeholder into `PromptComposer` via `placeholderText`.
> - **Prompt Composer**:
>   - Convert to `forwardRef` and expose textarea via `useImperativeHandle`.
>   - Auto-move caret to end when `pending` clears; minor internal refactors.
> - **Layout Shell**:
>   - Stop passing dropped panel props to `CentralPanel`.
> - **Tests**:
>   - Remove welcome/landing conditional test; add focus/tab behavior and pending-finalization tests in `central-panel.test.tsx`.
>   - Refactor composer tests; add proposal decision flow focusing the composer.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0dd690fb5a175d15d6d4f78ea8183456d510d3c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->