### PR TITLE
Tanstack mirrored links

### DIFF
--- a/packages/website-v2/src/marketplace/marketplaceData.test.ts
+++ b/packages/website-v2/src/marketplace/marketplaceData.test.ts
@@ -200,4 +200,23 @@ describe("resolveHtmlAssetLinks", () => {
       'href="https://raw.githubusercontent.com/opral/paraglide-js/refs/heads/main/docs/assets/og.png"',
     );
   });
+
+  it("does not rewrite external links with different origins", () => {
+    const baseUrl =
+      "https://raw.githubusercontent.com/opral/paraglide-js/refs/heads/main/docs/strategy.md";
+    const html =
+      '<p><a href="https://github.com/TanStack/router/tree/main/examples/react/start-i18n-paraglide">TanStack Start</a></p>';
+    const pageLinkMap = new Map([
+      [
+        "https://github.com/TanStack/router/tree/main/examples/react/start-i18n-paraglide",
+        "/m/gerre34r/library-inlang-paraglideJs/tanstack-start",
+      ],
+    ]);
+
+    const resolved = resolveHtmlAssetLinks(html, baseUrl, pageLinkMap);
+
+    expect(resolved).toContain(
+      'href="https://github.com/TanStack/router/tree/main/examples/react/start-i18n-paraglide"',
+    );
+  });
 });

--- a/packages/website-v2/src/marketplace/marketplaceData.ts
+++ b/packages/website-v2/src/marketplace/marketplaceData.ts
@@ -361,7 +361,11 @@ export function resolveHtmlAssetLinks(
       const resolved = resolveRelativeUrl(String(value), baseUrl, {
         appendMarkdownExtension: attr.toLowerCase() === "href",
       });
-      if (attr.toLowerCase() === "href" && pageLinkMap) {
+      if (
+        attr.toLowerCase() === "href" &&
+        pageLinkMap &&
+        isSameOrigin(resolved, baseUrl)
+      ) {
         const target = pageLinkMap.get(normalizePageLinkKey(resolved));
         if (target) {
           const suffix = extractSearchAndHash(resolved);
@@ -381,6 +385,14 @@ function normalizePageLinkKey(value: string) {
     return url.toString();
   } catch {
     return value;
+  }
+}
+
+function isSameOrigin(value: string, baseUrl: string) {
+  try {
+    return new URL(value).origin === new URL(baseUrl).origin;
+  } catch {
+    return false;
   }
 }
 


### PR DESCRIPTION
Prevent marketplace link rewriting across origins to fix incorrect "mirrored from" links for external GitHub repositories.

---
<a href="https://cursor.com/background-agent?bcId=bc-fdc7c08e-cd21-43e7-96e3-22f77fe84b18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fdc7c08e-cd21-43e7-96e3-22f77fe84b18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents incorrect rewriting of external links when rendering mirrored/markdown pages.
> 
> - Add `isSameOrigin` and gate `pageLinkMap` rewrites in `resolveHtmlAssetLinks` to only apply for same-origin `href`s
> - Keep asset `src/href` resolution behavior unchanged otherwise
> - Extend tests to verify external links (e.g., TanStack GitHub URLs) are not rewritten
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05b9f1eae58013198a3390fd4199d08d2834f841. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->