### PR TITLE
Fix mirrored link rewriting for TanStack examples

### DIFF
--- a/packages/website-v2/src/marketplace/marketplaceData.test.ts
+++ b/packages/website-v2/src/marketplace/marketplaceData.test.ts
@@ -200,4 +200,23 @@ describe("resolveHtmlAssetLinks", () => {
       'href="https://raw.githubusercontent.com/opral/paraglide-js/refs/heads/main/docs/assets/og.png"',
     );
   });
+
+  it("does not rewrite links that point to a different origin", () => {
+    const baseUrl =
+      "https://raw.githubusercontent.com/TanStack/router/main/examples/react/i18n-paraglide/README.md";
+    const html =
+      '<p><a href="https://github.com/TanStack/router/tree/main/examples/react/i18n-paraglide">TanStack Router</a></p>';
+    const pageLinkMap = new Map([
+      [
+        "https://github.com/TanStack/router/tree/main/examples/react/i18n-paraglide",
+        "/m/gerre34r/library-inlang-paraglideJs/tanstack-router",
+      ],
+    ]);
+
+    const resolved = resolveHtmlAssetLinks(html, baseUrl, pageLinkMap);
+
+    expect(resolved).toContain(
+      'href="https://github.com/TanStack/router/tree/main/examples/react/i18n-paraglide"',
+    );
+  });
 });

--- a/packages/website-v2/src/marketplace/marketplaceData.ts
+++ b/packages/website-v2/src/marketplace/marketplaceData.ts
@@ -355,6 +355,7 @@ export function resolveHtmlAssetLinks(
   pageLinkMap?: PageLinkMap,
 ) {
   if (!baseUrl || !baseUrl.startsWith("http")) return html;
+  const baseOrigin = getUrlOrigin(baseUrl);
   return html.replace(
     /(src|href)=(["'])([^"']+)\2/gi,
     (_match, attr, quote, value) => {
@@ -364,6 +365,10 @@ export function resolveHtmlAssetLinks(
       if (attr.toLowerCase() === "href" && pageLinkMap) {
         const target = pageLinkMap.get(normalizePageLinkKey(resolved));
         if (target) {
+          const targetOrigin = getUrlOrigin(resolved);
+          if (baseOrigin && targetOrigin && baseOrigin !== targetOrigin) {
+            return `${attr}=${quote}${resolved}${quote}`;
+          }
           const suffix = extractSearchAndHash(resolved);
           return `${attr}=${quote}${target}${suffix}${quote}`;
         }
@@ -390,6 +395,14 @@ function extractSearchAndHash(value: string) {
     return `${url.search}${url.hash}`;
   } catch {
     return "";
+  }
+}
+
+function getUrlOrigin(value: string) {
+  try {
+    return new URL(value).origin;
+  } catch {
+    return null;
   }
 }
 


### PR DESCRIPTION
### Motivation
- Mirrored example pages could incorrectly rewrite links pointing to a different origin into internal marketplace routes, producing wrong "mirrored from" URLs for TanStack examples. 
- The intent is to preserve external-origin links (e.g. `github.com`) and only rewrite links that are on the same origin as the mirrored source (e.g. `raw.githubusercontent.com`).

### Description
- In `packages/website-v2/src/marketplace/marketplaceData.ts` compute the page `baseOrigin` and added a `getUrlOrigin` helper. 
- In `resolveHtmlAssetLinks` skip mapping an `href` to a marketplace route when the resolved link's origin differs from the page origin and return the original resolved URL instead. 
- Added a unit test in `packages/website-v2/src/marketplace/marketplaceData.test.ts` that asserts links pointing to a different origin are not rewritten to internal routes.

### Testing
- Added a unit test `does not rewrite links that point to a different origin` in `packages/website-v2/src/marketplace/marketplaceData.test.ts` to cover the new behavior. 
- No automated test suite was executed as part of this change (tests added but not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973be5762848326946f723cbaae5cb2)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures mirrored pages only rewrite links on the same origin as the source, preventing incorrect internal routing for external links (e.g., GitHub).
> 
> - In `resolveHtmlAssetLinks`, compute `baseOrigin` and compare with `targetOrigin`; if origins differ, keep the resolved external URL
> - Added `getUrlOrigin` helper to safely extract URL origins
> - Added unit test `does not rewrite links that point to a different origin` in `marketplaceData.test.ts` verifying external links remain unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3fffdea5a1ad8b92338fb54d75e99b2069e9dd6b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->