### PR TITLE
fix(plugin-i18next): match _zero at count = 0 in every language

### DIFF
--- a/.changeset/i18next-zero-count-selector.md
+++ b/.changeset/i18next-zero-count-selector.md
@@ -1,0 +1,5 @@
+---
+"@inlang/plugin-i18next": patch
+---
+
+Import `_zero` keys with i18next's actual semantics: an exact `count = 0` match (via a `count` selector ahead of the plural category) plus the Intl "zero" category fallback. Previously `_zero` was modeled only as the Intl plural category, which most languages never select — so the zero translation was dead code at `count = 0` in e.g. English and French. Fixes https://github.com/opral/inlang/issues/4357

--- a/packages/plugins/i18next/src/import-export/exportFiles.ts
+++ b/packages/plugins/i18next/src/import-export/exportFiles.ts
@@ -92,6 +92,9 @@ function serializeMessage(
 		const contextMatch = variant.matches.find(
 			(match) => match.type === "literal-match" && match.key === "context"
 		) as LiteralMatch | undefined;
+		const countMatch = variant.matches.find(
+			(match) => match.type === "literal-match" && match.key === "count"
+		) as LiteralMatch | undefined;
 		const pluralMatch = variant.matches.find(
 			(match) => match.type === "literal-match" && match.key === "countPlural"
 		) as LiteralMatch | undefined;
@@ -105,7 +108,12 @@ function serializeMessage(
 		if (contextMatch !== undefined) {
 			key += `_${contextMatch.value}`;
 		}
-		if (pluralMatch !== undefined) {
+		if (countMatch?.value === "0") {
+			// the exact `count = 0` match serializes back to i18next's
+			// `_zero` suffix (its Intl category fallback variant derives the
+			// same key), see https://github.com/opral/inlang/issues/4357
+			key += "_zero";
+		} else if (pluralMatch !== undefined) {
 			key += `_${pluralMatch.value}`;
 		}
 		result.push({ key, value: pattern, locale: message.locale });

--- a/packages/plugins/i18next/src/import-export/importFiles.ts
+++ b/packages/plugins/i18next/src/import-export/importFiles.ts
@@ -71,7 +71,7 @@ function parseFile(args: {
 	// https://www.i18next.com/translation-function/context#combining-with-plurals
 	const bundleSelectorsByRootKey = new Map<
 		string,
-		{ hasPlurals: boolean; hasContext: boolean }
+		{ hasPlurals: boolean; hasContext: boolean; hasZero: boolean }
 	>();
 	for (const key in resource) {
 		const keyParts = key.split("_");
@@ -79,17 +79,22 @@ function parseFile(args: {
 		const summary = bundleSelectorsByRootKey.get(keyParts[0]!) ?? {
 			hasPlurals: false,
 			hasContext: false,
+			hasZero: false,
 		};
 		summary.hasPlurals = summary.hasPlurals || hasPlurals;
 		summary.hasContext =
 			summary.hasContext ||
 			(hasPlurals ? keyParts.length === 3 : keyParts.length === 2);
+		// `_zero` is i18next's exact `count === 0` match in every language
+		// (in addition to the Intl "zero" plural category), see
+		// https://www.i18next.com/translation-function/plurals
+		summary.hasZero = summary.hasZero || key.endsWith("_zero");
 		bundleSelectorsByRootKey.set(keyParts[0]!, summary);
 	}
 
 	for (const key in resource) {
 		const value = resource[key]!;
-		const { bundle, message, variant } = parseMessage({
+		const parsed = parseMessage({
 			namespace: args.namespace,
 			key,
 			value,
@@ -97,9 +102,9 @@ function parseFile(args: {
 			bundleSelectors: bundleSelectorsByRootKey.get(key.split("_")[0]!)!,
 			settings: args.settings,
 		});
-		bundles.push(bundle);
-		messages.push(message);
-		variants.push(variant);
+		bundles.push(parsed.bundle);
+		messages.push(parsed.message);
+		variants.push(...parsed.variants);
 	}
 
 	// order each bundle's variants most-specific-first (`friend_male_one` >
@@ -125,9 +130,17 @@ function parseMessage(args: {
 	key: string;
 	value: string;
 	locale: string;
-	bundleSelectors: { hasPlurals: boolean; hasContext: boolean };
+	bundleSelectors: {
+		hasPlurals: boolean;
+		hasContext: boolean;
+		hasZero: boolean;
+	};
 	settings?: PluginSettings;
-}): { bundle: BundleImport; message: MessageImport; variant: VariantImport } {
+}): {
+	bundle: BundleImport;
+	message: MessageImport;
+	variants: VariantImport[];
+} {
 	const pattern = parsePattern(args.value, args.settings);
 
 	// i18next suffixes keys with context or plurals
@@ -165,11 +178,15 @@ function parseMessage(args: {
 	const hasPlurals = testForPlurals(args.key);
 	// context is used see https://www.i18next.com/translation-function/context
 	const hasContext = hasPlurals ? keyParts.length === 3 : keyParts.length === 2;
+	const isZero = args.key.endsWith("_zero");
 
 	// base keys are the fallback for their context/plural siblings and get
 	// explicit catchall matches (see the per-bundle summary in parseFile).
-	const { hasPlurals: bundleHasPlurals, hasContext: bundleHasContext } =
-		args.bundleSelectors;
+	const {
+		hasPlurals: bundleHasPlurals,
+		hasContext: bundleHasContext,
+		hasZero: bundleHasZero,
+	} = args.bundleSelectors;
 
 	const selectors: Message["selectors"] = [];
 	const matches: Variant["matches"] = [];
@@ -196,6 +213,30 @@ function parseMessage(args: {
 					{
 						type: "catchall-match",
 						key: "context",
+					}
+		);
+	}
+
+	if (bundleHasZero) {
+		// `_zero` matches exactly `count === 0` in i18next, in every
+		// language — expressed as a selector on the `count` input itself,
+		// ahead of the plural category (the mechanism proposed in
+		// https://github.com/opral/paraglide-js/issues/552).
+		// https://github.com/opral/inlang/issues/4357
+		selectors.push({
+			type: "variable-reference",
+			name: "count",
+		});
+		matches.push(
+			isZero
+				? {
+						type: "literal-match",
+						key: "count",
+						value: "0",
+					}
+				: {
+						type: "catchall-match",
+						key: "count",
 					}
 		);
 	}
@@ -230,7 +271,8 @@ function parseMessage(args: {
 			name: "countPlural",
 		});
 		matches.push(
-			hasPlurals
+			// the exact `count = 0` variant matches any plural category
+			hasPlurals && !isZero
 				? {
 						type: "literal-match",
 						key: "countPlural",
@@ -247,9 +289,30 @@ function parseMessage(args: {
 	message.selectors = selectors;
 	variant.matches = matches;
 
+	const variants: VariantImport[] = [variant];
+
+	if (isZero) {
+		// `_zero` additionally serves as the Intl "zero" plural category key
+		// (selected for counts other than 0 in languages like Latvian), so a
+		// second variant keeps category-based selection working alongside
+		// the exact-0 match.
+		variants.push({
+			messageBundleId: bundleId,
+			messageLocale: args.locale,
+			matches: matches.map((match) =>
+				match.key === "count"
+					? { type: "catchall-match", key: "count" }
+					: match.key === "countPlural"
+						? { type: "literal-match", key: "countPlural", value: "zero" }
+						: match
+			),
+			pattern: pattern.result,
+		});
+	}
+
 	bundle.declarations = removeDuplicates(bundle.declarations);
 
-	return { bundle, message, variant };
+	return { bundle, message, variants };
 }
 
 function parsePattern(

--- a/packages/plugins/i18next/src/import-export/matchSpecificity.ts
+++ b/packages/plugins/i18next/src/import-export/matchSpecificity.ts
@@ -4,12 +4,15 @@ import type { Variant } from "@inlang/sdk";
  * Specificity of a variant's matches, following i18next's key resolution
  * order where the most specific key wins and the base key is the fallback:
  *
- * `key_context_plural` (3) > `key_context` (2) > `key_plural` (1) > `key` (0)
+ * `key_context_zero` (6) > `key_context_plural` (5) > `key_context` (4) >
+ * `key_zero` (2) > `key_plural` (1) > `key` (0)
  *
- * Catchall matches and absent matches do not add specificity.
+ * The exact `count = 0` match (`_zero`) outranks the plural category within
+ * the same context level, mirroring i18next's lookup order. Catchall matches
+ * and absent matches do not add specificity.
  *
  * https://www.i18next.com/translation-function/context
- * https://www.i18next.com/translation-function/context#combining-with-plurals
+ * https://www.i18next.com/translation-function/plurals
  */
 export function matchSpecificity(variant: {
 	matches?: Variant["matches"];
@@ -19,7 +22,8 @@ export function matchSpecificity(variant: {
 			(match) => match.type === "literal-match" && match.key === key
 		);
 	return (
-		(hasLiteralMatch("context") ? 2 : 0) +
+		(hasLiteralMatch("context") ? 4 : 0) +
+		(hasLiteralMatch("count") ? 2 : 0) +
 		(hasLiteralMatch("countPlural") ? 1 : 0)
 	);
 }

--- a/packages/plugins/i18next/src/import-export/roundtrip.test.ts
+++ b/packages/plugins/i18next/src/import-export/roundtrip.test.ts
@@ -2,7 +2,6 @@ import { expect, test } from "vitest";
 import { importFiles } from "./importFiles.js";
 import {
 	type Bundle,
-	type LiteralMatch,
 	type Message,
 	type Pattern,
 	type Variant,
@@ -271,7 +270,9 @@ test("keyContextCombinedWithPlurals", async () => {
 			{ type: "input-variable", name: "count" },
 		])
 	);
-	expect(imported.variants).lengthOf(8);
+	// 8 keys -> 10 variants: each `_zero` key imports as an exact
+	// `count = 0` match plus the Intl "zero" category fallback (#4357)
+	expect(imported.variants).lengthOf(10);
 });
 
 // a plural key set can ship a base key as the fallback for calls without a
@@ -443,7 +444,10 @@ test("keyPluralMultipleEgArabic", async () => {
 
 	expect(imported.bundles[0]?.id).toStrictEqual("keyPluralMultipleEgArabic");
 
+	// the `_zero` sibling makes `count` itself a selector ahead of the
+	// plural category, see https://github.com/opral/inlang/issues/4357
 	expect(imported?.messages[0]?.selectors).toStrictEqual([
+		{ type: "variable-reference", name: "count" },
 		{ type: "variable-reference", name: "countPlural" },
 	]);
 
@@ -472,28 +476,91 @@ test("keyPluralMultipleEgArabic", async () => {
 		])
 	);
 
-	const matches = imported.variants.map(
-		(variant) => (variant.matches?.[0] as LiteralMatch).value
-	);
-
-	expect(matches).toStrictEqual(["zero", "one", "two", "few", "many", "other"]);
+	// 6 keys -> 7 variants: `_zero` imports as an exact `count = 0` match
+	// (i18next prefers `_zero` at count 0 in every language) plus the Intl
+	// "zero" category fallback (e.g. Arabic, Latvian)
+	expect(
+		imported.variants.map((variant) =>
+			variant.matches
+				?.map((match) =>
+					match.type === "literal-match"
+						? `${match.key}=${match.value}`
+						: `${match.key}=*`
+				)
+				.join(" ")
+		)
+	).toStrictEqual([
+		"count=0 countPlural=*",
+		"count=* countPlural=zero",
+		"count=* countPlural=one",
+		"count=* countPlural=two",
+		"count=* countPlural=few",
+		"count=* countPlural=many",
+		"count=* countPlural=other",
+	]);
 	expect(imported.variants[0]?.pattern).toStrictEqual([
 		{ type: "text", value: "the plural form 0" },
 	]);
 	expect(imported.variants[1]?.pattern).toStrictEqual([
-		{ type: "text", value: "the plural form 1" },
+		{ type: "text", value: "the plural form 0" },
 	]);
 	expect(imported.variants[2]?.pattern).toStrictEqual([
-		{ type: "text", value: "the plural form 2" },
+		{ type: "text", value: "the plural form 1" },
 	]);
 	expect(imported.variants[3]?.pattern).toStrictEqual([
-		{ type: "text", value: "the plural form 3" },
+		{ type: "text", value: "the plural form 2" },
 	]);
 	expect(imported.variants[4]?.pattern).toStrictEqual([
-		{ type: "text", value: "the plural form 4" },
+		{ type: "text", value: "the plural form 3" },
 	]);
 	expect(imported.variants[5]?.pattern).toStrictEqual([
+		{ type: "text", value: "the plural form 4" },
+	]);
+	expect(imported.variants[6]?.pattern).toStrictEqual([
 		{ type: "text", value: "the plural form 5" },
+	]);
+});
+
+// `_zero` is i18next's exact `count === 0` match in every language — not just
+// the Intl "zero" plural category, which most languages never select
+// (https://www.i18next.com/translation-function/plurals). encoded via `count`
+// as a selector ahead of `countPlural`, exactly the mechanism proposed in
+// https://github.com/opral/paraglide-js/issues/552.
+// reproduces https://github.com/opral/inlang/issues/4357
+test("keyPluralWithZero", async () => {
+	const json = {
+		item_zero: "You have no items. Create your first now.",
+		item_one: "You have one item.",
+		item_other: "You have {{count}} items.",
+	};
+	const imported = await runImportFiles(json);
+	expect(await runExportFilesParsed(imported)).toStrictEqual(json);
+
+	expect(imported.bundles).lengthOf(1);
+	expect(imported.messages[0]?.selectors).toStrictEqual([
+		{ type: "variable-reference", name: "count" },
+		{ type: "variable-reference", name: "countPlural" },
+	]);
+
+	// the exact `count = 0` variant is the most specific and comes first;
+	// the Intl "zero" category fallback keeps languages like Latvian working
+	expect(imported.variants.map((variant) => variant.matches)).toStrictEqual([
+		[
+			{ type: "literal-match", key: "count", value: "0" },
+			{ type: "catchall-match", key: "countPlural" },
+		],
+		[
+			{ type: "catchall-match", key: "count" },
+			{ type: "literal-match", key: "countPlural", value: "zero" },
+		],
+		[
+			{ type: "catchall-match", key: "count" },
+			{ type: "literal-match", key: "countPlural", value: "one" },
+		],
+		[
+			{ type: "catchall-match", key: "count" },
+			{ type: "literal-match", key: "countPlural", value: "other" },
+		],
 	]);
 });
 


### PR DESCRIPTION
Fixes #4357

Follow-up to #4359/#4360, as discussed: plugin-side fixes come from the i18next side. This implements the mechanism @samuelstroschein proposed in opral/paraglide-js#552 — `count` itself as a selector ahead of the plural category.

## Problem

`_zero` was imported as a literal match on the Intl `countPlural` category, but in i18next `_zero` means "exact `count === 0`" — in **every** language ([`needsZeroSuffixLookup`](https://github.com/i18next/i18next/blob/6e086281e/src/Translator.js#L484)). Most languages never select the "zero" category, so the zero translation was dead code at `count = 0` (en: 0 → `other`, fr: 0 → `one`). Repro with side-by-side i18next 26.3.1 reference output in #4357.

## Change

- Bundles containing a `_zero` key declare `count` itself as a selector ahead of `countPlural`.
- `_zero` imports as **two variants**: the exact match (`count = "0"` with a `countPlural` catchall) plus the Intl "zero" category fallback (`countPlural = "zero"`). The fallback keeps languages whose cardinal rules genuinely use "zero" for other counts working (e.g. Latvian selects "zero" for 10, 20, …). Both serialize back to the same `_zero` key, so round-trips stay lossless.
- `matchSpecificity` ranks the exact-zero match above plural categories within the same context level, mirroring i18next's lookup order (`ctx_zero` > `ctx_plural` > `ctx` > `zero` > `plural` > `base`).
- Fixtures: new `keyPluralWithZero`; `keyPluralMultipleEgArabic` and `keyContextCombinedWithPlurals` updated where the imported shape is the point of the fix. First commit adds the fixtures red, second makes them green.

No compiler changes needed: input literal matches already compile numeric-tolerant (`i?.count === 0 || i?.count === "0"`, [match-literals.ts](https://github.com/opral/paraglide-js/blob/c5bd5dec52436269a7d461b913526072b94c8336/src/compiler/match-literals.ts#L4-L15)). Verified end-to-end with `@inlang/paraglide-js` 2.18.2: `m.item({ count: 0 })` now returns the `_zero` translation; counts 1/5 unchanged.

Backwards compatible: bundles without `_zero` keys import and export exactly as before.
