### PR TITLE
prep markdown plugin for publishment

### DIFF
--- a/.changeset/publish-plugin-md.md
+++ b/.changeset/publish-plugin-md.md
@@ -1,0 +1,5 @@
+---
+"@lix-js/plugin-md": minor
+---
+
+Prepare the Markdown plugin for its first public publish on npm.

--- a/packages/lix/plugin-md/package.json
+++ b/packages/lix/plugin-md/package.json
@@ -1,11 +1,14 @@
 {
 	"name": "@lix-js/plugin-md",
 	"type": "module",
-	"private": true,
 	"version": "0.1.3",
 	"license": "Apache-2.0",
+	"types": "./dist/index.d.ts",
 	"exports": {
 		".": "./dist/index.js"
+	},
+	"publishConfig": {
+		"access": "public"
 	},
 	"scripts": {
 		"build": "rolldown -c",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Prepare @lix-js/plugin-md for first public npm publish by making the package public and exposing TypeScript types.
> 
> - **Package config (`packages/lix/plugin-md/package.json`)**:
>   - Make package public by removing `"private"` and adding `"publishConfig": { "access": "public" }`.
>   - Expose TypeScript declarations via `"types": "./dist/index.d.ts"`.
> - **Release**:
>   - Add changeset `/.changeset/publish-plugin-md.md` for a minor release announcing first public publish.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b975e101e6779825cf243e46387eace2001271e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->