### PR TITLE
refactor: update documentation for file history queries and plugin information

### DIFF
--- a/packages/lix/docs/src/docs/plugins.md
+++ b/packages/lix/docs/src/docs/plugins.md
@@ -133,13 +133,7 @@ Each file is automatically processed by the plugin whose `detectChangesGlob` pat
 
 ## Finding Plugins
 
-Official plugins:
-- [@lix-js/plugin-json](https://www.npmjs.com/package/@lix-js/plugin-json)
-- [@lix-js/plugin-csv](https://www.npmjs.com/package/@lix-js/plugin-csv)
-- [@lix-js/plugin-md](https://www.npmjs.com/package/@lix-js/plugin-md)
-- [@lix-js/plugin-prosemirror](https://www.npmjs.com/package/@lix-js/plugin-prosemirror)
-
-Community plugins: Check the [Lix GitHub organization](https://github.com/opral/lix-sdk)
+Browse the [plugins directory](/plugins) for official and community plugins, installation instructions, and file type coverage.
 
 ## Next Steps
 


### PR DESCRIPTION
- Enhanced the file history query examples to reflect changes in the database structure and improve clarity on querying file states and changes.
- Updated the plugins documentation to direct users to a centralized plugins directory for official and community plugins, along with installation instructions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Revamps docs to showcase SQL-native change querying (updated file/state history examples and new blame-style query) and points plugin discovery to a centralized directory.
> 
> - **Docs (comparison-to-git.md)**
>   - Update SQL examples to use `file_history`/`state_history`, `lixcol_root_commit_id`, and depth-scoped filters; add cross-version comparison selecting `versionAData`/`versionBData`.
>   - Introduce **SQL-Native Change Queries** section; replace prior line-diff discussion with an entity-level blame-style query example joining `change_author`/`account`.
>   - Clarify phrasing (e.g., time-travel from a specific commit) and focus on querying changes directly.
> - **Docs (plugins.md)**
>   - Replace explicit plugin package list with a link to a centralized [plugins directory](/plugins) in “Finding Plugins”.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9b3f9ad5f9aea652b4843c6d5d6d72865c2f28f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->