### PR TITLE
Add TanStack Router examples to Paraglide docs

### DIFF
--- a/inlang/packages/paraglide/paraglide-js/docs/introduction.md
+++ b/inlang/packages/paraglide/paraglide-js/docs/introduction.md
@@ -42,6 +42,8 @@ If you use a bundler like [Vite](/m/gerre34r/library-inlang-paraglideJs/vite) in
 <doc-links>
   <doc-link title="Vanilla JS/TS" icon="devicon:javascript" href="/m/gerre34r/library-inlang-paraglideJs/vanilla-js-ts" description="Open example"></doc-link>
   <doc-link title="React" icon="devicon:react" href="/m/gerre34r/library-inlang-paraglideJs/vite" description="Open example"></doc-link>
+  <doc-link title="TanStack Router" icon="simple-icons:tanstack" href="https://github.com/TanStack/router/tree/main/examples/react/i18n-paraglide" description="Open example"></doc-link>
+  <doc-link title="TanStack Start" icon="simple-icons:tanstack" href="https://github.com/TanStack/router/tree/main/examples/react/start-i18n-paraglide" description="Open example"></doc-link>
   <doc-link title="Vue" icon="devicon:vuejs" href="/m/gerre34r/library-inlang-paraglideJs/vite" description="Open example"></doc-link>
   <doc-link title="SvelteKit" icon="devicon:svelte" href="/m/gerre34r/library-inlang-paraglideJs/sveltekit" description="Open example"></doc-link>
   <doc-link title="NextJS" icon="devicon:nextjs" href="/m/gerre34r/library-inlang-paraglideJs/next-js" description="Open example"></doc-link>


### PR DESCRIPTION
## Summary
- add TanStack Router and TanStack Start example links to the Paraglide JS framework list
- point the new entries to the official TanStack example repositories

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69387cb10e5c83268b6c6e302f39ec90)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds TanStack Router and TanStack Start example links to the Paraglide JS framework list, pointing to official examples.
> 
> - **Docs**:
>   - Update `inlang/packages/paraglide/paraglide-js/docs/introduction.md`:
>     - Add `doc-link` entries for `TanStack Router` and `TanStack Start` linking to official example repositories.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e236689a6c462bef1ba34a8167786acc04aedcf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->