### PR TITLE
Update Discord invite links

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ Welcome to Opral's repository.
 |------------------------|---------------|
 | [./careers](./careers) | Open positions @ Opral |
 | [./contributing](./CONTRIBUTING.md) | Contribute to inlang or lix |
-| [Official Discord](https://discord.gg/CNPfhWpcAa) | Join our official Discord |
+| [Official Discord](https://discord.gg/gdMPPWy57R) | Join our official Discord |
 | [Discussions](https://github.com/opral/monorepo/discussions) | Discuss new features |
 | [inlang.com](https://inlang.com/) | Search through the ecosystem |
 
 #### Support
 
-If you need support for inlang, one of inlang's products or lix, we encourage you to join our [Discord](https://discord.gg/CNPfhWpcAa) where we usually respond and help as soon as possible.
+If you need support for inlang, one of inlang's products or lix, we encourage you to join our [Discord](https://discord.gg/gdMPPWy57R) where we usually respond and help as soon as possible.
 
 Do you have a request that has to do with security, privacy-related, or other non-related issues? Find our [security policy here](https://github.com/opral/monorepo/security/policy) or contact us via e-mail: `hello@opral.com`.

--- a/inlang/packages/fink/docs/supported-i18n-libraries.md
+++ b/inlang/packages/fink/docs/supported-i18n-libraries.md
@@ -14,4 +14,4 @@ Here you can find a list of supported i18n libraries and their corresponding plu
 ## Is there no plugin for your library?
 
 - [Create a new plugin](/documentation/plugin/guide) for your library.
-- [Join our Discord](https://discord.gg/CNPfhWpcAa) and let us know which library you would like to see supported.
+- [Join our Discord](https://discord.gg/gdMPPWy57R) and let us know which library you would like to see supported.

--- a/inlang/packages/plugins/i18next/README.md
+++ b/inlang/packages/plugins/i18next/README.md
@@ -135,4 +135,4 @@ Read the [jsDelivr documentation](https://www.jsdelivr.com/?docs=gh) on importin
 
 ---
 
-_Is something unclear or do you have questions? Reach out to us in our [Discord channel](https://discord.gg/CNPfhWpcAa) or open a [Discussion](https://github.com/opral/monorepo/discussions) or an [Issue](https://github.com/opral/monorepo/issues) on [Github](https://github.com/opral/monorepo)._
+_Is something unclear or do you have questions? Reach out to us in our [Discord channel](https://discord.gg/gdMPPWy57R) or open a [Discussion](https://github.com/opral/monorepo/discussions) or an [Issue](https://github.com/opral/monorepo/issues) on [Github](https://github.com/opral/monorepo)._

--- a/inlang/packages/plugins/json/README.md
+++ b/inlang/packages/plugins/json/README.md
@@ -154,4 +154,4 @@ Read the [jsDelivr documentation](https://www.jsdelivr.com/?docs=gh) on importin
 
 ---
 
-_Is something unclear or do you have questions? Reach out to us in our [Discord channel](https://discord.gg/CNPfhWpcAa) or open a [Discussion](https://github.com/opral/monorepo/discussions) or an [Issue](https://github.com/opral/monorepo/issues) on [Github](https://github.com/opral/monorepo)._
+_Is something unclear or do you have questions? Reach out to us in our [Discord channel](https://discord.gg/gdMPPWy57R) or open a [Discussion](https://github.com/opral/monorepo/discussions) or an [Issue](https://github.com/opral/monorepo/issues) on [Github](https://github.com/opral/monorepo)._

--- a/inlang/packages/plugins/next-intl/README.md
+++ b/inlang/packages/plugins/next-intl/README.md
@@ -125,4 +125,4 @@ Read the [jsDelivr documentation](https://www.jsdelivr.com/?docs=gh) on importin
 
 ---
 
-_Is something unclear or do you have questions? Reach out to us in our [Discord channel](https://discord.gg/CNPfhWpcAa) or open a [Discussion](https://github.com/opral/monorepo/discussions) or an [Issue](https://github.com/opral/monorepo/issues) on [Github](https://github.com/opral/monorepo)._
+_Is something unclear or do you have questions? Reach out to us in our [Discord channel](https://discord.gg/gdMPPWy57R) or open a [Discussion](https://github.com/opral/monorepo/discussions) or an [Issue](https://github.com/opral/monorepo/issues) on [Github](https://github.com/opral/monorepo)._

--- a/inlang/packages/recommendations/recommend-sherlock/README.md
+++ b/inlang/packages/recommendations/recommend-sherlock/README.md
@@ -64,4 +64,4 @@ async function addSherlock(fs: NodeishFilesystem) {
 
 ## Contributing
 
-Contributions are welcome! If you have a feature request, bug report, or proposal, please open an issue or submit a pull request. Our Discord can be found [here](https://discord.gg/CNPfhWpcAa).
+Contributions are welcome! If you have a feature request, bug report, or proposal, please open an issue or submit a pull request. Our Discord can be found [here](https://discord.gg/gdMPPWy57R).

--- a/inlang/packages/sdk/README.md
+++ b/inlang/packages/sdk/README.md
@@ -1,6 +1,6 @@
 # Inlang file format SDK
 
-[![NPM Downloads](https://img.shields.io/npm/dw/%40inlang%2Fsdk?logo=npm&logoColor=red&label=npm%20downloads)](https://www.npmjs.com/package/@inlang/sdk) [![Discord](https://img.shields.io/discord/897438559458430986?style=flat&logo=discord&labelColor=white)](https://discord.gg/ecsc6bFtZw)
+[![NPM Downloads](https://img.shields.io/npm/dw/%40inlang%2Fsdk?logo=npm&logoColor=red&label=npm%20downloads)](https://www.npmjs.com/package/@inlang/sdk) [![Discord](https://img.shields.io/discord/897438559458430986?style=flat&logo=discord&labelColor=white)](https://discord.gg/gdMPPWy57R)
 
 
 <p align="center">

--- a/inlang/packages/sherlock/MARKETPLACE.md
+++ b/inlang/packages/sherlock/MARKETPLACE.md
@@ -58,7 +58,7 @@ You can have multiple projects in your repository. By using the Sherlock tab, it
 
 ## Support: Join our Discord!
 
-If something isn't working as expected or you have a feature suggestion, please join our [Discord](https://discord.gg/CNPfhWpcAa) or [create an issue](<[https](https://github.com/opral/monorepo/issues/new/choose)>). We are happy to help!
+If something isn't working as expected or you have a feature suggestion, please join our [Discord](https://discord.gg/gdMPPWy57R) or [create an issue](<[https](https://github.com/opral/monorepo/issues/new/choose)>). We are happy to help!
 
 ## Requirements:
 

--- a/inlang/packages/sherlock/README.md
+++ b/inlang/packages/sherlock/README.md
@@ -251,7 +251,7 @@ If you are having trouble with the **loading icon** not disappearing, this is a 
 
 ## Support: Join our Discord / Open an issue on GitHub!
 
-If something isn't working as expected or you have a feature suggestion, please join our [Discord](https://discord.gg/CNPfhWpcAa) or [create an issue](<[https](https://github.com/opral/monorepo/issues/new/choose)>). We are happy to help!
+If something isn't working as expected or you have a feature suggestion, please join our [Discord](https://discord.gg/gdMPPWy57R) or [create an issue](<[https](https://github.com/opral/monorepo/issues/new/choose)>). We are happy to help!
 
 <style>
 .flex-container {

--- a/inlang/packages/sherlock/docs/quick-start.md
+++ b/inlang/packages/sherlock/docs/quick-start.md
@@ -51,4 +51,4 @@ Just _highlight/select_ the text you want and hit `cmd .` or `ctrl +` (Quick Fix
 
 Hover over the message to see the tooltip with the translation.
 
-If something isn't working as expected, please join our [Discord](https://discord.gg/CNPfhWpcAa) or [create an issue](https://github.com/opral/monorepo/issues/new/choose). We are happy to help!
+If something isn't working as expected, please join our [Discord](https://discord.gg/gdMPPWy57R) or [create an issue](https://github.com/opral/monorepo/issues/new/choose). We are happy to help!

--- a/inlang/packages/sherlock/docs/supported-i18n-libraries.md
+++ b/inlang/packages/sherlock/docs/supported-i18n-libraries.md
@@ -18,4 +18,4 @@ Note: The plugins are not limited to the libraries mentioned above. If you have 
 ## Is there no plugin for your library?
 
 - [Create a new plugin](/documentation/plugin/guide) for your library.
-- [Join our Discord](https://discord.gg/CNPfhWpcAa) and let us know which library you would like to see supported.
+- [Join our Discord](https://discord.gg/gdMPPWy57R) and let us know which library you would like to see supported.

--- a/inlang/packages/website/src/pages/index/custom_section/HeroSearch.tsx
+++ b/inlang/packages/website/src/pages/index/custom_section/HeroSearch.tsx
@@ -45,7 +45,7 @@ const HeroSearch = () => {
 					<a href="https://www.npmjs.com/package/@inlang/sdk" target="_blank">
 						<img src="https://img.shields.io/npm/dw/%40inlang%2Fsdk?logo=npm&logoColor=red&labelColor=white&color=gray&label=npm%20downloads"></img>
 					</a>
-					<a href="https://discord.gg/ecsc6bFtZw" target="_blank">
+					<a href="https://discord.gg/gdMPPWy57R" target="_blank">
 						<img src="https://img.shields.io/discord/897438559458430986?style=flat&logo=discord&color=gray&labelColor=white"></img>
 					</a>
 				</div>

--- a/packages/flashtype/src/app/landing-screen.tsx
+++ b/packages/flashtype/src/app/landing-screen.tsx
@@ -506,7 +506,7 @@ function LandingScreenContent({
 					</a>
 					<span aria-hidden="true">·</span>
 					<a
-						href="https://discord.gg/StVekJpyBp"
+						href="https://discord.gg/gdMPPWy57R"
 						target="_blank"
 						rel="noreferrer"
 						className="inline-flex items-center gap-1.5 transition hover:text-neutral-600"

--- a/packages/flashtype/src/app/top-bar/index.tsx
+++ b/packages/flashtype/src/app/top-bar/index.tsx
@@ -147,7 +147,7 @@ export function TopBar({
 									<span aria-hidden>·</span>
 									<a
 										className="text-primary underline-offset-4 hover:underline"
-										href="https://discord.gg/StVekJpyBp"
+										href="https://discord.gg/gdMPPWy57R"
 										target="_blank"
 										rel="noreferrer"
 									>
@@ -193,7 +193,7 @@ export function TopBar({
 					asChild
 				>
 					<a
-						href="https://discord.gg/StVekJpyBp"
+						href="https://discord.gg/gdMPPWy57R"
 						target="_blank"
 						rel="noreferrer"
 						title="Discord"

--- a/packages/flashtype/src/app/welcome-screen.tsx
+++ b/packages/flashtype/src/app/welcome-screen.tsx
@@ -185,7 +185,7 @@ export function WelcomeScreen({
 					</a>
 					<span aria-hidden="true">·</span>
 					<a
-						href="https://discord.gg/StVekJpyBp"
+						href="https://discord.gg/gdMPPWy57R"
 						target="_blank"
 						rel="noreferrer"
 						className="inline-flex items-center gap-1.5 transition hover:text-neutral-600"

--- a/packages/flashtype/src/seed/welcome.md
+++ b/packages/flashtype/src/seed/welcome.md
@@ -11,12 +11,12 @@ Welcome to Opral's repository.
 | ------------------------------------------------------------ | ---------------------------- |
 | [./careers](./careers)                                       | Open positions @ Opral       |
 | [./contributing](./CONTRIBUTING.md)                          | Contribute to inlang or lix  |
-| [Official Discord](https://discord.gg/CNPfhWpcAa)            | Join our official Discord    |
+| [Official Discord](https://discord.gg/gdMPPWy57R)            | Join our official Discord    |
 | [Discussions](https://github.com/opral/monorepo/discussions) | Discuss new features         |
 | [inlang.com](https://inlang.com/)                            | Search through the ecosystem |
 
 #### Support
 
-If you need support for inlang, one of inlang's products or lix, we encourage you to join our [Discord](https://discord.gg/CNPfhWpcAa) where we usually respond and help as soon as possible.
+If you need support for inlang, one of inlang's products or lix, we encourage you to join our [Discord](https://discord.gg/gdMPPWy57R) where we usually respond and help as soon as possible.
 
 Do you have a request that has to do with security, privacy-related, or other non-related issues? Find our [security policy here](https://github.com/opral/monorepo/security/policy) or contact us via e-mail: `hello@opral.com`.

--- a/packages/lix/docs/rspress.config.ts
+++ b/packages/lix/docs/rspress.config.ts
@@ -168,7 +168,7 @@ export default defineConfig({
       {
         icon: "discord",
         mode: "link",
-        content: "https://discord.gg/xjQA897RyK",
+        content: "https://discord.gg/gdMPPWy57R",
       },
     ],
     footer: {

--- a/packages/lix/docs/src/docs/components/landing-page.tsx
+++ b/packages/lix/docs/src/docs/components/landing-page.tsx
@@ -1520,7 +1520,7 @@ function LandingPage() {
               Go to Docs
             </a>
             <a
-              href="https://discord.gg/GhjdFXsEgM"
+              href="https://discord.gg/gdMPPWy57R"
               className="inline-flex items-center justify-center gap-2 text-base font-medium text-gray-700 transition-colors hover:text-[#0692B6]"
             >
               <span aria-hidden>💬</span>

--- a/packages/lix/file-manager/src/layouts/AppLayout.tsx
+++ b/packages/lix/file-manager/src/layouts/AppLayout.tsx
@@ -51,7 +51,7 @@ function Banner() {
 				</a>{" "}
 				and join{" "}
 				<a
-					href="https://discord.gg/xjQA897RyK"
+					href="https://discord.gg/gdMPPWy57R"
 					target="__blank"
 					className="underline"
 				>


### PR DESCRIPTION
## Summary
- replace all Discord invite URLs across documentation and UI surfaces with the new invite link

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69335845c22883269604868c73a3ac9d)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces all Discord invite URLs across docs and UI with https://discord.gg/gdMPPWy57R.
> 
> - **Docs**:
>   - Update Discord links in `README.md`, `inlang/packages/*/README.md`, `inlang/packages/fink/docs/*`, `inlang/packages/sherlock/*`, and `packages/flashtype/src/seed/welcome.md` to the new invite URL.
> - **Web/UI**:
>   - Replace Discord links in `inlang/packages/website/.../HeroSearch.tsx`, `packages/flashtype/src/app/{landing-screen,top-bar,welcome-screen}.tsx`, `packages/lix/docs/rspress.config.ts`, `packages/lix/docs/src/docs/components/landing-page.tsx`, and `packages/lix/file-manager/src/layouts/AppLayout.tsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ec81f23bfc004d4f890374f867922390c45190b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->