### PR TITLE
566 adds emitTsDeclarations setting and error documentation

### DIFF
--- a/inlang/packages/paraglide/paraglide-js/docs/errors.md
+++ b/inlang/packages/paraglide/paraglide-js/docs/errors.md
@@ -98,3 +98,17 @@ setLocale("de");
   reload={true}
 >Deutsch</a>
 ```
+
+## TS does not autocomplete messages and shows errors 
+
+> Property 'some_message_key' does not exist on type 'typeof import("/path/to/your/repo/src/lib/paraglide/messages/_index")'
+
+TS does not pick up the new message keys, after the TS language server started. Try using the `emitTsDeclarations` flag, to emit a `messages.d.ts` declaration file for your Typescript intellisense to grab. It will update on each paraglide compilation.
+
+```diff
+// project.inlang/settings.json
+{
+  // ...
++  "emitTsDeclarations": true
+}
+```

--- a/inlang/packages/paraglide/paraglide-js/src/compiler/compile-project.ts
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/compile-project.ts
@@ -70,6 +70,14 @@ export const compileProject = async (args: {
 			"export * as m from './messages/_index.js'",
 		].join("\n"),
 	};
+	if (settings.emitTsDeclarations) {
+		const messageKeys = bundles.map((bundle) => `"${bundle.id}"`);
+		output["messages.d.ts"] = [
+			"type MessageKeys = " + messageKeys.join(" | ") + ";",
+			"export const m: Record<MessageKeys, (...args: any[]) => string>;",
+			"export { " + messageKeys.join(", ") + " } from './messages/_index.js'",
+		].join("\n");
+	}
 
 	// generate the output modules
 	Object.assign(


### PR DESCRIPTION
Adds option to generate a `messages.d.ts` next to the compiled messages, so typescript can pick up changes to the json files. This is optional and must be activated in the settings, as documented in `errors.md`

The generated file looks like this:

```ts
// src/lib/paraglide/messages.d.ts
type MessageKeys = "example_message" | "hello_world" | "app_title" | "…";
export const m: Record<MessageKeys, (...args: any[]) => string>;
export { m };
export default m;
```

Things I watched out for:

- location agnostic. there is no hardcoded directory, so custom `outdir` should work
- import with or without file extension: It only works **without** file-extension. Example:
  - `import { m } from '$lib/paraglide/messages.js';` won't show an import error, but it also won't pick up changes
  - `import { m } from '$lib/paraglide/messages';` works as intendet. VS-Code also autocompletes to this
- testing during dev-server as described in the issue
- tested build step of my project (message-modules)

Have I missed something? 

closes https://github.com/opral/inlang-paraglide-js/issues/566 