### PR TITLE
fix(plugin-i18next): resolve context variants correctly by importing most-specific-first

### DIFF
--- a/.changeset/i18next-export-context-roundtrip.md
+++ b/.changeset/i18next-export-context-roundtrip.md
@@ -1,0 +1,5 @@
+---
+"@inlang/plugin-i18next": patch
+---
+
+Fix `exportFiles` throwing `The variant does not have a context match` (or `The variant does not have a plural match`) for bundles that `importFiles` itself created from i18next context and plural sibling keys. Variants without a literal context/plural match — catchall variants and the base key fallback — now serialize back to their base key, so projects using context keys round-trip again. Fixes https://github.com/opral/inlang/issues/4355

--- a/.changeset/i18next-import-context-ordering.md
+++ b/.changeset/i18next-import-context-ordering.md
@@ -1,0 +1,5 @@
+---
+"@inlang/plugin-i18next": patch
+---
+
+Import i18next context and plural sibling keys with explicit catchall matches on the base key variants, consistent selectors across the bundle, and most-specific-first variant ordering (`key_context_plural` > `key_context` > `key_plural` > `key`). First-match-wins consumers like the Paraglide compiler now resolve context the way i18next does instead of always returning the base variant. Fixes https://github.com/opral/inlang/issues/4354

--- a/packages/plugins/i18next/src/import-export/exportFiles.ts
+++ b/packages/plugins/i18next/src/import-export/exportFiles.ts
@@ -8,6 +8,7 @@ import type {
 } from "@inlang/sdk";
 import { type plugin } from "../plugin.js";
 import { unflatten } from "flat";
+import { matchSpecificity } from "./matchSpecificity.js";
 import type { PluginSettings } from "../settings.js";
 
 export const exportFiles: NonNullable<(typeof plugin)["exportFiles"]> = async ({
@@ -80,19 +81,13 @@ function serializeMessage(
 ): Array<{ key: string; value: string; locale: string }> {
 	const result = [];
 
-	const hasContext = bundle.declarations.some(
-		(declaration) =>
-			declaration.type === "input-variable" && declaration.name === "context"
+	// emit base keys first and the most specific keys last, mirroring how
+	// i18next files are conventionally written
+	const sortedVariants = [...variants].sort(
+		(a, b) => matchSpecificity(a) - matchSpecificity(b)
 	);
 
-	const hasPlurals = bundle.declarations.some(
-		(declaration) =>
-			declaration.type === "local-variable" &&
-			declaration.value.annotation?.type === "function-reference" &&
-			declaration.value.annotation?.name === "plural"
-	);
-
-	for (const variant of variants) {
+	for (const variant of sortedVariants) {
 		const pattern = serializePattern(variant.pattern, settings);
 		const contextMatch = variant.matches.find(
 			(match) => match.type === "literal-match" && match.key === "context"
@@ -101,32 +96,19 @@ function serializeMessage(
 			(match) => match.type === "literal-match" && match.key === "countPlural"
 		) as LiteralMatch | undefined;
 
-		const isCatchAll = variant.matches.some(
-			(match) => match.type === "catchall-match"
-		);
-
-		if (hasContext && contextMatch === undefined) {
-			throw new Error("The variant does not have a context match");
+		// i18next derives keys as `key[_context][_pluralSuffix]`.
+		// variants without a literal match — catchall matches or no match at
+		// all, i.e. the base key fallback that importFiles creates for
+		// context/plural sibling keys — add no suffix.
+		// https://www.i18next.com/translation-function/context#combining-with-plurals
+		let key = bundle.id;
+		if (contextMatch !== undefined) {
+			key += `_${contextMatch.value}`;
 		}
-		if (hasPlurals && pluralMatch === undefined) {
-			throw new Error("The variant does not have a plural match");
+		if (pluralMatch !== undefined) {
+			key += `_${pluralMatch.value}`;
 		}
-		// matches need to be appended
-		// 'keyContext' -> 'keyContext_match'
-		let key: string;
-		if (hasContext && hasPlurals && isCatchAll) {
-			key = `${bundle.id}_${contextMatch?.value}`;
-		} else if (hasContext && hasPlurals && isCatchAll === false) {
-			key = `${bundle.id}_${contextMatch?.value}_${pluralMatch?.value}`;
-		} else if (hasContext === false && hasPlurals) {
-			key = `${bundle.id}_${pluralMatch?.value}`;
-		} else if (hasContext && hasPlurals === false) {
-			key = `${bundle.id}_${contextMatch?.value}`;
-		} else {
-			key = bundle.id;
-		}
-		const value = pattern;
-		result.push({ key, value, locale: message.locale });
+		result.push({ key, value: pattern, locale: message.locale });
 	}
 
 	return result;

--- a/packages/plugins/i18next/src/import-export/importFiles.ts
+++ b/packages/plugins/i18next/src/import-export/importFiles.ts
@@ -1,8 +1,15 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import type { Bundle, Pattern, VariableReference, Variant } from "@inlang/sdk";
+import type {
+	Bundle,
+	Message,
+	Pattern,
+	VariableReference,
+	Variant,
+} from "@inlang/sdk";
 import { type plugin } from "../plugin.js";
 import { flatten } from "flat";
 import type { BundleImport, MessageImport, VariantImport } from "@inlang/sdk";
+import { matchSpecificity } from "./matchSpecificity.js";
 import type { PluginSettings } from "../settings.js";
 
 export const importFiles: NonNullable<(typeof plugin)["importFiles"]> = async ({
@@ -71,7 +78,23 @@ function parseFile(args: {
 		messages.push(message);
 		variants.push(variant);
 	}
-	return { bundles, messages, variants };
+
+	// order each bundle's variants most-specific-first (`friend_male_one` >
+	// `friend_male` > `friend_one` > `friend`) so that first-match-wins
+	// consumers (e.g. the paraglide compiler) resolve context and plurals
+	// the way i18next does.
+	// https://github.com/opral/inlang/issues/4354
+	const variantsByBundleId = new Map<string, VariantImport[]>();
+	for (const variant of variants) {
+		const group = variantsByBundleId.get(variant.messageBundleId!) ?? [];
+		group.push(variant);
+		variantsByBundleId.set(variant.messageBundleId!, group);
+	}
+	const sortedVariants = [...variantsByBundleId.values()].flatMap((group) =>
+		group.sort((a, b) => matchSpecificity(b) - matchSpecificity(a))
+	);
+
+	return { bundles, messages, variants: sortedVariants };
 }
 
 function parseMessage(args: {
@@ -121,138 +144,96 @@ function parseMessage(args: {
 		? args.key.split("_").length === 3
 		: args.key.split("_").length === 2;
 
-	// the key itself has no plurals, but the resource has plurals
-	// hence, it must be the catch all variant
+	// sibling keys of the same bundle (`friend` -> `friend_one`,
+	// `friend_male_one`, ...) decide which selectors the bundle has. base
+	// keys are the fallback for their context/plural siblings and get
+	// explicit catchall matches.
 	// https://www.i18next.com/translation-function/context#combining-with-plurals
-	const isCatchAll =
-		testForPlurals(args.key) === false &&
-		Object.keys(args.resource).some(
-			// the first part of the key is identical e.g.
-			// ["friend"] -> ["friend", "one"]
-			(key) =>
-				args.key.split("_")[0] === key.split("_")[0] && testForPlurals(key)
-		);
+	const siblingKeys = Object.keys(args.resource).filter(
+		(key) => key.split("_")[0] === args.key.split("_")[0]
+	);
+	const bundleHasPlurals = siblingKeys.some(testForPlurals);
+	const bundleHasContext = siblingKeys.some((key) =>
+		testForPlurals(key)
+			? key.split("_").length === 3
+			: key.split("_").length === 2
+	);
 
-	if (hasContext && hasPlurals === false && isCatchAll === false) {
-		// "friend_male" -> ["friend", "male"]
-		const [, context] = args.key.split("_");
+	const selectors: Message["selectors"] = [];
+	const matches: Variant["matches"] = [];
+
+	if (bundleHasContext) {
 		bundle.declarations.push({
 			type: "input-variable",
 			name: "context",
 		});
-		message.selectors = [
-			{
-				type: "variable-reference",
-				name: "context",
-			},
-		];
-		variant.matches = [
-			{
-				type: "literal-match",
-				// i18next always uses "context" as the key
-				key: "context",
-				value: context!,
-			},
-		];
-	} else if (hasContext && hasPlurals && isCatchAll === false) {
-		// "friend_female_one": "A girlfriend" -> ["friend", "female", "one"]
-		const [, context, plural] = args.key.split("_");
-		bundle.declarations.push({
-			type: "input-variable",
+		selectors.push({
+			type: "variable-reference",
 			name: "context",
 		});
-		bundle.declarations.push({
-			type: "input-variable",
-			name: "count",
-		});
-		bundle.declarations.push({
-			type: "local-variable",
-			name: "countPlural",
-			value: {
-				type: "expression",
-				arg: {
-					type: "variable-reference",
-					name: "count",
-				},
-				annotation: {
-					type: "function-reference",
-					name: "plural",
-					options: [],
-				},
-			},
-		});
-		message.selectors = [
-			{
-				type: "variable-reference",
-				name: "context",
-			},
-			{
-				type: "variable-reference",
-				name: "countPlural",
-			},
-		];
-		variant.matches = [
-			{
-				type: "literal-match",
-				key: "context",
-				value: context!,
-			},
-			{
-				type: "literal-match",
-				// i18next only allows matching against a count variable.
-				// suffixing plural here because the inlang sdk v2 purposefully
-				// did not allow using a variable with a function like `plural`
-				// without declaring a new variable
-				key: "countPlural",
-				value: plural!,
-			},
-		];
-	} else if (hasPlurals && isCatchAll === false) {
-		variant.matches = [
-			{
-				// i18next only allows matching against a count variable
-				// suffixing plural because the inlang sdk v2 purposefully
-				// did not allow using a variable with a function like `plural`
-				// without declaring a new variable to reduce complexity
-				type: "literal-match",
-				key: "countPlural",
-				value: args.key.split("_").at(-1)!,
-			},
-		];
-		message.selectors = [
-			{
-				type: "variable-reference",
-				name: "countPlural",
-			},
-		];
-		bundle.declarations.push({
-			type: "input-variable",
-			name: "count",
-		});
-		bundle.declarations.push({
-			type: "local-variable",
-			name: "countPlural",
-			value: {
-				type: "expression",
-				arg: {
-					type: "variable-reference",
-					name: "count",
-				},
-				annotation: {
-					type: "function-reference",
-					name: "plural",
-					options: [],
-				},
-			},
-		});
-	} else if (isCatchAll) {
-		variant.matches = [
-			{
-				type: "catchall-match",
-				key: "context",
-			},
-		];
+		matches.push(
+			hasContext
+				? {
+						type: "literal-match",
+						// i18next always uses "context" as the key
+						// "friend_male" -> ["friend", "male"]
+						key: "context",
+						value: args.key.split("_")[1]!,
+					}
+				: // the base key is the fallback for all context variants
+					{
+						type: "catchall-match",
+						key: "context",
+					}
+		);
 	}
+
+	if (bundleHasPlurals) {
+		bundle.declarations.push({
+			type: "input-variable",
+			name: "count",
+		});
+		bundle.declarations.push({
+			type: "local-variable",
+			name: "countPlural",
+			value: {
+				type: "expression",
+				arg: {
+					type: "variable-reference",
+					name: "count",
+				},
+				annotation: {
+					type: "function-reference",
+					name: "plural",
+					options: [],
+				},
+			},
+		});
+		selectors.push({
+			type: "variable-reference",
+			// i18next only allows matching against a count variable.
+			// suffixing plural here because the inlang sdk v2 purposefully
+			// did not allow using a variable with a function like `plural`
+			// without declaring a new variable
+			name: "countPlural",
+		});
+		matches.push(
+			hasPlurals
+				? {
+						type: "literal-match",
+						key: "countPlural",
+						value: args.key.split("_").at(-1)!,
+					}
+				: // the base key is the fallback for all plural variants
+					{
+						type: "catchall-match",
+						key: "countPlural",
+					}
+		);
+	}
+
+	message.selectors = selectors;
+	variant.matches = matches;
 
 	bundle.declarations = removeDuplicates(bundle.declarations);
 
@@ -284,7 +265,10 @@ function parsePattern(
 	for (let index = 0; index < value.length; index += 1) {
 		// parse interpolation first to avoid conflicts with custom patterns
 		if (openPattern && closePattern && value.startsWith(openPattern, index)) {
-			const closingIndex = value.indexOf(closePattern, index + openPattern.length);
+			const closingIndex = value.indexOf(
+				closePattern,
+				index + openPattern.length
+			);
 			if (closingIndex !== -1) {
 				flushBuffer();
 

--- a/packages/plugins/i18next/src/import-export/importFiles.ts
+++ b/packages/plugins/i18next/src/import-export/importFiles.ts
@@ -64,6 +64,29 @@ function parseFile(args: {
 	const messages: MessageImport[] = [];
 	const variants: VariantImport[] = [];
 
+	// sibling keys of the same bundle (`friend` -> `friend_one`,
+	// `friend_male_one`, ...) decide which selectors the bundle has. the
+	// summary is precomputed in a single pass to avoid rescanning the
+	// resource for every key.
+	// https://www.i18next.com/translation-function/context#combining-with-plurals
+	const bundleSelectorsByRootKey = new Map<
+		string,
+		{ hasPlurals: boolean; hasContext: boolean }
+	>();
+	for (const key in resource) {
+		const keyParts = key.split("_");
+		const hasPlurals = testForPlurals(key);
+		const summary = bundleSelectorsByRootKey.get(keyParts[0]!) ?? {
+			hasPlurals: false,
+			hasContext: false,
+		};
+		summary.hasPlurals = summary.hasPlurals || hasPlurals;
+		summary.hasContext =
+			summary.hasContext ||
+			(hasPlurals ? keyParts.length === 3 : keyParts.length === 2);
+		bundleSelectorsByRootKey.set(keyParts[0]!, summary);
+	}
+
 	for (const key in resource) {
 		const value = resource[key]!;
 		const { bundle, message, variant } = parseMessage({
@@ -71,7 +94,7 @@ function parseFile(args: {
 			key,
 			value,
 			locale: args.locale,
-			resource,
+			bundleSelectors: bundleSelectorsByRootKey.get(key.split("_")[0]!)!,
 			settings: args.settings,
 		});
 		bundles.push(bundle);
@@ -102,14 +125,15 @@ function parseMessage(args: {
 	key: string;
 	value: string;
 	locale: string;
-	resource: Record<string, any>;
+	bundleSelectors: { hasPlurals: boolean; hasContext: boolean };
 	settings?: PluginSettings;
 }): { bundle: BundleImport; message: MessageImport; variant: VariantImport } {
 	const pattern = parsePattern(args.value, args.settings);
 
 	// i18next suffixes keys with context or plurals
 	// "friend_female_one" -> "friend"
-	let bundleId = args.key.split("_")[0]!;
+	const keyParts = args.key.split("_");
+	let bundleId = keyParts[0]!;
 	if (args.namespace) {
 		// following i18next's convention
 		// https://www.i18next.com/principles/namespaces#sample
@@ -140,24 +164,12 @@ function parseMessage(args: {
 	// plurals, see https://www.i18next.com/misc/json-format#i18next-json-v4
 	const hasPlurals = testForPlurals(args.key);
 	// context is used see https://www.i18next.com/translation-function/context
-	const hasContext = hasPlurals
-		? args.key.split("_").length === 3
-		: args.key.split("_").length === 2;
+	const hasContext = hasPlurals ? keyParts.length === 3 : keyParts.length === 2;
 
-	// sibling keys of the same bundle (`friend` -> `friend_one`,
-	// `friend_male_one`, ...) decide which selectors the bundle has. base
-	// keys are the fallback for their context/plural siblings and get
-	// explicit catchall matches.
-	// https://www.i18next.com/translation-function/context#combining-with-plurals
-	const siblingKeys = Object.keys(args.resource).filter(
-		(key) => key.split("_")[0] === args.key.split("_")[0]
-	);
-	const bundleHasPlurals = siblingKeys.some(testForPlurals);
-	const bundleHasContext = siblingKeys.some((key) =>
-		testForPlurals(key)
-			? key.split("_").length === 3
-			: key.split("_").length === 2
-	);
+	// base keys are the fallback for their context/plural siblings and get
+	// explicit catchall matches (see the per-bundle summary in parseFile).
+	const { hasPlurals: bundleHasPlurals, hasContext: bundleHasContext } =
+		args.bundleSelectors;
 
 	const selectors: Message["selectors"] = [];
 	const matches: Variant["matches"] = [];
@@ -178,7 +190,7 @@ function parseMessage(args: {
 						// i18next always uses "context" as the key
 						// "friend_male" -> ["friend", "male"]
 						key: "context",
-						value: args.key.split("_")[1]!,
+						value: keyParts[1]!,
 					}
 				: // the base key is the fallback for all context variants
 					{
@@ -222,7 +234,7 @@ function parseMessage(args: {
 				? {
 						type: "literal-match",
 						key: "countPlural",
-						value: args.key.split("_").at(-1)!,
+						value: keyParts.at(-1)!,
 					}
 				: // the base key is the fallback for all plural variants
 					{

--- a/packages/plugins/i18next/src/import-export/matchSpecificity.ts
+++ b/packages/plugins/i18next/src/import-export/matchSpecificity.ts
@@ -1,0 +1,25 @@
+import type { Variant } from "@inlang/sdk";
+
+/**
+ * Specificity of a variant's matches, following i18next's key resolution
+ * order where the most specific key wins and the base key is the fallback:
+ *
+ * `key_context_plural` (3) > `key_context` (2) > `key_plural` (1) > `key` (0)
+ *
+ * Catchall matches and absent matches do not add specificity.
+ *
+ * https://www.i18next.com/translation-function/context
+ * https://www.i18next.com/translation-function/context#combining-with-plurals
+ */
+export function matchSpecificity(variant: {
+	matches?: Variant["matches"];
+}): number {
+	const hasLiteralMatch = (key: string) =>
+		(variant.matches ?? []).some(
+			(match) => match.type === "literal-match" && match.key === key
+		);
+	return (
+		(hasLiteralMatch("context") ? 2 : 0) +
+		(hasLiteralMatch("countPlural") ? 1 : 0)
+	);
+}

--- a/packages/plugins/i18next/src/import-export/roundtrip.test.ts
+++ b/packages/plugins/i18next/src/import-export/roundtrip.test.ts
@@ -191,7 +191,9 @@ test("keyMarkupMixedNamedAndNumericTransTags", async () => {
 	] satisfies Pattern);
 });
 
-test.todo("keyContext", async () => {
+// context keys, see https://www.i18next.com/translation-function/context
+// reproduces https://github.com/opral/inlang/issues/4355
+test("keyContext", async () => {
 	const imported = await runImportFiles({
 		// catch all
 		keyContext: "the variant",
@@ -207,34 +209,80 @@ test.todo("keyContext", async () => {
 	});
 
 	expect(imported.bundles).lengthOf(1);
-	expect(imported.messages).lengthOf(1);
+	// one message per imported key, see
+	// "a key with a single variant should have no matches even if other keys are multi variant"
+	expect(imported.messages).lengthOf(3);
 	expect(imported.variants).lengthOf(3);
 
 	expect(imported.bundles[0]?.id).toStrictEqual("keyContext");
 	expect(imported.bundles[0]?.declarations).toStrictEqual([
 		{ type: "input-variable", name: "context" },
 	]);
-	expect(imported?.messages[0]?.selectors).toStrictEqual([
-		{ type: "variable-reference", name: "context" },
+
+	const variantByText = (text: string) =>
+		imported.variants.find((variant) =>
+			variant.pattern?.some(
+				(part) => part.type === "text" && part.value === text
+			)
+		);
+
+	// the base key is the fallback in i18next — it must not carry a literal
+	// context match
+	expect(
+		variantByText("the variant")?.matches?.some(
+			(match) => match.type === "literal-match" && match.key === "context"
+		)
+	).toBe(false);
+	expect(variantByText("the male variant")?.matches).toStrictEqual([
+		{ type: "literal-match", key: "context", value: "male" },
 	]);
-	expect(imported.variants[0]).toStrictEqual(
-		expect.objectContaining({
-			matches: [{ type: "catchall-match", key: "context" }],
-			pattern: [{ type: "text", value: "the variant" }],
-		} satisfies Partial<Variant>)
+	expect(variantByText("the female variant")?.matches).toStrictEqual([
+		{ type: "literal-match", key: "context", value: "female" },
+	]);
+});
+
+// context combined with plurals, mirrors the example in
+// https://www.i18next.com/translation-function/context#combining-with-plurals
+// reproduces https://github.com/opral/inlang/issues/4355
+test("keyContextCombinedWithPlurals", async () => {
+	// the context+plural keys mirror i18next's own test fixture in
+	// test/runtime/translator/translator.translate.combination.test.js
+	const json = {
+		friend_one: "A friend",
+		friend_other: "{{count}} friends",
+		friend_male_zero: "No boyfriend",
+		friend_male_one: "A boyfriend",
+		friend_male_other: "{{count}} boyfriends",
+		friend_female_zero: "no girlfriend",
+		friend_female_one: "a girlfriend",
+		friend_female_other: "{{count}} girlfriends",
+	};
+	const imported = await runImportFiles(json);
+	expect(await runExportFilesParsed(imported)).toStrictEqual(json);
+
+	expect(imported.bundles).lengthOf(1);
+	expect(imported.bundles[0]?.id).toStrictEqual("friend");
+	expect(imported.bundles[0]?.declarations).toStrictEqual(
+		expect.arrayContaining([
+			{ type: "input-variable", name: "context" },
+			{ type: "input-variable", name: "count" },
+		])
 	);
-	expect(imported.variants[1]).toStrictEqual(
-		expect.objectContaining({
-			matches: [{ type: "literal-match", key: "context", value: "male" }],
-			pattern: [{ type: "text", value: "the male variant" }],
-		} satisfies Partial<Variant>)
-	);
-	expect(imported.variants[2]).toStrictEqual(
-		expect.objectContaining({
-			matches: [{ type: "literal-match", key: "context", value: "female" }],
-			pattern: [{ type: "text", value: "the female variant" }],
-		} satisfies Partial<Variant>)
-	);
+	expect(imported.variants).lengthOf(8);
+});
+
+// a plural key set can ship a base key as the fallback for calls without a
+// count, see https://www.i18next.com/translation-function/plurals
+// reproduces https://github.com/opral/inlang/issues/4355
+// ("The variant does not have a plural match")
+test("keyPluralWithBaseKey", async () => {
+	const json = {
+		friend: "A friend",
+		friend_one: "A friend",
+		friend_other: "{{count}} friends",
+	};
+	const imported = await runImportFiles(json);
+	expect(await runExportFilesParsed(imported)).toStrictEqual(json);
 });
 
 test("keyPluralSimple", async () => {

--- a/packages/plugins/i18next/src/import-export/roundtrip.test.ts
+++ b/packages/plugins/i18next/src/import-export/roundtrip.test.ts
@@ -219,26 +219,29 @@ test("keyContext", async () => {
 		{ type: "input-variable", name: "context" },
 	]);
 
-	const variantByText = (text: string) =>
-		imported.variants.find((variant) =>
-			variant.pattern?.some(
-				(part) => part.type === "text" && part.value === text
-			)
-		);
+	// every message of the bundle declares the same selectors
+	for (const message of imported.messages) {
+		expect(message.selectors).toStrictEqual([
+			{ type: "variable-reference", name: "context" },
+		]);
+	}
 
-	// the base key is the fallback in i18next — it must not carry a literal
-	// context match
+	// variants are ordered most-specific-first so that first-match-wins
+	// consumers (e.g. the paraglide compiler) resolve context like i18next.
+	// the base key is the fallback, expressed as a catchall match.
+	// https://github.com/opral/inlang/issues/4354
+	expect(imported.variants.map((variant) => variant.matches)).toStrictEqual([
+		[{ type: "literal-match", key: "context", value: "male" }],
+		[{ type: "literal-match", key: "context", value: "female" }],
+		[{ type: "catchall-match", key: "context" }],
+	]);
 	expect(
-		variantByText("the variant")?.matches?.some(
-			(match) => match.type === "literal-match" && match.key === "context"
+		imported.variants.map((variant) =>
+			variant.pattern?.[0]?.type === "text"
+				? variant.pattern[0].value
+				: undefined
 		)
-	).toBe(false);
-	expect(variantByText("the male variant")?.matches).toStrictEqual([
-		{ type: "literal-match", key: "context", value: "male" },
-	]);
-	expect(variantByText("the female variant")?.matches).toStrictEqual([
-		{ type: "literal-match", key: "context", value: "female" },
-	]);
+	).toStrictEqual(["the male variant", "the female variant", "the variant"]);
 });
 
 // context combined with plurals, mirrors the example in
@@ -283,6 +286,70 @@ test("keyPluralWithBaseKey", async () => {
 	};
 	const imported = await runImportFiles(json);
 	expect(await runExportFilesParsed(imported)).toStrictEqual(json);
+});
+
+// reproduces https://github.com/opral/inlang/issues/4354 — imported variants
+// must be ordered most-specific-first with explicit catchall matches so that
+// first-match-wins consumers (e.g. the paraglide compiler) resolve a call
+// like t("friend", { context: "male", count: 1 }) the way i18next does:
+// `friend_male_one` > `friend_male` > `friend_one` > `friend`
+// https://www.i18next.com/translation-function/context#combining-with-plurals
+test("context and plural sibling keys are ordered most-specific-first with catchall fallbacks", async () => {
+	const json = {
+		friend: "A friend",
+		friend_one: "A friend",
+		friend_other: "{{count}} friends",
+		friend_male: "A boyfriend",
+		friend_male_one: "A boyfriend",
+		friend_male_other: "{{count}} boyfriends",
+	};
+	const imported = await runImportFiles(json);
+
+	// round-trips unchanged
+	expect(await runExportFilesParsed(imported)).toStrictEqual(json);
+
+	expect(imported.bundles).lengthOf(1);
+	expect(imported.bundles[0]?.declarations).toStrictEqual(
+		expect.arrayContaining([
+			{ type: "input-variable", name: "context" },
+			{ type: "input-variable", name: "count" },
+		])
+	);
+
+	// every message of the bundle declares the same selectors
+	for (const message of imported.messages) {
+		expect(message.selectors).toStrictEqual([
+			{ type: "variable-reference", name: "context" },
+			{ type: "variable-reference", name: "countPlural" },
+		]);
+	}
+
+	expect(imported.variants.map((variant) => variant.matches)).toStrictEqual([
+		[
+			{ type: "literal-match", key: "context", value: "male" },
+			{ type: "literal-match", key: "countPlural", value: "one" },
+		],
+		[
+			{ type: "literal-match", key: "context", value: "male" },
+			{ type: "literal-match", key: "countPlural", value: "other" },
+		],
+		[
+			{ type: "literal-match", key: "context", value: "male" },
+			{ type: "catchall-match", key: "countPlural" },
+		],
+		[
+			{ type: "catchall-match", key: "context" },
+			{ type: "literal-match", key: "countPlural", value: "one" },
+		],
+		[
+			{ type: "catchall-match", key: "context" },
+			{ type: "literal-match", key: "countPlural", value: "other" },
+		],
+		[
+			{ type: "catchall-match", key: "context" },
+			{ type: "catchall-match", key: "countPlural" },
+		],
+	]);
 });
 
 test("keyPluralSimple", async () => {


### PR DESCRIPTION
Fixes #4354

Stacked on #4359 (the export fix for #4355 — its round-trip fixtures exercise the catchall matches this PR introduces).

As discussed with @samuelstroschein on Discord: plugin-side fixes come from the i18next side; SDK #4356 and compiler opral/paraglide-js#694 are handled by the inlang team.

## Problem

`importFiles` emits variants in JSON key order and gives base keys no usable matches. Consumers that compile variants first-match-wins — the Paraglide compiler emits an if-chain in stored order — therefore resolve `t("friend", { context: "male", count: 1 })` to the base variant: the context branches are unreachable dead code, and the result silently depends on the key order of the JSON file. Root-cause recap with permalinks in #4354.

## Change

In `importFiles`:

- Sibling keys of the same bundle decide the bundle's selectors; base keys get explicit `catchall-match`es for the selectors they don't constrain (`friend_one` → `[catchall context, literal countPlural=one]`, plain `friend` → catchalls only).
- Every message of a bundle declares the same selectors (`[context, countPlural]`) instead of per-key subsets.
- Each bundle's variants are ordered most-specific-first, following i18next's resolution order — `key_context_plural` > `key_context` > `key_plural` > `key` (most specific key wins, base key is the fallback): https://www.i18next.com/translation-function/context

## Alignment with the i18next implementation

The ordering follows i18next v26.3.1 exactly: `resolve()` builds `finalKeys = [key, key_plural, key_context, key_context_plural]` and consumes them via `finalKeys.pop()` — most-specific-first, base key as last fallback (the in-source comment reads "iterate over finalKeys starting with most specific pluralkey (-> contextkey only) -> singularkey only"): https://github.com/i18next/i18next/blob/6e086281e/src/Translator.js#L516-L567 — and react-i18next has no key-resolution logic of its own (it delegates to core), so nothing further to align there.

Two pre-existing nuances are intentionally out of scope (unchanged by this PR) and filed separately with repros and fix sketches: #4357 (`_zero` is i18next's exact-`count === 0` match, not an Intl plural category) and #4358 (ordinal keys `key_ordinal_one` misparse as context `"ordinal"`). Both look implementable plugin-only on top of this PR's model — happy to take them next.

The first commit adds the fixtures red (exact variant order, catchall shapes, selector consistency — including tightening the `keyContext` test to the shapes the old `test.todo` already described); the second commit makes them green.

Verified end-to-end against `@inlang/paraglide-js` 2.18.2 with the locally built plugin: `m.friend({ count: 1, context: "male" })` now returns `"A boyfriend"` (was `"A friend"`), plain context (`buddy`/`buddy_male`) resolves correctly regardless of file order, and `saveProjectToDirectory` round-trips the file content unchanged.

Note: the runtime half of #4354 could additionally be addressed compiler-side by sorting variants by specificity in opral/paraglide-js — that would make compiled output robust against any plugin's variant order. Your call; this PR fixes it at the source for the i18next plugin either way.
