### PR TITLE
Refactor project command actions to handle exit codes and ensure project file queue is settled on completion

### DIFF
--- a/.changeset/olive-hounds-collect.md
+++ b/.changeset/olive-hounds-collect.md
@@ -1,0 +1,8 @@
+---
+"@inlang/sdk": patch
+"@inlang/cli": patch
+---
+
+Await the Lix file queue before closing or exiting to avoid "DB has been closed" errors in CLI workflows.
+
+Refs: https://github.com/opral/paraglide-js/issues/526

--- a/packages/cli/src/commands/machine/translate.ts
+++ b/packages/cli/src/commands/machine/translate.ts
@@ -1,7 +1,10 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { Command } from "commander";
 import { rpc } from "@inlang/rpc";
-import { getInlangProject } from "../../utilities/getInlangProject.js";
+import {
+  getInlangProject,
+  settleLastUsedProjectFileQueue,
+} from "../../utilities/getInlangProject.js";
 import { log, logError } from "../../utilities/log.js";
 import {
   saveProjectToDirectory,
@@ -29,14 +32,17 @@ export const translate = new Command()
   .option("-n, --nobar", "disable progress bar", false)
   .description("Machine translate bundles.")
   .action(async (args: { force: boolean; project: string }) => {
+    let exitCode = 0;
     try {
       const project = await getInlangProject({ projectPath: args.project });
       await translateCommandAction({ project });
       await saveProjectToDirectory({ fs, path: args.project, project });
-      process.exit(0);
     } catch (error) {
       logError(error);
-      process.exit(1);
+      exitCode = 1;
+    } finally {
+      await settleLastUsedProjectFileQueue();
+      process.exit(exitCode);
     }
   });
 

--- a/packages/cli/src/commands/validate/index.ts
+++ b/packages/cli/src/commands/validate/index.ts
@@ -1,5 +1,8 @@
 import { Command } from "commander";
-import { getInlangProject } from "../../utilities/getInlangProject.js";
+import {
+  getInlangProject,
+  settleLastUsedProjectFileQueue,
+} from "../../utilities/getInlangProject.js";
 import { log } from "../../utilities/log.js";
 import { projectOption } from "../../utilities/globalFlags.js";
 
@@ -10,6 +13,7 @@ export const validate = new Command()
   .action(validateCommandAction);
 
 export async function validateCommandAction(args: { project: string }) {
+  let exitCode = 0;
   try {
     log.info("🔎 Validating the inlang project...");
     // if `getInlangProject` doesn't throw, the project is valid
@@ -19,13 +23,16 @@ export async function validateCommandAction(args: { project: string }) {
     if (errors.length > 0) {
       log.info("The project contains errors:");
       for (const error of errors) log.error(error);
-      process.exit(1);
+      exitCode = 1;
+      return;
     }
 
     log.success("The project is valid!");
-    process.exit(0);
   } catch (error) {
     log.error(error);
-    process.exit(1);
+    exitCode = 1;
+  } finally {
+    await settleLastUsedProjectFileQueue();
+    process.exit(exitCode);
   }
 }

--- a/packages/cli/src/utilities/getInlangProject.ts
+++ b/packages/cli/src/utilities/getInlangProject.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import { loadProjectFromDirectory, type InlangProject } from "@inlang/sdk";
+import { fileQueueSettled } from "@inlang/sdk/lix";
 import { resolve } from "node:path";
 
 /**
@@ -28,5 +29,16 @@ export async function getInlangProject(args: {
   } catch (err) {
     console.error(`Error opening inlang project at ${args.projectPath}`, err);
     process.exit(1);
+  }
+}
+
+export async function settleLastUsedProjectFileQueue(): Promise<void> {
+  if (!lastUsedProject) {
+    return;
+  }
+  try {
+    await fileQueueSettled({ lix: lastUsedProject.lix });
+  } catch {
+    // Best-effort: ignore queue settle failures during shutdown.
   }
 }

--- a/packages/sdk/src/project/loadProjectFromDirectory.ts
+++ b/packages/sdk/src/project/loadProjectFromDirectory.ts
@@ -1,6 +1,12 @@
 import { newProject } from "./newProject.js";
 import { loadProjectInMemory } from "./loadProjectInMemory.js";
-import { closeLix, openLixInMemory, toBlob, type Lix } from "@lix-js/sdk";
+import {
+	closeLix,
+	fileQueueSettled,
+	openLixInMemory,
+	toBlob,
+	type Lix,
+} from "@lix-js/sdk";
 import fs from "node:fs";
 import nodePath from "node:path";
 import type {
@@ -73,6 +79,7 @@ export async function loadProjectFromDirectory(
 		lix: tempLix,
 		syncInterval: undefined,
 	});
+	await fileQueueSettled({ lix: tempLix });
 
 	// TODO call tempProject.lix.settled() to wait for the new settings file, and remove reload of the proejct as soon as reactive settings has landed
 	// NOTE: we need to ensure two things:


### PR DESCRIPTION
Closes https://github.com/opral/paraglide-js/issues/526

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Addresses intermittent shutdown errors by ensuring Lix file operations complete before process exit.
> 
> - CLI: `translate` and `validate` now set an `exitCode`, `await settleLastUsedProjectFileQueue()`, then `process.exit(exitCode)`; removed direct exits in try/catch
> - Utility: added `settleLastUsedProjectFileQueue` in `getInlangProject.ts` using `fileQueueSettled` against `lastUsedProject.lix`
> - SDK: in `loadProjectFromDirectory`, call `fileQueueSettled` on the temporary Lix after initial FS→Lix sync; updated imports accordingly
> - Changeset: patch releases for `@inlang/sdk` and `@inlang/cli` with note linking related issue
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d73b9090b82d8c65f7c8f9054f79f31fd308554. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->