### PR TITLE
feat: add welcome screen to AI agent view

### DIFF
--- a/packages/flashtype/src/views/agent-view/components/agent-empty-state.tsx
+++ b/packages/flashtype/src/views/agent-view/components/agent-empty-state.tsx
@@ -1,0 +1,27 @@
+import { Bot } from "lucide-react";
+
+const SUGGESTIONS = [
+	"Write a blog post",
+	"Review your resume",
+	"Answer questions about your docs",
+];
+
+export function AgentEmptyState() {
+	return (
+		<div className="flex h-full w-full flex-col items-center justify-center gap-6 p-4">
+			<div className="flex flex-col items-center gap-3">
+				<div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+					<Bot className="h-6 w-6 text-muted-foreground" />
+				</div>
+				<h2 className="text-lg font-medium text-foreground">
+					What can I do for you?
+				</h2>
+			</div>
+			<ul className="flex flex-col gap-1 text-sm text-muted-foreground">
+				{SUGGESTIONS.map((suggestion) => (
+					<li key={suggestion}>• {suggestion}</li>
+				))}
+			</ul>
+		</div>
+	);
+}

--- a/packages/flashtype/src/views/agent-view/index.tsx
+++ b/packages/flashtype/src/views/agent-view/index.tsx
@@ -43,6 +43,7 @@ import { PromptComposer } from "./components/prompt-composer";
 import { VITE_DEV_OPENROUTER_API_KEY } from "@/env-variables";
 import { useKeyValue } from "@/hooks/key-value/use-key-value";
 import { WelcomeScreen } from "./components/welcome-screen";
+import { AgentEmptyState } from "./components/agent-empty-state";
 import {
 	AGENT_VIEW_KIND,
 	DIFF_VIEW_KIND,
@@ -772,27 +773,33 @@ export function AgentView({ context, instance }: AgentViewProps) {
 				<div className="w-full max-w-3xl mx-auto flex flex-col gap-4">
 					{hasKey ? (
 						<>
-							{messages?.map((message) => (
-								<ConversationMessage key={message.id} message={message} />
-							))}
-							{pendingMessage && !isMessageEmpty(pendingMessage) ? (
-								<ConversationMessage
-									key={pendingMessage.id || "agent-pending"}
-									message={pendingMessage}
-								/>
-							) : pending ? (
-								<div className="px-3 py-1 text-xs text-muted-foreground">
-									Thinking…
-								</div>
-							) : null}
-							{notice ? (
-								<div className="px-3 py-1 text-xs text-muted-foreground">
-									{notice}
-								</div>
-							) : null}
-							{error ? (
-								<div className="px-3 py-1 text-xs text-rose-500">{error}</div>
-							) : null}
+							{(!messages || messages.length === 0) && !pending && !pendingMessage ? (
+								<AgentEmptyState />
+							) : (
+								<>
+									{messages?.map((message) => (
+										<ConversationMessage key={message.id} message={message} />
+									))}
+									{pendingMessage && !isMessageEmpty(pendingMessage) ? (
+										<ConversationMessage
+											key={pendingMessage.id || "agent-pending"}
+											message={pendingMessage}
+										/>
+									) : pending ? (
+										<div className="px-3 py-1 text-xs text-muted-foreground">
+											Thinking…
+										</div>
+									) : null}
+									{notice ? (
+										<div className="px-3 py-1 text-xs text-muted-foreground">
+											{notice}
+										</div>
+									) : null}
+									{error ? (
+										<div className="px-3 py-1 text-xs text-rose-500">{error}</div>
+									) : null}
+								</>
+							)}
 						</>
 					) : keyLoaded ? (
 						<WelcomeScreen


### PR DESCRIPTION
## Changes made

- Created AgentEmptyState for empty state (only imports and renders when messages are empty)

## Screenshots

<img width="503" height="388" alt="Screenshot 2025-11-29 at 19 40 29" src="https://github.com/user-attachments/assets/353a9e6b-c8ec-4b39-83a8-cbdbfeda71d5" />
