### PR TITLE
Update lix and GitHub links across repo

### DIFF
--- a/.changeset/update-sdk-links.md
+++ b/.changeset/update-sdk-links.md
@@ -1,0 +1,5 @@
+---
+"@inlang/sdk": patch
+---
+
+Update documentation links to the latest lix.dev and GitHub repository locations.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
-  <a href="https://github.com/opral/monorepo">  </a>
+  <a href="https://github.com/opral/inlang">  </a>
 
-  <img src="https://github.com/opral/monorepo/blob/main/inlang/assets/logo_rounded.png?raw=true" alt="inlang icon" width="90px">
+  <img src="https://github.com/opral/inlang/blob/main/inlang/assets/logo_rounded.png?raw=true" alt="inlang icon" width="90px">
   
   <h2 align="center">
     The open file format and ecosystem for localization (i18n)
@@ -89,6 +89,6 @@ There are many ways you can contribute to inlang! Here are a few options:
 - Create issues every time you feel something is missing or goes wrong
 - Upvote issues with 👍 reaction so we know what the demand for a particular issue to prioritize it within the roadmap
 
-If you would like to contribute to the development of the project, please refer to our [Contributing guide](https://github.com/opral/monorepo/blob/main/CONTRIBUTING.md).
+If you would like to contribute to the development of the project, please refer to our [Contributing guide](https://github.com/opral/inlang/blob/main/CONTRIBUTING.md).
 
 All contributions are highly appreciated. 🙏

--- a/blog/update-on-inlang-v2/index.md
+++ b/blog/update-on-inlang-v2/index.md
@@ -5,7 +5,7 @@ og:description: "Accelerating both inlang and lix by prioritizing lix."
 
 Dear inlang community, 
 
-The release of the inlang SDK v2 (variant support) is blocked until we have a 1.0 release of the lix version control system. We are prioritizing [lix](https://lix.opral.com/) so we can unblock v2. Which means:
+The release of the inlang SDK v2 (variant support) is blocked until we have a 1.0 release of the lix version control system. We are prioritizing [lix](https://lix.dev/) so we can unblock v2. Which means:
 
 - The release of the inlang SDK v2 is likely postponed until Jan/Feb next year.
 
@@ -33,7 +33,7 @@ You can try out a CSV file demo of lix [here](https://csv.lix.opral.com/).
 
 What makes globalization of software complicated is the required coordination effort. Designers need to know that translators updated translations to adjust their UIs, developers need to redeploy the app if translations change, auditors need to know that a message has changed, … the list goes on. 
 
-It was clear in March 2022 [[RFC 01](https://github.com/opral/monorepo/blob/c3ea483c6b6de65f8f05b211e06cbd53f73054b1/inlang/blog/notes-on-git-based-architecture.md)] that solving globalization of software requires version control to coordinate changes between teams. It was also clear that [git is unsuited for applications](https://github.com/opral/monorepo/blob/c3ea483c6b6de65f8f05b211e06cbd53f73054b1/inlang/blog/git-as-sdk.md#but-git-as-back-end-is-not-perfect), and we would have to develop lix.
+It was clear in March 2022 [[RFC 01](https://github.com/opral/inlang/blob/c3ea483c6b6de65f8f05b211e06cbd53f73054b1/inlang/blog/notes-on-git-based-architecture.md)] that solving globalization of software requires version control to coordinate changes between teams. It was also clear that [git is unsuited for applications](https://github.com/opral/inlang/blob/c3ea483c6b6de65f8f05b211e06cbd53f73054b1/inlang/blog/git-as-sdk.md#but-git-as-back-end-is-not-perfect), and we would have to develop lix.
 
 ![Coordination and automation diagram](./assets/coordination-automation.png)
 
@@ -41,11 +41,11 @@ Version control is required to reduce the coordination effort and automate globa
 
 ## Git slowed lix and inlang down
 
-We [initially built lix on top of Git](https://github.com/opral/monorepo/blob/c3ea483c6b6de65f8f05b211e06cbd53f73054b1/inlang/blog/notes-on-git-based-architecture.md), thinking that we ease adoption and benefit from Git’s decade-long development. That turned out to be false. We delayed building differentiating lix technologies. I gave a [presentation last week that delaying differentiating technology leads to a death trap for startups](https://samuelstroschein.substack.com/p/dont-delay-building-differentiating). A vicious cycle of building around git instead of building what differentiates lix occurred, consuming most engineering resources. Among the workarounds that we did because of git: 
+We [initially built lix on top of Git](https://github.com/opral/inlang/blob/c3ea483c6b6de65f8f05b211e06cbd53f73054b1/inlang/blog/notes-on-git-based-architecture.md), thinking that we ease adoption and benefit from Git’s decade-long development. That turned out to be false. We delayed building differentiating lix technologies. I gave a [presentation last week that delaying differentiating technology leads to a death trap for startups](https://samuelstroschein.substack.com/p/dont-delay-building-differentiating). A vicious cycle of building around git instead of building what differentiates lix occurred, consuming most engineering resources. Among the workarounds that we did because of git: 
 
-- we [needed to develop a git-compatible persistency layer](https://github.com/opral/monorepo/issues/1844) to deliver multi-variant support (gendering, pluralization, etc). It took more than 6 months and ended up getting canceled. 
+- we [needed to develop a git-compatible persistency layer](https://github.com/opral/inlang/issues/1844) to deliver multi-variant support (gendering, pluralization, etc). It took more than 6 months and ended up getting canceled. 
 
-- were [about to build a custom database](https://github.com/opral/monorepo/issues/1772) to sync git, filesystem, and app state
+- were [about to build a custom database](https://github.com/opral/inlang/issues/1772) to sync git, filesystem, and app state
 
 ![The git workaround trap](./assets/git-workaround-trap.png)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,7 +14,7 @@ Inlang's architecture has three layers: storage, data model, and plugins.
 
 ## Storage
 
-An `.inlang` file is a SQLite database with built-in version control via [Lix](https://lix.opral.com). One portable file containing all your translations, settings, and change history.
+An `.inlang` file is a SQLite database with built-in version control via [Lix](https://lix.dev). One portable file containing all your translations, settings, and change history.
 
 SQLite was chosen because:
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -71,5 +71,5 @@ To store an inlang project in git, you can use the **unpacked format** — a dir
 
 ## Credits
 
-Inlang builds on [Lix](https://lix.opral.com) for version control and [Kysely](https://kysely.dev) for the query API.
+Inlang builds on [Lix](https://lix.dev) for version control and [Kysely](https://kysely.dev) for the query API.
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -130,7 +130,7 @@ Fix @inlang/rpc is a bundled dependency that is not published on npm
 
   BREAKING:
 
-  - The `inlang lint` command has been removed. Please upvote https://github.com/opral/lix-sdk/issues/239 to re-introduce linting in a future release.
+  - The `inlang lint` command has been removed. Please upvote https://github.com/opral/lix/issues/239 to re-introduce linting in a future release.
 
   ```diff
   - inlang lint

--- a/packages/cli/src/commands/lint/index.ts
+++ b/packages/cli/src/commands/lint/index.ts
@@ -13,6 +13,6 @@ export async function lintCommandAction(args: { project: string }) {
     "Inlang lint rules have been removed for the CLI v3 after the major lix and inlang SDK update to be replaced by a new validation system that generalizes beyond inlang and to reduce the scope of the update."
   );
   log.info(
-    "Upvote https://github.com/opral/lix-sdk/issues/239 to re-introduce linting."
+    "Upvote https://github.com/opral/lix/issues/239 to re-introduce linting."
   );
 }

--- a/packages/fink/src/helper/utils.ts
+++ b/packages/fink/src/helper/utils.ts
@@ -37,7 +37,7 @@ export const handleMerge = async (
 			reader.onload = async () => {
 				const blob = new Blob([reader.result as ArrayBuffer]);
 				const incoming = await loadProjectInMemory({ blob });
-				// TODO remove workaround for https://github.com/opral/lix-sdk/issues/47
+				// TODO remove workaround for https://github.com/opral/lix/issues/47
 				const opfsRoot = await navigator.storage.getDirectory();
 				const fileHandle = await opfsRoot.getFileHandle(selectedProjectPath!, {
 					create: true,

--- a/packages/fink/src/state.ts
+++ b/packages/fink/src/state.ts
@@ -34,7 +34,7 @@ export const forceReloadProjectAtom = atom<ReturnType<typeof Date.now> | undefin
 
 export const projectAtom = atom(async (get) => {
 	// listen to forceReloadProjectAtom to reload the project
-	// workaround for https://github.com/opral/lix-sdk/issues/47
+	// workaround for https://github.com/opral/lix/issues/47
 	get(forceReloadProjectAtom);
 
 	if (safeProjectToOpfsInterval) {

--- a/packages/plugins/i18next/CHANGELOG.md
+++ b/packages/plugins/i18next/CHANGELOG.md
@@ -112,7 +112,7 @@
 
   ### Breaking changes
 
-  - Lint rules are now polyfilled (and therefore may work different), as we are currently reworking how lint rules are working with [Lix Validation Rules](https://lix.opral.com).
+  - Lint rules are now polyfilled (and therefore may work different), as we are currently reworking how lint rules are working with [Lix Validation Rules](https://lix.dev).
   - The `messageId` parameter in the `extractMessages` function has been renamed to `bundleId`. This change is due to the new API in Sherlock v2. If you are using the `extractMessages` function, please update the parameter name to `bundleId`.
 
 ## 5.0.10

--- a/packages/plugins/m-function-matcher/CHANGELOG.md
+++ b/packages/plugins/m-function-matcher/CHANGELOG.md
@@ -114,7 +114,7 @@
 
   ### Breaking changes
 
-  - Lint rules are now polyfilled (and therefore may work different), as we are currently reworking how lint rules are working with [Lix Validation Rules](https://lix.opral.com).
+  - Lint rules are now polyfilled (and therefore may work different), as we are currently reworking how lint rules are working with [Lix Validation Rules](https://lix.dev).
   - The `messageId` parameter in the `extractMessages` function has been renamed to `bundleId`. This change is due to the new API in Sherlock v2. If you are using the `extractMessages` function, please update the parameter name to `bundleId`.
 
 ## 1.0.11

--- a/packages/plugins/next-intl/CHANGELOG.md
+++ b/packages/plugins/next-intl/CHANGELOG.md
@@ -26,7 +26,7 @@
 
   ### Breaking changes
 
-  - Lint rules are now polyfilled (and therefore may work different), as we are currently reworking how lint rules are working with [Lix Validation Rules](https://lix.opral.com).
+  - Lint rules are now polyfilled (and therefore may work different), as we are currently reworking how lint rules are working with [Lix Validation Rules](https://lix.dev).
   - The `messageId` parameter in the `extractMessages` function has been renamed to `bundleId`. This change is due to the new API in Sherlock v2. If you are using the `extractMessages` function, please update the parameter name to `bundleId`.
 
 ## 1.4.0

--- a/packages/plugins/t-function-matcher/CHANGELOG.md
+++ b/packages/plugins/t-function-matcher/CHANGELOG.md
@@ -110,7 +110,7 @@
 
   ### Breaking changes
 
-  - Lint rules are now polyfilled (and therefore may work different), as we are currently reworking how lint rules are working with [Lix Validation Rules](https://lix.opral.com).
+  - Lint rules are now polyfilled (and therefore may work different), as we are currently reworking how lint rules are working with [Lix Validation Rules](https://lix.dev).
   - The `messageId` parameter in the `extractMessages` function has been renamed to `bundleId`. This change is due to the new API in Sherlock v2. If you are using the `extractMessages` function, please update the parameter name to `bundleId`.
 
 ## 1.0.10

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -151,7 +151,7 @@
 
 ### Minor Changes
 
-- c0b857a: stable lix ids when opening a project with `loadProjectFromDirectory()` https://github.com/opral/inlang-sdk/issues/228
+- c0b857a: stable lix ids when opening a project with `loadProjectFromDirectory()` https://github.com/opral/inlang/issues/228
 
 ### Patch Changes
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -27,7 +27,7 @@ The inlang SDK is the official specification and parser for `.inlang` files.
 - 🖊️ **CRUD API**: Query messages with SQL.
 - 🧩 **Plugin System**: Extend the capabilities with plugins.
 - 📦 **Import/Export**: Import and export messages in different file formats.
-- [<img src="https://raw.githubusercontent.com/opral/inlang/refs/heads/main/lix/assets/lix-icon.svg" width="20" height="12" alt="Lix Icon">**Change control**](https://lix.opral.com/): Collaboration, change proposals, reviews, and automation. 
+- [<img src="https://raw.githubusercontent.com/opral/inlang/refs/heads/main/lix/assets/lix-icon.svg" width="20" height="12" alt="Lix Icon">**Change control**](https://lix.dev/): Collaboration, change proposals, reviews, and automation. 
 
 
 
@@ -153,9 +153,9 @@ console.log(messages);
 ### Querying changes
 
 > [!NOTE]  
-> The inlang plugin for lix is work in progress. If you stumble on issues, please open an issue on the [GitHub](https://github.com/opral/inlang-sdk).
+> The inlang plugin for lix is work in progress. If you stumble on issues, please open an issue on the [GitHub](https://github.com/opral/inlang).
 
-The inlang file format uses lix for change control. The lix APIs are exposed via `project.lix.*`. Visit the [lix documentation](https://lix.opral.com/) for more information on how to query changes.
+The inlang file format uses lix for change control. The lix APIs are exposed via `project.lix.*`. Visit the [lix documentation](https://lix.dev/) for more information on how to query changes.
 
 ```typescript
 const changes = await project.lix.db
@@ -214,7 +214,7 @@ await project.settings.set(settings)
 >
 > Git can't handle binary files. **If you don't intend to store the inlang file in git, do not use unpacked inlang files.** 
 > 
-> Unpacked inlang files are not portable. They depent on plugins that and do not persist [lix change control](https://lix.opral.com/) data.
+> Unpacked inlang files are not portable. They depent on plugins that and do not persist [lix change control](https://lix.dev/) data.
 
 ```typescript
 import { 

--- a/packages/sdk/src/database/initDbAndSchema.test.ts
+++ b/packages/sdk/src/database/initDbAndSchema.test.ts
@@ -154,7 +154,7 @@ test("it should preserve json-like text in variant patterns", async () => {
 	]);
 });
 
-// https://github.com/opral/inlang-sdk/issues/209
+// https://github.com/opral/inlang/issues/209
 test.todo("it should enable foreign key constraints", async () => {
 	const sqlite = await createInMemoryDatabase({
 		readOnly: false,

--- a/packages/sdk/src/database/jsonbPlugin.ts
+++ b/packages/sdk/src/database/jsonbPlugin.ts
@@ -229,7 +229,7 @@ function maybeSerializeJson(value: any): any {
 	return value;
 }
 
-// The code here didn't work https://github.com/opral/inlang-sdk/issues/132#issuecomment-2339321910
+// The code here didn't work https://github.com/opral/inlang/issues/132#issuecomment-2339321910
 // but would be the "right" solution to avoid heuristics which column might or might not be a json column
 // // modifies the query in place for readability and performance
 // function mapQuery(

--- a/packages/sdk/src/database/schema.ts
+++ b/packages/sdk/src/database/schema.ts
@@ -77,7 +77,7 @@ type VariantTable = {
 /**
  * A match is a variable reference that is either a literal or a catch-all.
  *
- * https://github.com/opral/inlang-sdk/issues/205
+ * https://github.com/opral/inlang/issues/205
  *
  * @example
  *   match = { type: "match", name: "gender", value: { type: "literal", value: "male"  }}

--- a/packages/sdk/src/lix-plugin/applyChanges.ts
+++ b/packages/sdk/src/lix-plugin/applyChanges.ts
@@ -124,7 +124,7 @@ async function handleForeignKeyViolation(args: {
 			// TODO shouldn't throw. The API needs to be able to
 			// report issues back to the app without throwing and potentially failing
 			// to apply 1000 changes because 1 change is invalid
-			// same requirement as in inlang, see https://github.com/opral/inlang-sdk/issues/213
+			// same requirement as in inlang, see https://github.com/opral/inlang/issues/213
 			.executeTakeFirstOrThrow();
 
 	if (args.change.type === "message") {

--- a/packages/sdk/src/lix-plugin/inlangLixPluginV1.test.ts
+++ b/packages/sdk/src/lix-plugin/inlangLixPluginV1.test.ts
@@ -347,7 +347,7 @@ describe.skip("plugin.diff.file", () => {
 		]);
 	});
 
-	// https://github.com/opral/lix-sdk/issues/33
+	// https://github.com/opral/lix/issues/33
 	test("it should generate changes after the first change", async () => {
 		const project = await loadProjectInMemory({ blob: await newProject() });
 

--- a/packages/sdk/src/plugin/schema.ts
+++ b/packages/sdk/src/plugin/schema.ts
@@ -43,7 +43,7 @@ export type InlangPlugin<
 	 *
 	 * - `metadata` is optional and can be used to store additional information
 	 *   that is accessible in `importFiles` via `toBeImportedMetadata`. See
-	 *   https://github.com/opral/inlang-sdk/issues/218 for more info.
+	 *   https://github.com/opral/inlang/issues/218 for more info.
 	 *
 	 */
 	toBeImportedFiles?: (args: {
@@ -87,7 +87,7 @@ export type InlangPlugin<
 /**
  * Exposing only a subset to ease mapping of fs functions.
  *
- * https://github.com/opral/inlang-sdk/issues/136
+ * https://github.com/opral/inlang/issues/136
  */
 export type NodeFsPromisesSubsetLegacy = {
 	readFile:

--- a/packages/sdk/src/project/api.ts
+++ b/packages/sdk/src/project/api.ts
@@ -52,7 +52,7 @@ export type ImportFile = {
 	 * The metadata of the file to be imported.
 	 *
 	 * Used to store additional information that is accessible in `importFiles` via `toBeImportedFilesMetadata`.
-	 * https://github.com/opral/inlang-sdk/issues/218
+	 * https://github.com/opral/inlang/issues/218
 	 */
 	toBeImportedFilesMetadata?: Record<string, any>;
 };

--- a/packages/sdk/src/project/loadProjectFromDirectory.test.ts
+++ b/packages/sdk/src/project/loadProjectFromDirectory.test.ts
@@ -885,7 +885,7 @@ test("it should provide plugins from disk for backwards compatibility but warn t
 	expect(settings.modules?.[0]).toBe("../local-plugins/mock-plugin.js");
 });
 
-// https://github.com/opral/inlang-sdk/issues/174
+// https://github.com/opral/inlang/issues/174
 test("plugin calls that use fs should be intercepted to use an absolute path", async () => {
 	process.cwd = () => "/";
 
@@ -1102,7 +1102,7 @@ test("providing multiple plugins that have legacy loadMessages and saveMessages 
 	expect(mockPlugin2.loadMessages).not.toHaveBeenCalled();
 });
 
-// https://github.com/opral/inlang-sdk/issues/228
+// https://github.com/opral/inlang/issues/228
 // Skipped: project ids are intentionally unstable for unpacked projects for now.
 test.skip("the lix id should be stable between loadings of the same project", async () => {
 	const mockRepo = {

--- a/packages/sdk/src/project/loadProjectFromDirectory.ts
+++ b/packages/sdk/src/project/loadProjectFromDirectory.ts
@@ -160,7 +160,7 @@ export async function loadProjectFromDirectory(
 						toBeImportedFilesMetadata: toBeImported.metadata,
 					});
 				} catch (e) {
-					// https://github.com/opral/inlang-sdk/issues/202
+					// https://github.com/opral/inlang/issues/202
 					if ((e as any)?.code === "ENOENT") {
 						continue;
 					}
@@ -648,7 +648,7 @@ async function upsertFileInLix(
 	data: ArrayBuffer
 ) {
 	// force posix path when upserting into lix
-	// https://github.com/opral/inlang-sdk/issues/229
+	// https://github.com/opral/inlang/issues/229
 	let posixPath = path.split(nodePath.win32.sep).join(nodePath.posix.sep);
 
 	if (posixPath.startsWith("/") === false) {
@@ -693,7 +693,7 @@ function categorizePlugins(plugins: readonly InlangPlugin[]) {
 /**
  * Imports local plugins for backwards compatibility.
  *
- * https://github.com/opral/inlang-sdk/issues/171
+ * https://github.com/opral/inlang/issues/171
  */
 async function importLocalPlugins(args: {
 	fs: typeof fs;

--- a/packages/website-v2/src/components/Footer.tsx
+++ b/packages/website-v2/src/components/Footer.tsx
@@ -64,7 +64,7 @@ const categoriesLinks = [
   { name: "Plugins", href: "/c/plugins" },
   {
     name: "Validation Rules",
-    href: "https://github.com/opral/lix-sdk/issues/239",
+    href: "https://github.com/opral/lix/issues/239",
   },
 ];
 

--- a/packages/website-v2/src/components/Header.tsx
+++ b/packages/website-v2/src/components/Header.tsx
@@ -42,7 +42,7 @@ const ecosystemLinks = [
   },
   {
     label: "Validation Rules",
-    to: "https://github.com/opral/lix-sdk/issues/239",
+    to: "https://github.com/opral/lix/issues/239",
     external: true,
     icon: (
       <span

--- a/packages/website-v2/src/marketplace/MarketplacePage.tsx
+++ b/packages/website-v2/src/marketplace/MarketplacePage.tsx
@@ -1014,7 +1014,7 @@ function getGithubLink(
   }
 
   if (!link) return undefined;
-  return `https://github.com/opral/monorepo/blob/main/${link.replace(
+  return `https://github.com/opral/inlang/blob/main/${link.replace(
     "./",
     "",
   )}`;

--- a/packages/website-v2/src/routes/docs/$slug.tsx
+++ b/packages/website-v2/src/routes/docs/$slug.tsx
@@ -683,7 +683,7 @@ function scrollToAnchor(anchor: string) {
 
 function getDocsGithubLink(relativePath: string) {
   const sanitized = relativePath.replace(/^[./]+/, "");
-  return `https://github.com/opral/monorepo/blob/main/docs/${sanitized}`;
+  return `https://github.com/opral/inlang/blob/main/docs/${sanitized}`;
 }
 
 function getDocsJson(filename: string): Promise<string> {


### PR DESCRIPTION
### Motivation

- Migrate legacy Lix documentation links from `https://lix.opral.com` to `https://lix.dev` and update deprecated GitHub references to the new repository locations to keep docs and code comments accurate.
- Ensure the SDK package has a recorded changeset that documents the link updates for releases.

### Description

- Replaced `https://lix.opral.com` with `https://lix.dev` and updated GitHub references from `github.com/opral/inlang-sdk`, `github.com/opral/monorepo`, and `github.com/opral/lix-sdk` to `github.com/opral/inlang` and `github.com/opral/lix` across docs, changelogs, tests, comments, and website components.
- Updated occurrences in documentation files (`README.md`, `docs/*`, `blog/*`), package READMEs, CHANGELOGs, SDK source files and tests, and website components under `packages/website-v2`.
- Added a patch changeset at `.changeset/update-sdk-links.md` targeting `@inlang/sdk` with a short note that documentation links were updated.
- Committed the changes (28 files changed and the new changeset file added).

### Testing

- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696828d5850c83269ddc41b534440353)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates stale documentation and repository references across docs, changelogs, source comments/tests, and website components.
> 
> - Replace `https://lix.opral.com` with `https://lix.dev` and GitHub paths from `opral/monorepo`, `opral/inlang-sdk`, and `opral/lix-sdk` to `opral/inlang` and `opral/lix`
> - Adjust links in `README.md`, `docs/*`, `blog/*`, package `CHANGELOG.md`s, SDK source comments/tests, CLI output, and website components (`packages/website-v2/*`)
> - Add `.changeset/update-sdk-links.md` declaring a patch for `@inlang/sdk` noting link updates
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6708ee51ea0b81ead206ca5e615b9765478002b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->