### PR TITLE
Truncate file names to prevent overflow

### DIFF
--- a/packages/flashtype/src/views/files-view/file-tree.tsx
+++ b/packages/flashtype/src/views/files-view/file-tree.tsx
@@ -159,9 +159,10 @@ function FileTreeNode({
 	readonly isPanelFocused: boolean;
 }) {
 	if (node.type === "file") {
+		const displayName = formatDisplayName(node.name);
 		const isSelected = selectedPath === node.path;
 		const buttonClass = clsx(
-			"flex w-full items-center gap-2 rounded border border-transparent px-2 py-1 text-left text-sm transition-colors",
+			"flex w-full min-w-0 items-center gap-2 rounded border border-transparent px-2 py-1 text-left text-sm transition-colors",
 			!isSelected && "hover:bg-neutral-100",
 			isSelected ? selectedClasses : "text-neutral-700",
 		);
@@ -178,20 +179,23 @@ function FileTreeNode({
 						void openFileView?.(node.id, node.path);
 					}}
 				>
-					<FileText className="h-3.5 w-3.5 text-neutral-500" />
-					<span>{formatDisplayName(node.name)}</span>
+					<FileText className="h-3.5 w-3.5 shrink-0 text-neutral-500" />
+					<span className="min-w-0 flex-1 truncate" title={displayName}>
+						{displayName}
+					</span>
 				</button>
 			</li>
 		);
 	}
 
+	const displayName = formatDisplayName(node.name);
 	const containsDraft = draft?.directoryPath === node.path;
 	const isOpen = containsDraft || openDirectories.has(node.path);
 	const Icon = isOpen ? FolderOpen : Folder;
 	const suppressSelection = Boolean(draft && draft.directoryPath === node.path);
 	const isSelected = !suppressSelection && selectedPath === node.path;
 	const buttonClass = clsx(
-		"flex items-center gap-1 rounded border border-transparent px-2 py-1 text-left text-sm font-medium transition-colors",
+		"flex w-full min-w-0 items-center gap-1 rounded border border-transparent px-2 py-1 text-left text-sm font-medium transition-colors",
 		!isSelected && "hover:bg-neutral-100",
 		isSelected ? selectedClasses : "text-neutral-700",
 	);
@@ -211,10 +215,12 @@ function FileTreeNode({
 					}}
 				>
 					<ChevronRight
-						className={`h-3 w-3 transition-transform ${isOpen ? "rotate-90" : ""}`}
+						className={`h-3 w-3 shrink-0 transition-transform ${isOpen ? "rotate-90" : ""}`}
 					/>
-					<Icon className="h-3.5 w-3.5 text-neutral-500" />
-					<span>{formatDisplayName(node.name)}</span>
+					<Icon className="h-3.5 w-3.5 shrink-0 text-neutral-500" />
+					<span className="min-w-0 flex-1 truncate" title={displayName}>
+						{displayName}
+					</span>
 				</button>
 			</div>
 			{isOpen ? (


### PR DESCRIPTION
Truncate long file and directory names in the file tree to prevent UI element shrinking and text overflow.

---
<a href="https://cursor.com/background-agent?bcId=bc-9f9261dd-c7e0-47bf-91f7-a19818ee1532"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9f9261dd-c7e0-47bf-91f7-a19818ee1532"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Truncates long file and directory names and adjusts layout to prevent overflow/shrinking in the file tree.
> 
> - **UI (files-view/file-tree.tsx)**:
>   - Truncate long file/directory names with `truncate` and show full name via `title`.
>   - Prevent icon/text shrink and enable proper truncation using `min-w-0`, `flex-1`, `shrink-0`, and `w-full` on buttons.
>   - Precompute `displayName = formatDisplayName(node.name)` for files and directories.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a1bd15bceef282bbfa7e5bf331858caa184d0b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->