### PR TITLE
Remove shutdown wait on fileQueueSettled and silence known shutdown noise in CLI

### DIFF
--- a/.changeset/shaggy-parrots-juggle.md
+++ b/.changeset/shaggy-parrots-juggle.md
@@ -1,0 +1,7 @@
+---
+"@inlang/cli": patch
+---
+
+Fix CLI commands not terminating by removing the shutdown wait on `fileQueueSettled`.
+
+Also silence known non-actionable shutdown noise from background file queue processing when the DB is already closed.

--- a/packages/cli/src/commands/machine/translate.ts
+++ b/packages/cli/src/commands/machine/translate.ts
@@ -1,10 +1,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { Command } from "commander";
 import { rpc } from "@inlang/rpc";
-import {
-  getInlangProject,
-  settleLastUsedProjectFileQueue,
-} from "../../utilities/getInlangProject.js";
+import { getInlangProject } from "../../utilities/getInlangProject.js";
 import { log, logError } from "../../utilities/log.js";
 import {
   saveProjectToDirectory,
@@ -41,7 +38,6 @@ export const translate = new Command()
       logError(error);
       exitCode = 1;
     } finally {
-      await settleLastUsedProjectFileQueue();
       process.exit(exitCode);
     }
   });

--- a/packages/cli/src/commands/validate/index.ts
+++ b/packages/cli/src/commands/validate/index.ts
@@ -1,8 +1,5 @@
 import { Command } from "commander";
-import {
-  getInlangProject,
-  settleLastUsedProjectFileQueue,
-} from "../../utilities/getInlangProject.js";
+import { getInlangProject } from "../../utilities/getInlangProject.js";
 import { log } from "../../utilities/log.js";
 import { projectOption } from "../../utilities/globalFlags.js";
 
@@ -32,7 +29,6 @@ export async function validateCommandAction(args: { project: string }) {
     log.error(error);
     exitCode = 1;
   } finally {
-    await settleLastUsedProjectFileQueue();
     process.exit(exitCode);
   }
 }

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -3,6 +3,7 @@ import { machine } from "./commands/machine/index.js";
 import { plugin } from "./commands/plugin/index.js";
 import { version } from "../package.json";
 import { initErrorMonitoring } from "./services/error-monitoring/implementation.js";
+import { silenceKnownShutdownNoise } from "./services/error-monitoring/silenceKnownShutdownNoise.js";
 import { validate } from "./commands/validate/index.js";
 import { capture } from "./telemetry/capture.js";
 import { lastUsedProject } from "./utilities/getInlangProject.js";
@@ -11,6 +12,7 @@ import { lint } from "./commands/lint/index.js";
 // --------------- INIT ---------------
 
 initErrorMonitoring();
+silenceKnownShutdownNoise();
 // checks whether the gitOrigin corresponds to the pattern
 
 // beautiful logging

--- a/packages/cli/src/services/error-monitoring/silenceKnownShutdownNoise.ts
+++ b/packages/cli/src/services/error-monitoring/silenceKnownShutdownNoise.ts
@@ -1,0 +1,31 @@
+const FILE_QUEUE_CONTEXT_PATTERN = /(file queue|Error processing file queue entry)/i;
+const DB_CLOSED_PATTERN = /(DB has been closed|driver has already been destroyed)/i;
+
+function shouldSilenceConsoleError(args: unknown[]): boolean {
+  if (args.length === 0) {
+    return false;
+  }
+
+  const text = args
+    .map((arg) => {
+      if (arg instanceof Error) {
+        return `${arg.name}: ${arg.message}`;
+      }
+      return String(arg);
+    })
+    .join(" ");
+
+  return FILE_QUEUE_CONTEXT_PATTERN.test(text) && DB_CLOSED_PATTERN.test(text);
+}
+
+export function silenceKnownShutdownNoise(): void {
+  const originalConsoleError = console.error.bind(console);
+
+  console.error = (...args: unknown[]) => {
+    if (shouldSilenceConsoleError(args)) {
+      return;
+    }
+
+    originalConsoleError(...args);
+  };
+}

--- a/packages/cli/src/utilities/getInlangProject.ts
+++ b/packages/cli/src/utilities/getInlangProject.ts
@@ -1,6 +1,5 @@
 import fs from "node:fs";
 import { loadProjectFromDirectory, type InlangProject } from "@inlang/sdk";
-import { fileQueueSettled } from "@inlang/sdk/lix";
 import { resolve } from "node:path";
 
 /**
@@ -29,16 +28,5 @@ export async function getInlangProject(args: {
   } catch (err) {
     console.error(`Error opening inlang project at ${args.projectPath}`, err);
     process.exit(1);
-  }
-}
-
-export async function settleLastUsedProjectFileQueue(): Promise<void> {
-  if (!lastUsedProject) {
-    return;
-  }
-  try {
-    await fileQueueSettled({ lix: lastUsedProject.lix });
-  } catch {
-    // Best-effort: ignore queue settle failures during shutdown.
   }
 }


### PR DESCRIPTION
Closes https://github.com/opral/inlang/issues/4327

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CLI shutdown behavior by removing a best-effort background-queue settle and by monkey-patching `console.error`, which could hide unexpected errors if the regexes are too broad, but scope is limited to known shutdown messages.
> 
> **Overview**
> Fixes CLI commands that could hang on exit by removing the shutdown wait on `fileQueueSettled` (deleting `settleLastUsedProjectFileQueue` and its usage in `translate`/`validate`).
> 
> Adds `silenceKnownShutdownNoise()` (called from `main.ts`) to suppress specific `console.error` messages from background file-queue processing when the DB has already been closed, reducing non-actionable shutdown noise.
> 
> Includes a patch changeset for `@inlang/cli` documenting the behavior change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8d0b20fd8d68227c8c59a4ac153f54a858ac186. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->