### PR TITLE
[codex] Update inlang sdk uuid dependencies

### DIFF
--- a/.changeset/fuzzy-uuid-guards.md
+++ b/.changeset/fuzzy-uuid-guards.md
@@ -1,0 +1,5 @@
+---
+"@inlang/sdk": patch
+---
+
+Update `@lix-js/sdk` to `0.4.10` and `uuid` to `^14.0.0` to address GHSA-w5hq-g745-h8pq.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -38,11 +38,11 @@
 		"node": ">=20.0.0"
 	},
 	"dependencies": {
-		"@lix-js/sdk": "0.4.9",
+		"@lix-js/sdk": "0.4.10",
 		"@sinclair/typebox": "^0.31.17",
 		"kysely": "^0.28.12",
 		"sqlite-wasm-kysely": "0.3.0",
-		"uuid": "^13.0.0"
+		"uuid": "^14.0.0"
 	},
 	"devDependencies": {
 		"@eslint/js": "^9.12.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -811,8 +811,8 @@ importers:
   packages/sdk:
     dependencies:
       '@lix-js/sdk':
-        specifier: 0.4.9
-        version: 0.4.9(babel-plugin-macros@3.1.0)
+        specifier: 0.4.10
+        version: 0.4.10(babel-plugin-macros@3.1.0)
       '@sinclair/typebox':
         specifier: ^0.31.17
         version: 0.31.28
@@ -823,8 +823,8 @@ importers:
         specifier: 0.3.0
         version: 0.3.0(kysely@0.28.14)
       uuid:
-        specifier: ^13.0.0
-        version: 13.0.0
+        specifier: ^14.0.0
+        version: 14.0.0
     devDependencies:
       '@eslint/js':
         specifier: ^9.12.0
@@ -3286,8 +3286,8 @@ packages:
     resolution: {integrity: sha512-B9X3FjD8WmdG7tbA44JuniSO0KdKBWnjfxl8zpgrDCkavrp/GP7U0xxBkc0WgeeoHjQ/pkqq9VqtWB2kS9jIUg==}
     deprecated: use the lix sdk instead https://www.npmjs.com/package/@lix-js/sdk
 
-  '@lix-js/sdk@0.4.9':
-    resolution: {integrity: sha512-30mDkXpx704359oRrJI42bjfCspCiaMItngVBbPkiTGypS7xX4jYbHWQkXI8XuJ7VDB69D0MsVU6xfrBAIrM4A==}
+  '@lix-js/sdk@0.4.10':
+    resolution: {integrity: sha512-0dMInAJK/67guTG5rRZaCEhvzC5cCXENOjaePA5AqMXrCE97kaY7SRor9e2vnoGsFIiGqXKlT0MCIoZj36G0gg==}
     engines: {node: '>=18'}
 
   '@lix-js/server-protocol-schema@0.1.1':
@@ -11155,16 +11155,12 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
-  uuid@10.0.0:
-    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
-    hasBin: true
-
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
     hasBin: true
 
-  uuid@13.0.0:
-    resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
   uuid@9.0.1:
@@ -13985,7 +13981,7 @@ snapshots:
     dependencies:
       typescript: 5.2.2
 
-  '@lix-js/sdk@0.4.9(babel-plugin-macros@3.1.0)':
+  '@lix-js/sdk@0.4.10(babel-plugin-macros@3.1.0)':
     dependencies:
       '@lix-js/server-protocol-schema': 0.1.1
       dedent: 1.5.1(babel-plugin-macros@3.1.0)
@@ -13993,7 +13989,7 @@ snapshots:
       js-sha256: 0.11.1
       kysely: 0.28.14
       sqlite-wasm-kysely: 0.3.0(kysely@0.28.14)
-      uuid: 10.0.0
+      uuid: 14.0.0
     transitivePeerDependencies:
       - babel-plugin-macros
 
@@ -24044,11 +24040,9 @@ snapshots:
 
   utils-merge@1.0.1: {}
 
-  uuid@10.0.0: {}
-
   uuid@11.1.0: {}
 
-  uuid@13.0.0: {}
+  uuid@14.0.0: {}
 
   uuid@9.0.1: {}
 


### PR DESCRIPTION
## Summary

- Update `@inlang/sdk` to consume `@lix-js/sdk@0.4.10`.
- Upgrade the direct `uuid` dependency to `^14.0.0`.
- Add a patch changeset for `@inlang/sdk`.

## Validation

- `pnpm --filter @inlang/sdk test`

Closes https://github.com/opral/inlang/issues/4347

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-only change; main impact is potential runtime/test incompatibilities from upgrading `uuid` and `@lix-js/sdk`.
> 
> **Overview**
> Updates `@inlang/sdk` dependencies to `@lix-js/sdk@0.4.10` and `uuid@^14.0.0` (and refreshes `pnpm-lock.yaml`) to address GHSA-w5hq-g745-h8pq.
> 
> Adds a patch changeset so this dependency/security update is released as a patch version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2929995a2f3986efa5fa02a42f46df69a027811. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->