### PR TITLE
Fix ICU MessageFormat v1 plugin date

### DIFF
--- a/blog/table_of_contents.json
+++ b/blog/table_of_contents.json
@@ -2,7 +2,7 @@
   {
     "path": "./icu-messageformat-v1-plugin/index.md",
     "slug": "icu-messageformat-v1-plugin",
-    "date": "2026-02-09",
+    "date": "2026-01-13",
     "authors": ["samuelstroschein"]
   },
   {


### PR DESCRIPTION
### Motivation
- Correct the publication date for the ICU MessageFormat v1 plugin in the blog table of contents so it matches the intended date `2026-01-13`.

### Description
- Update `blog/table_of_contents.json` by changing the `icu-messageformat-v1-plugin` entry `date` from `2026-02-09` to `2026-01-13`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696824cffbfc8326b157bfa8d06a0e14)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates blog metadata to reflect the intended publication date.
> 
> - Changes `date` for `icu-messageformat-v1-plugin` in `blog/table_of_contents.json` from `2026-02-09` to `2026-01-13`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 201efa8742041bf3c9d23a9d375032368d983d8a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->