### PR TITLE
fix(sdk): remove blocking `fileQueueSettled` wait from `loadProjectFromDirectory`

### DIFF
--- a/.changeset/bright-socks-explain.md
+++ b/.changeset/bright-socks-explain.md
@@ -1,0 +1,5 @@
+---
+"@inlang/sdk": patch
+---
+
+Remove the `fileQueueSettled` wait after the initial filesystem sync in `loadProjectFromDirectory` to avoid hangs when file operations never settle.

--- a/packages/sdk/src/project/loadProjectFromDirectory.ts
+++ b/packages/sdk/src/project/loadProjectFromDirectory.ts
@@ -2,7 +2,6 @@ import { newProject } from "./newProject.js";
 import { loadProjectInMemory } from "./loadProjectInMemory.js";
 import {
 	closeLix,
-	fileQueueSettled,
 	openLixInMemory,
 	toBlob,
 	type Lix,
@@ -98,7 +97,6 @@ export async function loadProjectFromDirectory(
 		lix: tempLix,
 		syncInterval: undefined,
 	});
-	await fileQueueSettled({ lix: tempLix });
 
 	// TODO call tempProject.lix.settled() to wait for the new settings file, and remove reload of the proejct as soon as reactive settings has landed
 	// NOTE: we need to ensure two things:


### PR DESCRIPTION
### Motivation
- Prevent `loadProjectFromDirectory` from hanging indefinitely because the `await fileQueueSettled` after the initial filesystem sync could wait for file operations that never settled. 

### Description
- Remove the `fileQueueSettled` import and the `await fileQueueSettled({ lix: tempLix })` call from `packages/sdk/src/project/loadProjectFromDirectory.ts` and add a `.changeset` entry describing the change. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ec27a283c8326b44bc69706b3ba1f)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Avoids potential hangs during project load by eliminating an unnecessary post-sync wait.
> 
> - Removes `fileQueueSettled` import and `await fileQueueSettled({ lix: tempLix })` in `loadProjectFromDirectory`
> - Adds `.changeset` entry for `@inlang/sdk` patch release
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9553df68cbcc93750840c73990ec0c26fdad23cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->