### PR TITLE
fix(plugin-i18next): make context keys round-trip through exportFiles

### DIFF
--- a/.changeset/i18next-export-context-roundtrip.md
+++ b/.changeset/i18next-export-context-roundtrip.md
@@ -1,0 +1,5 @@
+---
+"@inlang/plugin-i18next": patch
+---
+
+Fix `exportFiles` throwing `The variant does not have a context match` (or `The variant does not have a plural match`) for bundles that `importFiles` itself created from i18next context and plural sibling keys. Variants without a literal context/plural match — catchall variants and the base key fallback — now serialize back to their base key, so projects using context keys round-trip again. Fixes https://github.com/opral/inlang/issues/4355

--- a/packages/plugins/i18next/src/import-export/exportFiles.ts
+++ b/packages/plugins/i18next/src/import-export/exportFiles.ts
@@ -8,6 +8,7 @@ import type {
 } from "@inlang/sdk";
 import { type plugin } from "../plugin.js";
 import { unflatten } from "flat";
+import { matchSpecificity } from "./matchSpecificity.js";
 import type { PluginSettings } from "../settings.js";
 
 export const exportFiles: NonNullable<(typeof plugin)["exportFiles"]> = async ({
@@ -80,19 +81,13 @@ function serializeMessage(
 ): Array<{ key: string; value: string; locale: string }> {
 	const result = [];
 
-	const hasContext = bundle.declarations.some(
-		(declaration) =>
-			declaration.type === "input-variable" && declaration.name === "context"
+	// emit base keys first and the most specific keys last, mirroring how
+	// i18next files are conventionally written
+	const sortedVariants = [...variants].sort(
+		(a, b) => matchSpecificity(a) - matchSpecificity(b)
 	);
 
-	const hasPlurals = bundle.declarations.some(
-		(declaration) =>
-			declaration.type === "local-variable" &&
-			declaration.value.annotation?.type === "function-reference" &&
-			declaration.value.annotation?.name === "plural"
-	);
-
-	for (const variant of variants) {
+	for (const variant of sortedVariants) {
 		const pattern = serializePattern(variant.pattern, settings);
 		const contextMatch = variant.matches.find(
 			(match) => match.type === "literal-match" && match.key === "context"
@@ -101,32 +96,19 @@ function serializeMessage(
 			(match) => match.type === "literal-match" && match.key === "countPlural"
 		) as LiteralMatch | undefined;
 
-		const isCatchAll = variant.matches.some(
-			(match) => match.type === "catchall-match"
-		);
-
-		if (hasContext && contextMatch === undefined) {
-			throw new Error("The variant does not have a context match");
+		// i18next derives keys as `key[_context][_pluralSuffix]`.
+		// variants without a literal match — catchall matches or no match at
+		// all, i.e. the base key fallback that importFiles creates for
+		// context/plural sibling keys — add no suffix.
+		// https://www.i18next.com/translation-function/context#combining-with-plurals
+		let key = bundle.id;
+		if (contextMatch !== undefined) {
+			key += `_${contextMatch.value}`;
 		}
-		if (hasPlurals && pluralMatch === undefined) {
-			throw new Error("The variant does not have a plural match");
+		if (pluralMatch !== undefined) {
+			key += `_${pluralMatch.value}`;
 		}
-		// matches need to be appended
-		// 'keyContext' -> 'keyContext_match'
-		let key: string;
-		if (hasContext && hasPlurals && isCatchAll) {
-			key = `${bundle.id}_${contextMatch?.value}`;
-		} else if (hasContext && hasPlurals && isCatchAll === false) {
-			key = `${bundle.id}_${contextMatch?.value}_${pluralMatch?.value}`;
-		} else if (hasContext === false && hasPlurals) {
-			key = `${bundle.id}_${pluralMatch?.value}`;
-		} else if (hasContext && hasPlurals === false) {
-			key = `${bundle.id}_${contextMatch?.value}`;
-		} else {
-			key = bundle.id;
-		}
-		const value = pattern;
-		result.push({ key, value, locale: message.locale });
+		result.push({ key, value: pattern, locale: message.locale });
 	}
 
 	return result;

--- a/packages/plugins/i18next/src/import-export/matchSpecificity.ts
+++ b/packages/plugins/i18next/src/import-export/matchSpecificity.ts
@@ -1,0 +1,25 @@
+import type { Variant } from "@inlang/sdk";
+
+/**
+ * Specificity of a variant's matches, following i18next's key resolution
+ * order where the most specific key wins and the base key is the fallback:
+ *
+ * `key_context_plural` (3) > `key_context` (2) > `key_plural` (1) > `key` (0)
+ *
+ * Catchall matches and absent matches do not add specificity.
+ *
+ * https://www.i18next.com/translation-function/context
+ * https://www.i18next.com/translation-function/context#combining-with-plurals
+ */
+export function matchSpecificity(variant: {
+	matches?: Variant["matches"];
+}): number {
+	const hasLiteralMatch = (key: string) =>
+		(variant.matches ?? []).some(
+			(match) => match.type === "literal-match" && match.key === key
+		);
+	return (
+		(hasLiteralMatch("context") ? 2 : 0) +
+		(hasLiteralMatch("countPlural") ? 1 : 0)
+	);
+}

--- a/packages/plugins/i18next/src/import-export/roundtrip.test.ts
+++ b/packages/plugins/i18next/src/import-export/roundtrip.test.ts
@@ -191,7 +191,9 @@ test("keyMarkupMixedNamedAndNumericTransTags", async () => {
 	] satisfies Pattern);
 });
 
-test.todo("keyContext", async () => {
+// context keys, see https://www.i18next.com/translation-function/context
+// reproduces https://github.com/opral/inlang/issues/4355
+test("keyContext", async () => {
 	const imported = await runImportFiles({
 		// catch all
 		keyContext: "the variant",
@@ -207,34 +209,80 @@ test.todo("keyContext", async () => {
 	});
 
 	expect(imported.bundles).lengthOf(1);
-	expect(imported.messages).lengthOf(1);
+	// one message per imported key, see
+	// "a key with a single variant should have no matches even if other keys are multi variant"
+	expect(imported.messages).lengthOf(3);
 	expect(imported.variants).lengthOf(3);
 
 	expect(imported.bundles[0]?.id).toStrictEqual("keyContext");
 	expect(imported.bundles[0]?.declarations).toStrictEqual([
 		{ type: "input-variable", name: "context" },
 	]);
-	expect(imported?.messages[0]?.selectors).toStrictEqual([
-		{ type: "variable-reference", name: "context" },
+
+	const variantByText = (text: string) =>
+		imported.variants.find((variant) =>
+			variant.pattern?.some(
+				(part) => part.type === "text" && part.value === text
+			)
+		);
+
+	// the base key is the fallback in i18next — it must not carry a literal
+	// context match
+	expect(
+		variantByText("the variant")?.matches?.some(
+			(match) => match.type === "literal-match" && match.key === "context"
+		)
+	).toBe(false);
+	expect(variantByText("the male variant")?.matches).toStrictEqual([
+		{ type: "literal-match", key: "context", value: "male" },
 	]);
-	expect(imported.variants[0]).toStrictEqual(
-		expect.objectContaining({
-			matches: [{ type: "catchall-match", key: "context" }],
-			pattern: [{ type: "text", value: "the variant" }],
-		} satisfies Partial<Variant>)
+	expect(variantByText("the female variant")?.matches).toStrictEqual([
+		{ type: "literal-match", key: "context", value: "female" },
+	]);
+});
+
+// context combined with plurals, mirrors the example in
+// https://www.i18next.com/translation-function/context#combining-with-plurals
+// reproduces https://github.com/opral/inlang/issues/4355
+test("keyContextCombinedWithPlurals", async () => {
+	// the context+plural keys mirror i18next's own test fixture in
+	// test/runtime/translator/translator.translate.combination.test.js
+	const json = {
+		friend_one: "A friend",
+		friend_other: "{{count}} friends",
+		friend_male_zero: "No boyfriend",
+		friend_male_one: "A boyfriend",
+		friend_male_other: "{{count}} boyfriends",
+		friend_female_zero: "no girlfriend",
+		friend_female_one: "a girlfriend",
+		friend_female_other: "{{count}} girlfriends",
+	};
+	const imported = await runImportFiles(json);
+	expect(await runExportFilesParsed(imported)).toStrictEqual(json);
+
+	expect(imported.bundles).lengthOf(1);
+	expect(imported.bundles[0]?.id).toStrictEqual("friend");
+	expect(imported.bundles[0]?.declarations).toStrictEqual(
+		expect.arrayContaining([
+			{ type: "input-variable", name: "context" },
+			{ type: "input-variable", name: "count" },
+		])
 	);
-	expect(imported.variants[1]).toStrictEqual(
-		expect.objectContaining({
-			matches: [{ type: "literal-match", key: "context", value: "male" }],
-			pattern: [{ type: "text", value: "the male variant" }],
-		} satisfies Partial<Variant>)
-	);
-	expect(imported.variants[2]).toStrictEqual(
-		expect.objectContaining({
-			matches: [{ type: "literal-match", key: "context", value: "female" }],
-			pattern: [{ type: "text", value: "the female variant" }],
-		} satisfies Partial<Variant>)
-	);
+	expect(imported.variants).lengthOf(8);
+});
+
+// a plural key set can ship a base key as the fallback for calls without a
+// count, see https://www.i18next.com/translation-function/plurals
+// reproduces https://github.com/opral/inlang/issues/4355
+// ("The variant does not have a plural match")
+test("keyPluralWithBaseKey", async () => {
+	const json = {
+		friend: "A friend",
+		friend_one: "A friend",
+		friend_other: "{{count}} friends",
+	};
+	const imported = await runImportFiles(json);
+	expect(await runExportFilesParsed(imported)).toStrictEqual(json);
 });
 
 test("keyPluralSimple", async () => {


### PR DESCRIPTION
Fixes #4355

As discussed with @samuelstroschein on Discord: plugin-side fixes come from the i18next side (this PR and a stacked follow-up for #4354); SDK #4356 and compiler opral/paraglide-js#694 are handled by the inlang team.

## Problem

`exportFiles` requires every variant of a bundle with a `context` input to carry a literal `context` match (and the plural equivalent), but `importFiles` itself creates variants that can't satisfy that invariant — the base-key fallback (`friend_one` next to `friend_male_one`, or plain `friend` next to `friend_male`) has no literal context match by design. Result: any project using i18next context keys imports cleanly (`project.errors` → `[]`) but throws `The variant does not have a context match` (or `The variant does not have a plural match`) on `saveProjectToDirectory`. Root-cause recap with permalinks in #4355.

## Change

- `serializeMessage` now derives keys uniformly as `key[_context][_pluralSuffix]` from the literal matches that are present. Catchall matches and absent matches add no suffix — that *is* the base key. The two throws and the four-branch key derivation (whose catchall branch was unreachable, since the throw always fired first) are gone.
- Within a bundle, exported keys are emitted base-first/most-specific-last (new `matchSpecificity` helper, shared with the import side in the follow-up PR), matching how i18next files are conventionally written.
- Tests: enables the existing `test.todo("keyContext")` — the expected round-trip was already spelled out there — and adds fixtures for context combined with plurals (the documented combination: https://www.i18next.com/translation-function/context#combining-with-plurals) and for a plural set with a base key. The first commit adds the fixtures red (reproducing both throw messages on main); the second commit makes them green.

## Alignment with the i18next implementation

Verified against i18next v26.3.1:

- The key derivation `key[_context][_pluralSuffix]` matches the lookup keys i18next constructs (`contextKey = key + contextSeparator + context`, then `contextKey + pluralSuffix`): https://github.com/i18next/i18next/blob/6e086281e/src/Translator.js#L516-L556
- `pluralSeparator` and `contextSeparator` both default to `_`: https://github.com/i18next/i18next/blob/6e086281e/src/defaults.js#L19-L20
- The context+plural fixture mirrors i18next's own test fixture, including the `_zero` keys: https://github.com/i18next/i18next/blob/6e086281e/test/runtime/translator/translator.translate.combination.test.js

Backwards compatible: bundles produced by the current `importFiles` (no catchalls, file order) serialize to the same keys as before, and projects that were imported before this fix export correctly too.

The variant-ordering half of the story (#4354) is a separate PR stacked on this one, so each issue stays reviewable on its own. Happy to adjust anything to your conventions.
