### PR TITLE
feat: enhance plugin documentation and metadata integration

### DIFF
--- a/packages/lix/docs/.gitignore
+++ b/packages/lix/docs/.gitignore
@@ -9,3 +9,9 @@ src/docs/api/*
 # generated from @lix-js/react-utils/README.md
 docs/react-integration.mdx
 src/docs/react-integration.mdx
+
+# generated from plugin registry/READMEs
+src/plugins/_meta.json
+src/plugins/*.mdx
+!src/plugins/index.mdx
+!src/plugins/plugin.registry.json

--- a/packages/lix/docs/rspress-plugins/sync-plugin-readmes.ts
+++ b/packages/lix/docs/rspress-plugins/sync-plugin-readmes.ts
@@ -1,0 +1,165 @@
+import path from "node:path";
+import fs from "node:fs/promises";
+import fsSync from "node:fs";
+import type { RspressPlugin } from "@rspress/core";
+
+// Map from package name to package directory name
+const packageToDir: Record<string, string> = {
+  "@lix-js/plugin-json": "plugin-json",
+  "@lix-js/plugin-md": "plugin-md",
+  "@lix-js/plugin-csv": "plugin-csv",
+  "@lix-js/plugin-prosemirror": "plugin-prosemirror",
+};
+
+type RegistryPlugin = {
+  key: string;
+  name: string;
+  package: string;
+  description: string;
+  file_types: string[];
+  links: {
+    npm: string;
+    github: string;
+    docs: string;
+    example?: string;
+  };
+};
+
+// Extract display name from plugin name (remove "Plugin" suffix)
+export function getDisplayName(pluginName: string): string {
+  return pluginName.replace(/\s+Plugin$/, "");
+}
+
+export function syncPluginReadmesPlugin(): RspressPlugin {
+  return {
+    name: "sync-plugin-readmes",
+    async config(config) {
+      const docsRoot = config.root!;
+      const pluginsDir = path.join(docsRoot, "plugins");
+      const registryPath = path.join(pluginsDir, "plugin.registry.json");
+
+      // Read the plugin registry
+      const registryContent = await fs.readFile(registryPath, "utf8");
+      const registry = JSON.parse(registryContent) as {
+        plugins: RegistryPlugin[];
+      };
+
+      // Generate sidebar metadata
+      const metaItems: Array<{
+        type: "file";
+        name: string;
+        label: string;
+        tag?: string;
+      }> = [
+        {
+          type: "file",
+          name: "index",
+          label: "Overview",
+        },
+      ];
+
+      // Sync READMEs and build sidebar entries
+      for (const plugin of registry.plugins) {
+        const slug = plugin.key;
+        const packageDir = packageToDir[plugin.package];
+
+        if (!slug || !packageDir) {
+          console.warn(
+            `⚠️  Unknown plugin package: ${plugin.package}, skipping`,
+          );
+          continue;
+        }
+
+        // Sync README
+        const src = path.join(
+          __dirname,
+          "..",
+          "..",
+          packageDir,
+          "README.md",
+        );
+        const dest = path.join(pluginsDir, `${slug}.mdx`);
+
+        let readme = await fs.readFile(src, "utf8");
+
+        // Replace relative image paths with GitHub raw URLs
+        readme = readme.replace(
+          /\]\(\.\/assets\/([^)]+)\)/g,
+          `](https://github.com/opral/monorepo/raw/main/packages/lix/${packageDir}/assets/$1)`,
+        );
+
+        // Replace relative example directory links with GitHub path to avoid dead links in docs
+        readme = readme.replace(
+          /\]\(\.\/example\)/g,
+          `](https://github.com/opral/monorepo/tree/main/packages/lix/${packageDir}/example)`,
+        );
+
+        // Generate metadata card component import and usage
+        const metadataCard = `<PluginMetadataCard
+  packageName="${plugin.package}"
+  npmUrl="${plugin.links.npm}"
+  githubUrl="${plugin.links.github}"
+  ${plugin.links.example ? `exampleUrl="${plugin.links.example}"` : ""}
+/>
+
+`;
+
+        await fs.mkdir(path.dirname(dest), { recursive: true });
+        await fs.writeFile(dest, metadataCard + readme, "utf8");
+        console.log(`✅ copied ${packageDir} README.md to ${dest}`);
+
+        // Add to sidebar
+        const displayName = getDisplayName(plugin.name);
+        metaItems.push({
+          type: "file",
+          name: slug,
+          label: displayName,
+        });
+      }
+
+      // Write _meta.json
+      const metaJsonPath = path.join(pluginsDir, "_meta.json");
+      await fs.writeFile(metaJsonPath, JSON.stringify(metaItems, null, 2));
+      console.log(`✅ generated _meta.json for plugins directory`);
+
+      return config;
+    },
+  };
+}
+
+export function generatePluginsSidebar(docsRoot: string) {
+  const pluginsDir = path.join(docsRoot, "plugins");
+  const registryPath = path.join(pluginsDir, "plugin.registry.json");
+
+  // Check if registry exists
+  if (!fsSync.existsSync(registryPath)) {
+    console.warn(`⚠️  plugin.registry.json not found at ${registryPath}`);
+    return [{ text: "Overview", link: "/plugins/" }];
+  }
+
+  // Read and parse registry
+  const registryContent = fsSync.readFileSync(registryPath, "utf8");
+  const registry = JSON.parse(registryContent) as {
+    plugins: Array<{
+      key: string;
+      name: string;
+      package: string;
+    }>;
+  };
+
+  // Generate sidebar from registry
+  const sidebar = [{ text: "Overview", link: "/plugins/" }];
+
+  for (const plugin of registry.plugins) {
+    const slug = plugin.key;
+    if (!slug) continue;
+
+    const displayName = getDisplayName(plugin.name);
+    sidebar.push({
+      text: displayName,
+      link: `/plugins/${slug}`,
+    });
+  }
+
+  return sidebar;
+}

--- a/packages/lix/docs/rspress.config.ts
+++ b/packages/lix/docs/rspress.config.ts
@@ -3,6 +3,10 @@ import { defineConfig } from "@rspress/core";
 import { pluginLlms } from "@rspress/plugin-llms";
 import { syncReactUtilsReadmePlugin } from "./rspress-plugins/sync-react-utils-readme";
 import {
+  syncPluginReadmesPlugin,
+  generatePluginsSidebar,
+} from "./rspress-plugins/sync-plugin-readmes";
+import {
   generateApiDocs,
   generateApiSidebar,
 } from "./rspress-plugins/typedoc-plugin";
@@ -53,6 +57,7 @@ export default defineConfig({
     mdxRs: false,
     globalComponents: [
       path.join(__dirname, "src/docs/components/InteractiveExampleCard.tsx"),
+      path.join(__dirname, "src/docs/components/PluginMetadataCard.tsx"),
       mermaidComponentPath,
     ],
     remarkPlugins: [remarkMermaid],
@@ -88,11 +93,13 @@ export default defineConfig({
       siteUrl: "https://lix.dev",
     }),
     syncReactUtilsReadmePlugin(),
+    syncPluginReadmesPlugin(),
   ],
   themeConfig: {
     darkMode: false,
     nav: [
       { text: "Docs", link: "/docs/what-is-lix" },
+      { text: "Plugins", link: "/plugins/" },
       { text: "API Reference", link: "/docs/api/" },
     ],
     sidebar: {
@@ -142,6 +149,7 @@ export default defineConfig({
           ],
         },
       ],
+      "/plugins/": generatePluginsSidebar(path.join(__dirname, "src")),
       "/docs/api/": generateApiSidebar(path.join(__dirname, "src/docs")),
     },
     socialLinks: [

--- a/packages/lix/docs/src/docs/components/PluginMetadataCard.tsx
+++ b/packages/lix/docs/src/docs/components/PluginMetadataCard.tsx
@@ -1,0 +1,175 @@
+import React from "react";
+
+type PluginMetadataCardProps = {
+  packageName: string;
+  npmUrl: string;
+  githubUrl: string;
+  exampleUrl?: string;
+};
+
+export default function PluginMetadataCard({
+  packageName,
+  npmUrl,
+  githubUrl,
+  exampleUrl,
+}: PluginMetadataCardProps) {
+  return (
+    <div
+      style={{
+        marginBottom: "24px",
+        display: "flex",
+        flexWrap: "wrap",
+        gap: "12px",
+        alignItems: "stretch",
+      }}
+    >
+      <a
+        href={npmUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "8px",
+          textDecoration: "none",
+          color: "#2563eb",
+          flex: "1",
+          minWidth: "200px",
+          padding: "8px 12px",
+          borderRadius: "6px",
+          border: "1px solid #e5e7eb",
+          backgroundColor: "#ffffff",
+          cursor: "pointer",
+          transition: "all 0.2s ease",
+        }}
+        onMouseEnter={(e) => {
+          e.currentTarget.style.borderColor = "#2563eb";
+          e.currentTarget.style.backgroundColor = "#eff6ff";
+          e.currentTarget.style.transform = "translateY(-1px)";
+          e.currentTarget.style.boxShadow = "0 2px 4px rgba(0,0,0,0.1)";
+        }}
+        onMouseLeave={(e) => {
+          e.currentTarget.style.borderColor = "#e5e7eb";
+          e.currentTarget.style.backgroundColor = "#ffffff";
+          e.currentTarget.style.transform = "translateY(0)";
+          e.currentTarget.style.boxShadow = "none";
+        }}
+      >
+        <svg
+          viewBox="0 0 2500 2500"
+          style={{ width: "24px", height: "24px", flexShrink: 0 }}
+        >
+          <path fill="#c00" d="M0 0h2500v2500H0z" />
+          <path
+            fill="#fff"
+            d="M1241.5 268.5h-973v1962.9h972.9V763.5h495v1467.9h495V268.5z"
+          />
+        </svg>
+        <div>
+          <div style={{ fontWeight: 600, fontSize: "14px" }}>npm</div>
+          <div style={{ fontSize: "13px", color: "#6b7280" }}>
+            {packageName}
+          </div>
+        </div>
+      </a>
+
+
+      <a
+        href={githubUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "8px",
+          textDecoration: "none",
+          color: "#2563eb",
+          flex: "1",
+          minWidth: "200px",
+          padding: "8px 12px",
+          borderRadius: "6px",
+          border: "1px solid #e5e7eb",
+          backgroundColor: "#ffffff",
+          cursor: "pointer",
+          transition: "all 0.2s ease",
+        }}
+        onMouseEnter={(e) => {
+          e.currentTarget.style.borderColor = "#2563eb";
+          e.currentTarget.style.backgroundColor = "#eff6ff";
+          e.currentTarget.style.transform = "translateY(-1px)";
+          e.currentTarget.style.boxShadow = "0 2px 4px rgba(0,0,0,0.1)";
+        }}
+        onMouseLeave={(e) => {
+          e.currentTarget.style.borderColor = "#e5e7eb";
+          e.currentTarget.style.backgroundColor = "#ffffff";
+          e.currentTarget.style.transform = "translateY(0)";
+          e.currentTarget.style.boxShadow = "none";
+        }}
+      >
+        <svg
+          viewBox="0 0 1024 1024"
+          fill="none"
+          style={{ width: "24px", height: "24px", flexShrink: 0 }}
+        >
+          <path
+            fillRule="evenodd"
+            clipRule="evenodd"
+            d="M8 0C3.58 0 0 3.58 0 8C0 11.54 2.29 14.53 5.47 15.59C5.87 15.66 6.02 15.42 6.02 15.21C6.02 15.02 6.01 14.39 6.01 13.72C4 14.09 3.48 13.23 3.32 12.78C3.23 12.55 2.84 11.84 2.5 11.65C2.22 11.5 1.82 11.13 2.49 11.12C3.12 11.11 3.57 11.7 3.72 11.94C4.44 13.15 5.59 12.81 6.05 12.6C6.12 12.08 6.33 11.73 6.56 11.53C4.78 11.33 2.92 10.64 2.92 7.58C2.92 6.71 3.23 5.99 3.74 5.43C3.66 5.23 3.38 4.41 3.82 3.31C3.82 3.31 4.49 3.1 6.02 4.13C6.66 3.95 7.34 3.86 8.02 3.86C8.7 3.86 9.38 3.95 10.02 4.13C11.55 3.09 12.22 3.31 12.22 3.31C12.66 4.41 12.38 5.23 12.3 5.43C12.81 5.99 13.12 6.7 13.12 7.58C13.12 10.65 11.25 11.33 9.47 11.53C9.76 11.78 10.01 12.26 10.01 13.01C10.01 14.08 10 14.94 10 15.21C10 15.42 10.15 15.67 10.55 15.59C13.71 14.53 16 11.53 16 8C16 3.58 12.42 0 8 0Z"
+            transform="scale(64)"
+            fill="#000"
+          />
+        </svg>
+        <div>
+          <div style={{ fontWeight: 600, fontSize: "14px" }}>GitHub</div>
+          <div style={{ fontSize: "13px", color: "#6b7280" }}>
+            View source code
+          </div>
+        </div>
+      </a>
+
+      {exampleUrl && (
+        <a
+            href={exampleUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "8px",
+              textDecoration: "none",
+              color: "#2563eb",
+              flex: "1",
+              minWidth: "200px",
+              padding: "8px 12px",
+              borderRadius: "6px",
+              border: "1px solid #e5e7eb",
+              backgroundColor: "#ffffff",
+              cursor: "pointer",
+              transition: "all 0.2s ease",
+            }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.borderColor = "#2563eb";
+              e.currentTarget.style.backgroundColor = "#eff6ff";
+              e.currentTarget.style.transform = "translateY(-1px)";
+              e.currentTarget.style.boxShadow = "0 2px 4px rgba(0,0,0,0.1)";
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.borderColor = "#e5e7eb";
+              e.currentTarget.style.backgroundColor = "#ffffff";
+              e.currentTarget.style.transform = "translateY(0)";
+              e.currentTarget.style.boxShadow = "none";
+            }}
+          >
+            <span style={{ fontSize: "20px" }}>💻</span>
+            <div>
+              <div style={{ fontWeight: 600, fontSize: "14px" }}>Example</div>
+              <div style={{ fontSize: "13px", color: "#6b7280" }}>
+                Try demo →
+              </div>
+            </div>
+          </a>
+      )}
+    </div>
+  );
+}
+

--- a/packages/lix/docs/src/plugins/index.mdx
+++ b/packages/lix/docs/src/plugins/index.mdx
@@ -1,0 +1,16 @@
+# Plugins
+
+Plugins define how Lix tracks changes in different file formats. Learn more about [how plugins work](/docs/plugins).
+
+## Available plugins
+
+| File type | Plugin |
+|-----------|--------|
+| `*.json` | [JSON Plugin](/plugins/plugin_json) |
+| `*.csv` | [CSV Plugin](/plugins/lix_plugin_csv) |
+| `*.md` | [Markdown Plugin](/plugins/plugin_md) |
+| ProseMirror docs | [ProseMirror Plugin](/plugins/plugin_prosemirror) |
+
+## Build your own plugin
+
+Read the [plugin documentation](/docs/plugins) to create a plugin for your file format.

--- a/packages/lix/docs/src/plugins/plugin.registry.json
+++ b/packages/lix/docs/src/plugins/plugin.registry.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "plugins": [
+    {
+      "key": "plugin_json",
+      "name": "JSON Plugin",
+      "package": "@lix-js/plugin-json",
+      "description": "Tracks JSON files with JSON Pointer entities",
+      "file_types": ["*.json"],
+      "links": {
+        "npm": "https://www.npmjs.com/package/@lix-js/plugin-json",
+        "github": "https://github.com/opral/monorepo/tree/main/packages/lix/plugin-json",
+        "docs": "/plugins/plugin_json"
+      }
+    },
+    {
+      "key": "lix_plugin_csv",
+      "name": "CSV Plugin",
+      "package": "@lix-js/plugin-csv",
+      "description": "Tracks CSV files with row-level entities",
+      "file_types": ["*.csv"],
+      "links": {
+        "npm": "https://www.npmjs.com/package/@lix-js/plugin-csv",
+        "github": "https://github.com/opral/monorepo/tree/main/packages/lix/plugin-csv",
+        "docs": "/plugins/lix_plugin_csv"
+      }
+    },
+    {
+      "key": "plugin_md",
+      "name": "Markdown Plugin",
+      "package": "@lix-js/plugin-md",
+      "description": "Tracks Markdown files using markdown-wc AST",
+      "file_types": ["*.md"],
+      "links": {
+        "npm": "https://www.npmjs.com/package/@lix-js/plugin-md",
+        "github": "https://github.com/opral/monorepo/tree/main/packages/lix/plugin-md",
+        "docs": "/plugins/plugin_md"
+      }
+    },
+    {
+      "key": "plugin_prosemirror",
+      "name": "ProseMirror Plugin",
+      "package": "@lix-js/plugin-prosemirror",
+      "description": "Tracks rich text edits in ProseMirror documents",
+      "file_types": ["/prosemirror.json"],
+      "links": {
+        "npm": "https://www.npmjs.com/package/@lix-js/plugin-prosemirror",
+        "github": "https://github.com/opral/monorepo/tree/main/packages/lix/plugin-prosemirror",
+        "docs": "/plugins/plugin_prosemirror",
+        "example": "https://prosemirror-example.onrender.com/"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
- Added new `sync-plugin-readmes` plugin to sync README files for plugins and generate sidebar metadata.
- Introduced `PluginMetadataCard` component for displaying plugin information.
- Updated `rspress.config.ts` to include new plugin features and sidebar generation.
- Created `plugin.registry.json` to define available plugins and their metadata.
- Added `index.mdx` for the plugins documentation page.
- Updated `.gitignore` to exclude generated files from the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a docs plugin to sync plugin READMEs and metadata, introduces a PluginMetadataCard, and wires a generated Plugins section with sidebar/navigation.
> 
> - **Docs tooling**:
>   - Add `sync-plugin-readmes` Rspress plugin to:
>     - Read `plugins/plugin.registry.json`, copy each package `README.md` to `src/plugins/<key>.mdx` with asset/example link rewrites and a prepended `PluginMetadataCard`.
>     - Generate `src/plugins/_meta.json` and export `generatePluginsSidebar()`.
> - **Site config** (`rspress.config.ts`):
>   - Register `syncPluginReadmesPlugin()` and `PluginMetadataCard` as a global component.
>   - Add "Plugins" to top nav and use `generatePluginsSidebar()` for `/plugins/`.
> - **UI component**: Add `src/docs/components/PluginMetadataCard.tsx` for npm/GitHub/example links.
> - **Content**:
>   - Add `src/plugins/index.mdx` overview and `src/plugins/plugin.registry.json`.
> - **Ignore rules**: Update `.gitignore` to exclude generated `src/plugins/*.mdx` and `_meta.json` (keep `index.mdx` and `plugin.registry.json`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6946515785a2fccd38588957d7ed5cbc53653f73. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->