### PR TITLE
fix(plugin-i18next): parse ordinal plural keys as a countOrdinal selector

### DIFF
--- a/.changeset/i18next-ordinal-plurals.md
+++ b/.changeset/i18next-ordinal-plurals.md
@@ -1,0 +1,5 @@
+---
+"@inlang/plugin-i18next": patch
+---
+
+Parse i18next ordinal plural keys (`key_ordinal_one`, including context combinations like `key_male_ordinal_one`) as a dedicated `countOrdinal` selector backed by `Intl.PluralRules` with `{ type: "ordinal" }`, instead of misparsing them as context `"ordinal"` with cardinal categories. Compiled messages now produce "1st/2nd/3rd/4th" correctly from a plain `count` input, and context+ordinal keys — which previously lost their context and ordinal marker on export — round-trip unchanged. Fixes https://github.com/opral/inlang/issues/4358

--- a/.changeset/i18next-zero-count-selector.md
+++ b/.changeset/i18next-zero-count-selector.md
@@ -1,0 +1,5 @@
+---
+"@inlang/plugin-i18next": patch
+---
+
+Import `_zero` keys with i18next's actual semantics: an exact `count = 0` match (via a `count` selector ahead of the plural category) plus the Intl "zero" category fallback. Previously `_zero` was modeled only as the Intl plural category, which most languages never select — so the zero translation was dead code at `count = 0` in e.g. English and French. Fixes https://github.com/opral/inlang/issues/4357

--- a/packages/plugins/i18next/src/import-export/exportFiles.ts
+++ b/packages/plugins/i18next/src/import-export/exportFiles.ts
@@ -95,6 +95,9 @@ function serializeMessage(
 		const countMatch = variant.matches.find(
 			(match) => match.type === "literal-match" && match.key === "count"
 		) as LiteralMatch | undefined;
+		const ordinalMatch = variant.matches.find(
+			(match) => match.type === "literal-match" && match.key === "countOrdinal"
+		) as LiteralMatch | undefined;
 		const pluralMatch = variant.matches.find(
 			(match) => match.type === "literal-match" && match.key === "countPlural"
 		) as LiteralMatch | undefined;
@@ -113,6 +116,10 @@ function serializeMessage(
 			// `_zero` suffix (its Intl category fallback variant derives the
 			// same key), see https://github.com/opral/inlang/issues/4357
 			key += "_zero";
+		} else if (ordinalMatch !== undefined) {
+			// ordinal plurals use the reserved `_ordinal_<category>` suffix,
+			// see https://github.com/opral/inlang/issues/4358
+			key += `_ordinal_${ordinalMatch.value}`;
 		} else if (pluralMatch !== undefined) {
 			key += `_${pluralMatch.value}`;
 		}

--- a/packages/plugins/i18next/src/import-export/exportFiles.ts
+++ b/packages/plugins/i18next/src/import-export/exportFiles.ts
@@ -92,6 +92,9 @@ function serializeMessage(
 		const contextMatch = variant.matches.find(
 			(match) => match.type === "literal-match" && match.key === "context"
 		) as LiteralMatch | undefined;
+		const countMatch = variant.matches.find(
+			(match) => match.type === "literal-match" && match.key === "count"
+		) as LiteralMatch | undefined;
 		const pluralMatch = variant.matches.find(
 			(match) => match.type === "literal-match" && match.key === "countPlural"
 		) as LiteralMatch | undefined;
@@ -105,7 +108,12 @@ function serializeMessage(
 		if (contextMatch !== undefined) {
 			key += `_${contextMatch.value}`;
 		}
-		if (pluralMatch !== undefined) {
+		if (countMatch?.value === "0") {
+			// the exact `count = 0` match serializes back to i18next's
+			// `_zero` suffix (its Intl category fallback variant derives the
+			// same key), see https://github.com/opral/inlang/issues/4357
+			key += "_zero";
+		} else if (pluralMatch !== undefined) {
 			key += `_${pluralMatch.value}`;
 		}
 		result.push({ key, value: pattern, locale: message.locale });

--- a/packages/plugins/i18next/src/import-export/importFiles.ts
+++ b/packages/plugins/i18next/src/import-export/importFiles.ts
@@ -71,7 +71,7 @@ function parseFile(args: {
 	// https://www.i18next.com/translation-function/context#combining-with-plurals
 	const bundleSelectorsByRootKey = new Map<
 		string,
-		{ hasPlurals: boolean; hasContext: boolean }
+		{ hasPlurals: boolean; hasContext: boolean; hasZero: boolean }
 	>();
 	for (const key in resource) {
 		const keyParts = key.split("_");
@@ -79,17 +79,22 @@ function parseFile(args: {
 		const summary = bundleSelectorsByRootKey.get(keyParts[0]!) ?? {
 			hasPlurals: false,
 			hasContext: false,
+			hasZero: false,
 		};
 		summary.hasPlurals = summary.hasPlurals || hasPlurals;
 		summary.hasContext =
 			summary.hasContext ||
 			(hasPlurals ? keyParts.length === 3 : keyParts.length === 2);
+		// `_zero` is i18next's exact `count === 0` match in every language
+		// (in addition to the Intl "zero" plural category), see
+		// https://www.i18next.com/translation-function/plurals
+		summary.hasZero = summary.hasZero || key.endsWith("_zero");
 		bundleSelectorsByRootKey.set(keyParts[0]!, summary);
 	}
 
 	for (const key in resource) {
 		const value = resource[key]!;
-		const { bundle, message, variant } = parseMessage({
+		const parsed = parseMessage({
 			namespace: args.namespace,
 			key,
 			value,
@@ -97,9 +102,9 @@ function parseFile(args: {
 			bundleSelectors: bundleSelectorsByRootKey.get(key.split("_")[0]!)!,
 			settings: args.settings,
 		});
-		bundles.push(bundle);
-		messages.push(message);
-		variants.push(variant);
+		bundles.push(parsed.bundle);
+		messages.push(parsed.message);
+		variants.push(...parsed.variants);
 	}
 
 	// order each bundle's variants most-specific-first (`friend_male_one` >
@@ -125,9 +130,17 @@ function parseMessage(args: {
 	key: string;
 	value: string;
 	locale: string;
-	bundleSelectors: { hasPlurals: boolean; hasContext: boolean };
+	bundleSelectors: {
+		hasPlurals: boolean;
+		hasContext: boolean;
+		hasZero: boolean;
+	};
 	settings?: PluginSettings;
-}): { bundle: BundleImport; message: MessageImport; variant: VariantImport } {
+}): {
+	bundle: BundleImport;
+	message: MessageImport;
+	variants: VariantImport[];
+} {
 	const pattern = parsePattern(args.value, args.settings);
 
 	// i18next suffixes keys with context or plurals
@@ -165,11 +178,15 @@ function parseMessage(args: {
 	const hasPlurals = testForPlurals(args.key);
 	// context is used see https://www.i18next.com/translation-function/context
 	const hasContext = hasPlurals ? keyParts.length === 3 : keyParts.length === 2;
+	const isZero = args.key.endsWith("_zero");
 
 	// base keys are the fallback for their context/plural siblings and get
 	// explicit catchall matches (see the per-bundle summary in parseFile).
-	const { hasPlurals: bundleHasPlurals, hasContext: bundleHasContext } =
-		args.bundleSelectors;
+	const {
+		hasPlurals: bundleHasPlurals,
+		hasContext: bundleHasContext,
+		hasZero: bundleHasZero,
+	} = args.bundleSelectors;
 
 	const selectors: Message["selectors"] = [];
 	const matches: Variant["matches"] = [];
@@ -196,6 +213,30 @@ function parseMessage(args: {
 					{
 						type: "catchall-match",
 						key: "context",
+					}
+		);
+	}
+
+	if (bundleHasZero) {
+		// `_zero` matches exactly `count === 0` in i18next, in every
+		// language — expressed as a selector on the `count` input itself,
+		// ahead of the plural category (the mechanism proposed in
+		// https://github.com/opral/paraglide-js/issues/552).
+		// https://github.com/opral/inlang/issues/4357
+		selectors.push({
+			type: "variable-reference",
+			name: "count",
+		});
+		matches.push(
+			isZero
+				? {
+						type: "literal-match",
+						key: "count",
+						value: "0",
+					}
+				: {
+						type: "catchall-match",
+						key: "count",
 					}
 		);
 	}
@@ -230,7 +271,8 @@ function parseMessage(args: {
 			name: "countPlural",
 		});
 		matches.push(
-			hasPlurals
+			// the exact `count = 0` variant matches any plural category
+			hasPlurals && !isZero
 				? {
 						type: "literal-match",
 						key: "countPlural",
@@ -247,9 +289,30 @@ function parseMessage(args: {
 	message.selectors = selectors;
 	variant.matches = matches;
 
+	const variants: VariantImport[] = [variant];
+
+	if (isZero) {
+		// `_zero` additionally serves as the Intl "zero" plural category key
+		// (selected for counts other than 0 in languages like Latvian), so a
+		// second variant keeps category-based selection working alongside
+		// the exact-0 match.
+		variants.push({
+			messageBundleId: bundleId,
+			messageLocale: args.locale,
+			matches: matches.map((match) =>
+				match.key === "count"
+					? { type: "catchall-match", key: "count" }
+					: match.key === "countPlural"
+						? { type: "literal-match", key: "countPlural", value: "zero" }
+						: match
+			),
+			pattern: pattern.result,
+		});
+	}
+
 	bundle.declarations = removeDuplicates(bundle.declarations);
 
-	return { bundle, message, variant };
+	return { bundle, message, variants };
 }
 
 function parsePattern(

--- a/packages/plugins/i18next/src/import-export/importFiles.ts
+++ b/packages/plugins/i18next/src/import-export/importFiles.ts
@@ -79,33 +79,19 @@ function parseFile(args: {
 		}
 	>();
 	for (const key in resource) {
-		const keyParts = key.split("_");
-		const hasPluralSuffix = testForPlurals(key);
-		// i18next ordinal plurals use the reserved `_ordinal_<category>`
-		// suffix, optionally combined with context:
-		// "race_male_ordinal_one" -> ["race", "male", "ordinal", "one"]
-		// https://www.i18next.com/translation-function/plurals#ordinal-plurals
-		const isOrdinal = hasPluralSuffix && keyParts.at(-2) === "ordinal";
-		const summary = bundleSelectorsByRootKey.get(keyParts[0]!) ?? {
+		const { rootKey, isOrdinal, isCardinalPlural, isZero, hasContext } =
+			classifyKey(key);
+		const summary = bundleSelectorsByRootKey.get(rootKey) ?? {
 			hasPlurals: false,
 			hasContext: false,
 			hasZero: false,
 			hasOrdinal: false,
 		};
-		summary.hasPlurals = summary.hasPlurals || (hasPluralSuffix && !isOrdinal);
+		summary.hasPlurals = summary.hasPlurals || isCardinalPlural;
 		summary.hasOrdinal = summary.hasOrdinal || isOrdinal;
-		summary.hasContext =
-			summary.hasContext ||
-			(isOrdinal
-				? keyParts.length === 4
-				: hasPluralSuffix
-					? keyParts.length === 3
-					: keyParts.length === 2);
-		// `_zero` is i18next's exact `count === 0` match in every language
-		// (in addition to the Intl "zero" plural category) — cardinal only,
-		// see https://www.i18next.com/translation-function/plurals
-		summary.hasZero = summary.hasZero || (!isOrdinal && key.endsWith("_zero"));
-		bundleSelectorsByRootKey.set(keyParts[0]!, summary);
+		summary.hasContext = summary.hasContext || hasContext;
+		summary.hasZero = summary.hasZero || isZero;
+		bundleSelectorsByRootKey.set(rootKey, summary);
 	}
 
 	for (const key in resource) {
@@ -162,7 +148,13 @@ function parseMessage(args: {
 
 	// i18next suffixes keys with context or plurals
 	// "friend_female_one" -> "friend"
-	const keyParts = args.key.split("_");
+	const {
+		keyParts,
+		isOrdinal,
+		isCardinalPlural: hasPlurals,
+		isZero,
+		hasContext,
+	} = classifyKey(args.key);
 	let bundleId = keyParts[0]!;
 	if (args.namespace) {
 		// following i18next's convention
@@ -190,20 +182,6 @@ function parseMessage(args: {
 		matches: [],
 		pattern: pattern.result,
 	};
-
-	// plurals, see https://www.i18next.com/misc/json-format#i18next-json-v4
-	const hasPluralSuffix = testForPlurals(args.key);
-	// ordinal plurals use the reserved `_ordinal_<category>` suffix, see
-	// https://www.i18next.com/translation-function/plurals#ordinal-plurals
-	const isOrdinal = hasPluralSuffix && keyParts.at(-2) === "ordinal";
-	const hasPlurals = hasPluralSuffix && !isOrdinal;
-	// context is used see https://www.i18next.com/translation-function/context
-	const hasContext = isOrdinal
-		? keyParts.length === 4
-		: hasPluralSuffix
-			? keyParts.length === 3
-			: keyParts.length === 2;
-	const isZero = !isOrdinal && args.key.endsWith("_zero");
 
 	// base keys are the fallback for their context/plural siblings and get
 	// explicit catchall matches (see the per-bundle summary in parseFile).
@@ -525,3 +503,45 @@ const testForPlurals = (key: string) =>
 	key.endsWith("_few") ||
 	key.endsWith("_many") ||
 	key.endsWith("_other");
+
+/**
+ * Classifies an i18next key by its suffixes — the single source of truth for
+ * the per-bundle summary in `parseFile` and the per-key parsing in
+ * `parseMessage`.
+ *
+ * - cardinal plural categories: `key_one`, `key_other`, ...
+ *   (https://www.i18next.com/misc/json-format#i18next-json-v4)
+ * - ordinal plurals use the reserved `_ordinal_<category>` suffix:
+ *   `key_ordinal_one`
+ *   (https://www.i18next.com/translation-function/plurals#ordinal-plurals)
+ * - `_zero` is i18next's exact `count === 0` match in every language, in
+ *   addition to the Intl "zero" plural category — cardinal only
+ *   (https://www.i18next.com/translation-function/plurals)
+ * - context adds one segment between the root key and the plural suffix:
+ *   `key_male`, `key_male_one`, `key_male_ordinal_one`
+ *   (https://www.i18next.com/translation-function/context)
+ */
+function classifyKey(key: string): {
+	keyParts: string[];
+	rootKey: string;
+	isOrdinal: boolean;
+	isCardinalPlural: boolean;
+	isZero: boolean;
+	hasContext: boolean;
+} {
+	const keyParts = key.split("_");
+	const hasPluralSuffix = testForPlurals(key);
+	const isOrdinal = hasPluralSuffix && keyParts.at(-2) === "ordinal";
+	return {
+		keyParts,
+		rootKey: keyParts[0]!,
+		isOrdinal,
+		isCardinalPlural: hasPluralSuffix && !isOrdinal,
+		isZero: !isOrdinal && key.endsWith("_zero"),
+		hasContext: isOrdinal
+			? keyParts.length === 4
+			: hasPluralSuffix
+				? keyParts.length === 3
+				: keyParts.length === 2,
+	};
+}

--- a/packages/plugins/i18next/src/import-export/importFiles.ts
+++ b/packages/plugins/i18next/src/import-export/importFiles.ts
@@ -71,24 +71,40 @@ function parseFile(args: {
 	// https://www.i18next.com/translation-function/context#combining-with-plurals
 	const bundleSelectorsByRootKey = new Map<
 		string,
-		{ hasPlurals: boolean; hasContext: boolean; hasZero: boolean }
+		{
+			hasPlurals: boolean;
+			hasContext: boolean;
+			hasZero: boolean;
+			hasOrdinal: boolean;
+		}
 	>();
 	for (const key in resource) {
 		const keyParts = key.split("_");
-		const hasPlurals = testForPlurals(key);
+		const hasPluralSuffix = testForPlurals(key);
+		// i18next ordinal plurals use the reserved `_ordinal_<category>`
+		// suffix, optionally combined with context:
+		// "race_male_ordinal_one" -> ["race", "male", "ordinal", "one"]
+		// https://www.i18next.com/translation-function/plurals#ordinal-plurals
+		const isOrdinal = hasPluralSuffix && keyParts.at(-2) === "ordinal";
 		const summary = bundleSelectorsByRootKey.get(keyParts[0]!) ?? {
 			hasPlurals: false,
 			hasContext: false,
 			hasZero: false,
+			hasOrdinal: false,
 		};
-		summary.hasPlurals = summary.hasPlurals || hasPlurals;
+		summary.hasPlurals = summary.hasPlurals || (hasPluralSuffix && !isOrdinal);
+		summary.hasOrdinal = summary.hasOrdinal || isOrdinal;
 		summary.hasContext =
 			summary.hasContext ||
-			(hasPlurals ? keyParts.length === 3 : keyParts.length === 2);
+			(isOrdinal
+				? keyParts.length === 4
+				: hasPluralSuffix
+					? keyParts.length === 3
+					: keyParts.length === 2);
 		// `_zero` is i18next's exact `count === 0` match in every language
-		// (in addition to the Intl "zero" plural category), see
-		// https://www.i18next.com/translation-function/plurals
-		summary.hasZero = summary.hasZero || key.endsWith("_zero");
+		// (in addition to the Intl "zero" plural category) — cardinal only,
+		// see https://www.i18next.com/translation-function/plurals
+		summary.hasZero = summary.hasZero || (!isOrdinal && key.endsWith("_zero"));
 		bundleSelectorsByRootKey.set(keyParts[0]!, summary);
 	}
 
@@ -134,6 +150,7 @@ function parseMessage(args: {
 		hasPlurals: boolean;
 		hasContext: boolean;
 		hasZero: boolean;
+		hasOrdinal: boolean;
 	};
 	settings?: PluginSettings;
 }): {
@@ -175,10 +192,18 @@ function parseMessage(args: {
 	};
 
 	// plurals, see https://www.i18next.com/misc/json-format#i18next-json-v4
-	const hasPlurals = testForPlurals(args.key);
+	const hasPluralSuffix = testForPlurals(args.key);
+	// ordinal plurals use the reserved `_ordinal_<category>` suffix, see
+	// https://www.i18next.com/translation-function/plurals#ordinal-plurals
+	const isOrdinal = hasPluralSuffix && keyParts.at(-2) === "ordinal";
+	const hasPlurals = hasPluralSuffix && !isOrdinal;
 	// context is used see https://www.i18next.com/translation-function/context
-	const hasContext = hasPlurals ? keyParts.length === 3 : keyParts.length === 2;
-	const isZero = args.key.endsWith("_zero");
+	const hasContext = isOrdinal
+		? keyParts.length === 4
+		: hasPluralSuffix
+			? keyParts.length === 3
+			: keyParts.length === 2;
+	const isZero = !isOrdinal && args.key.endsWith("_zero");
 
 	// base keys are the fallback for their context/plural siblings and get
 	// explicit catchall matches (see the per-bundle summary in parseFile).
@@ -186,6 +211,7 @@ function parseMessage(args: {
 		hasPlurals: bundleHasPlurals,
 		hasContext: bundleHasContext,
 		hasZero: bundleHasZero,
+		hasOrdinal: bundleHasOrdinal,
 	} = args.bundleSelectors;
 
 	const selectors: Message["selectors"] = [];
@@ -237,6 +263,52 @@ function parseMessage(args: {
 				: {
 						type: "catchall-match",
 						key: "count",
+					}
+		);
+	}
+
+	if (bundleHasOrdinal) {
+		bundle.declarations.push({
+			type: "input-variable",
+			name: "count",
+		});
+		bundle.declarations.push({
+			type: "local-variable",
+			name: "countOrdinal",
+			value: {
+				type: "expression",
+				arg: {
+					type: "variable-reference",
+					name: "count",
+				},
+				annotation: {
+					type: "function-reference",
+					name: "plural",
+					options: [
+						{
+							name: "type",
+							value: { type: "literal", value: "ordinal" },
+						},
+					],
+				},
+			},
+		});
+		selectors.push({
+			type: "variable-reference",
+			name: "countOrdinal",
+		});
+		matches.push(
+			isOrdinal
+				? {
+						type: "literal-match",
+						key: "countOrdinal",
+						value: keyParts.at(-1)!,
+					}
+				: // cardinal/zero/base variants are the fallback for ordinal
+					// lookups of the same key
+					{
+						type: "catchall-match",
+						key: "countOrdinal",
 					}
 		);
 	}

--- a/packages/plugins/i18next/src/import-export/matchSpecificity.ts
+++ b/packages/plugins/i18next/src/import-export/matchSpecificity.ts
@@ -4,12 +4,17 @@ import type { Variant } from "@inlang/sdk";
  * Specificity of a variant's matches, following i18next's key resolution
  * order where the most specific key wins and the base key is the fallback:
  *
- * `key_context_zero` (6) > `key_context_plural` (5) > `key_context` (4) >
- * `key_zero` (2) > `key_plural` (1) > `key` (0)
+ * `key_context_zero` (6) > `key_context_plural` / `key_context_ordinal_*` (5) >
+ * `key_context` (4) > `key_zero` (2) > `key_plural` / `key_ordinal_*` (1) >
+ * `key` (0)
  *
  * The exact `count = 0` match (`_zero`) outranks the plural category within
- * the same context level, mirroring i18next's lookup order. Catchall matches
- * and absent matches do not add specificity.
+ * the same context level, mirroring i18next's lookup order. Cardinal
+ * (`countPlural`) and ordinal (`countOrdinal`) literal matches carry the same
+ * weight — in i18next they are mutually exclusive lookups (`ordinal: true`) —
+ * and ties keep their stable import order, i.e. cardinal variants come first
+ * in mixed bundles. Catchall matches and absent matches do not add
+ * specificity.
  *
  * https://www.i18next.com/translation-function/context
  * https://www.i18next.com/translation-function/plurals

--- a/packages/plugins/i18next/src/import-export/matchSpecificity.ts
+++ b/packages/plugins/i18next/src/import-export/matchSpecificity.ts
@@ -4,12 +4,15 @@ import type { Variant } from "@inlang/sdk";
  * Specificity of a variant's matches, following i18next's key resolution
  * order where the most specific key wins and the base key is the fallback:
  *
- * `key_context_plural` (3) > `key_context` (2) > `key_plural` (1) > `key` (0)
+ * `key_context_zero` (6) > `key_context_plural` (5) > `key_context` (4) >
+ * `key_zero` (2) > `key_plural` (1) > `key` (0)
  *
- * Catchall matches and absent matches do not add specificity.
+ * The exact `count = 0` match (`_zero`) outranks the plural category within
+ * the same context level, mirroring i18next's lookup order. Catchall matches
+ * and absent matches do not add specificity.
  *
  * https://www.i18next.com/translation-function/context
- * https://www.i18next.com/translation-function/context#combining-with-plurals
+ * https://www.i18next.com/translation-function/plurals
  */
 export function matchSpecificity(variant: {
 	matches?: Variant["matches"];
@@ -19,7 +22,8 @@ export function matchSpecificity(variant: {
 			(match) => match.type === "literal-match" && match.key === key
 		);
 	return (
-		(hasLiteralMatch("context") ? 2 : 0) +
+		(hasLiteralMatch("context") ? 4 : 0) +
+		(hasLiteralMatch("count") ? 2 : 0) +
 		(hasLiteralMatch("countPlural") ? 1 : 0)
 	);
 }

--- a/packages/plugins/i18next/src/import-export/matchSpecificity.ts
+++ b/packages/plugins/i18next/src/import-export/matchSpecificity.ts
@@ -24,6 +24,7 @@ export function matchSpecificity(variant: {
 	return (
 		(hasLiteralMatch("context") ? 4 : 0) +
 		(hasLiteralMatch("count") ? 2 : 0) +
+		(hasLiteralMatch("countOrdinal") ? 1 : 0) +
 		(hasLiteralMatch("countPlural") ? 1 : 0)
 	);
 }

--- a/packages/plugins/i18next/src/import-export/roundtrip.test.ts
+++ b/packages/plugins/i18next/src/import-export/roundtrip.test.ts
@@ -170,10 +170,12 @@ test("keyMarkupNumericTransTags", async () => {
 
 test("keyMarkupMixedNamedAndNumericTransTags", async () => {
 	const imported = await runImportFiles({
-		keyMarkupMixedNamedAndNumericTransTags: "A <0>nested <b>tag</b></0> <icon/>",
+		keyMarkupMixedNamedAndNumericTransTags:
+			"A <0>nested <b>tag</b></0> <icon/>",
 	});
 	expect(await runExportFilesParsed(imported)).toStrictEqual({
-		keyMarkupMixedNamedAndNumericTransTags: "A <0>nested <b>tag</b></0> <icon/>",
+		keyMarkupMixedNamedAndNumericTransTags:
+			"A <0>nested <b>tag</b></0> <icon/>",
 	});
 
 	expect(imported.bundles[0]?.declarations).toStrictEqual([]);
@@ -560,6 +562,131 @@ test("keyPluralWithZero", async () => {
 		[
 			{ type: "catchall-match", key: "count" },
 			{ type: "literal-match", key: "countPlural", value: "other" },
+		],
+	]);
+});
+
+// i18next ordinal plurals use the reserved `_ordinal_<category>` suffix and
+// resolve with ordinal Intl.PluralRules ("1st", "2nd", ...), see
+// https://www.i18next.com/translation-function/plurals#ordinal-plurals
+// reproduces https://github.com/opral/inlang/issues/4358 (currently parsed
+// as context "ordinal" with cardinal categories)
+test("keyOrdinal", async () => {
+	const json = {
+		place_ordinal_one: "{{count}}st place",
+		place_ordinal_two: "{{count}}nd place",
+		place_ordinal_few: "{{count}}rd place",
+		place_ordinal_other: "{{count}}th place",
+	};
+	const imported = await runImportFiles(json);
+	expect(await runExportFilesParsed(imported)).toStrictEqual(json);
+
+	expect(imported.bundles).lengthOf(1);
+	expect(imported.bundles[0]?.id).toStrictEqual("place");
+
+	expect(imported.bundles[0]?.declarations).toStrictEqual(
+		expect.arrayContaining([
+			{ type: "input-variable", name: "count" },
+			expect.objectContaining({
+				type: "local-variable",
+				name: "countOrdinal",
+				value: {
+					type: "expression",
+					arg: { type: "variable-reference", name: "count" },
+					annotation: {
+						type: "function-reference",
+						name: "plural",
+						options: [
+							{ name: "type", value: { type: "literal", value: "ordinal" } },
+						],
+					},
+				},
+			}),
+		])
+	);
+	// ordinal keys must not be parsed as context "ordinal"
+	expect(
+		(imported.bundles[0]?.declarations ?? []).some(
+			(declaration) => declaration.name === "context"
+		)
+	).toBe(false);
+
+	expect(imported.messages[0]?.selectors).toStrictEqual([
+		{ type: "variable-reference", name: "countOrdinal" },
+	]);
+
+	expect(imported.variants.map((variant) => variant.matches)).toStrictEqual([
+		[{ type: "literal-match", key: "countOrdinal", value: "one" }],
+		[{ type: "literal-match", key: "countOrdinal", value: "two" }],
+		[{ type: "literal-match", key: "countOrdinal", value: "few" }],
+		[{ type: "literal-match", key: "countOrdinal", value: "other" }],
+	]);
+});
+
+// context combines with ordinal plurals the same way as with cardinal ones
+// (`contextKey + pluralSuffix` in i18next's lookup).
+// reproduces https://github.com/opral/inlang/issues/4358 — on main these
+// keys lose their context AND ordinal marker on export (`race_one`)
+test("keyContextWithOrdinal", async () => {
+	const json = {
+		race_male_ordinal_one: "his {{count}}st race",
+		race_male_ordinal_other: "his {{count}}th race",
+	};
+	const imported = await runImportFiles(json);
+	expect(await runExportFilesParsed(imported)).toStrictEqual(json);
+
+	expect(imported.bundles[0]?.id).toStrictEqual("race");
+	expect(imported.messages[0]?.selectors).toStrictEqual([
+		{ type: "variable-reference", name: "context" },
+		{ type: "variable-reference", name: "countOrdinal" },
+	]);
+	expect(imported.variants.map((variant) => variant.matches)).toStrictEqual([
+		[
+			{ type: "literal-match", key: "context", value: "male" },
+			{ type: "literal-match", key: "countOrdinal", value: "one" },
+		],
+		[
+			{ type: "literal-match", key: "context", value: "male" },
+			{ type: "literal-match", key: "countOrdinal", value: "other" },
+		],
+	]);
+});
+
+// cardinal and ordinal forms of the same key coexist (i18next picks by the
+// `ordinal: true` option); cardinal variants get a catchall on countOrdinal
+// and vice versa. cardinal variants come first (file order), so calls
+// without a disambiguating input resolve cardinal — matching i18next's
+// default.
+test("keyPluralCardinalAndOrdinalMixed", async () => {
+	const json = {
+		race_one: "{{count}} race",
+		race_other: "{{count}} races",
+		race_ordinal_one: "{{count}}st race",
+		race_ordinal_other: "{{count}}th race",
+	};
+	const imported = await runImportFiles(json);
+	expect(await runExportFilesParsed(imported)).toStrictEqual(json);
+
+	expect(imported.messages[0]?.selectors).toStrictEqual([
+		{ type: "variable-reference", name: "countOrdinal" },
+		{ type: "variable-reference", name: "countPlural" },
+	]);
+	expect(imported.variants.map((variant) => variant.matches)).toStrictEqual([
+		[
+			{ type: "catchall-match", key: "countOrdinal" },
+			{ type: "literal-match", key: "countPlural", value: "one" },
+		],
+		[
+			{ type: "catchall-match", key: "countOrdinal" },
+			{ type: "literal-match", key: "countPlural", value: "other" },
+		],
+		[
+			{ type: "literal-match", key: "countOrdinal", value: "one" },
+			{ type: "catchall-match", key: "countPlural" },
+		],
+		[
+			{ type: "literal-match", key: "countOrdinal", value: "other" },
+			{ type: "catchall-match", key: "countPlural" },
 		],
 	]);
 });

--- a/packages/plugins/i18next/src/import-export/roundtrip.test.ts
+++ b/packages/plugins/i18next/src/import-export/roundtrip.test.ts
@@ -2,7 +2,6 @@ import { expect, test } from "vitest";
 import { importFiles } from "./importFiles.js";
 import {
 	type Bundle,
-	type LiteralMatch,
 	type Message,
 	type Pattern,
 	type Variant,
@@ -271,7 +270,9 @@ test("keyContextCombinedWithPlurals", async () => {
 			{ type: "input-variable", name: "count" },
 		])
 	);
-	expect(imported.variants).lengthOf(8);
+	// 8 keys -> 10 variants: each `_zero` key imports as an exact
+	// `count = 0` match plus the Intl "zero" category fallback (#4357)
+	expect(imported.variants).lengthOf(10);
 });
 
 // a plural key set can ship a base key as the fallback for calls without a
@@ -443,7 +444,10 @@ test("keyPluralMultipleEgArabic", async () => {
 
 	expect(imported.bundles[0]?.id).toStrictEqual("keyPluralMultipleEgArabic");
 
+	// the `_zero` sibling makes `count` itself a selector ahead of the
+	// plural category, see https://github.com/opral/inlang/issues/4357
 	expect(imported?.messages[0]?.selectors).toStrictEqual([
+		{ type: "variable-reference", name: "count" },
 		{ type: "variable-reference", name: "countPlural" },
 	]);
 
@@ -472,28 +476,91 @@ test("keyPluralMultipleEgArabic", async () => {
 		])
 	);
 
-	const matches = imported.variants.map(
-		(variant) => (variant.matches?.[0] as LiteralMatch).value
-	);
-
-	expect(matches).toStrictEqual(["zero", "one", "two", "few", "many", "other"]);
+	// 6 keys -> 7 variants: `_zero` imports as an exact `count = 0` match
+	// (i18next prefers `_zero` at count 0 in every language) plus the Intl
+	// "zero" category fallback (e.g. Arabic, Latvian)
+	expect(
+		imported.variants.map((variant) =>
+			variant.matches
+				?.map((match) =>
+					match.type === "literal-match"
+						? `${match.key}=${match.value}`
+						: `${match.key}=*`
+				)
+				.join(" ")
+		)
+	).toStrictEqual([
+		"count=0 countPlural=*",
+		"count=* countPlural=zero",
+		"count=* countPlural=one",
+		"count=* countPlural=two",
+		"count=* countPlural=few",
+		"count=* countPlural=many",
+		"count=* countPlural=other",
+	]);
 	expect(imported.variants[0]?.pattern).toStrictEqual([
 		{ type: "text", value: "the plural form 0" },
 	]);
 	expect(imported.variants[1]?.pattern).toStrictEqual([
-		{ type: "text", value: "the plural form 1" },
+		{ type: "text", value: "the plural form 0" },
 	]);
 	expect(imported.variants[2]?.pattern).toStrictEqual([
-		{ type: "text", value: "the plural form 2" },
+		{ type: "text", value: "the plural form 1" },
 	]);
 	expect(imported.variants[3]?.pattern).toStrictEqual([
-		{ type: "text", value: "the plural form 3" },
+		{ type: "text", value: "the plural form 2" },
 	]);
 	expect(imported.variants[4]?.pattern).toStrictEqual([
-		{ type: "text", value: "the plural form 4" },
+		{ type: "text", value: "the plural form 3" },
 	]);
 	expect(imported.variants[5]?.pattern).toStrictEqual([
+		{ type: "text", value: "the plural form 4" },
+	]);
+	expect(imported.variants[6]?.pattern).toStrictEqual([
 		{ type: "text", value: "the plural form 5" },
+	]);
+});
+
+// `_zero` is i18next's exact `count === 0` match in every language — not just
+// the Intl "zero" plural category, which most languages never select
+// (https://www.i18next.com/translation-function/plurals). encoded via `count`
+// as a selector ahead of `countPlural`, exactly the mechanism proposed in
+// https://github.com/opral/paraglide-js/issues/552.
+// reproduces https://github.com/opral/inlang/issues/4357
+test("keyPluralWithZero", async () => {
+	const json = {
+		item_zero: "You have no items. Create your first now.",
+		item_one: "You have one item.",
+		item_other: "You have {{count}} items.",
+	};
+	const imported = await runImportFiles(json);
+	expect(await runExportFilesParsed(imported)).toStrictEqual(json);
+
+	expect(imported.bundles).lengthOf(1);
+	expect(imported.messages[0]?.selectors).toStrictEqual([
+		{ type: "variable-reference", name: "count" },
+		{ type: "variable-reference", name: "countPlural" },
+	]);
+
+	// the exact `count = 0` variant is the most specific and comes first;
+	// the Intl "zero" category fallback keeps languages like Latvian working
+	expect(imported.variants.map((variant) => variant.matches)).toStrictEqual([
+		[
+			{ type: "literal-match", key: "count", value: "0" },
+			{ type: "catchall-match", key: "countPlural" },
+		],
+		[
+			{ type: "catchall-match", key: "count" },
+			{ type: "literal-match", key: "countPlural", value: "zero" },
+		],
+		[
+			{ type: "catchall-match", key: "count" },
+			{ type: "literal-match", key: "countPlural", value: "one" },
+		],
+		[
+			{ type: "catchall-match", key: "count" },
+			{ type: "literal-match", key: "countPlural", value: "other" },
+		],
 	]);
 });
 


### PR DESCRIPTION
Fixes #4358

Stacked on #4363 (the `_zero` fix — same classification code paths). Follow-up to #4359/#4360, as discussed: plugin-side fixes come from the i18next side.

## Problem

`place_ordinal_one` was parsed by the `_`-split heuristic as context `"ordinal"` combined with a *cardinal* plural: the generated message demanded a `context: "ordinal"` input, matched on cardinal categories (`"2th place"`), and the natural call fell through to the raw key. Worse: context+ordinal keys (`race_male_ordinal_one`) lost both their context and the ordinal marker on export (they came back as `race_one`) — silent data loss. Repro with side-by-side i18next 26.3.1 reference output in #4358.

## Change

- Keys with the reserved `_ordinal_<category>` suffix — optionally combined with context (`race_male_ordinal_one`) — import against a dedicated `countOrdinal` selector declared as `local countOrdinal = count: plural type=ordinal`. No compiler changes needed: `registry.plural` already forwards its options to `Intl.PluralRules` (cf. opral/paraglide-js#567).
- Cardinal/zero/base variants of the same bundle get a catchall on `countOrdinal` and vice versa. In mixed cardinal+ordinal bundles, cardinal variants come first, so calls resolve cardinal by default — matching i18next, where ordinal lookup requires the explicit `ordinal: true` option. (A compiled message function has no equivalent of that flag; if both forms of one key must select differently at runtime, that's a model limit worth a separate discussion — noted in #4358.)
- Export serializes `countOrdinal` literals back to `_ordinal_<category>`. A genuine context named `"ordinal"` without a trailing plural category (`friend_ordinal`) stays a context, since i18next only reserves the exact `_ordinal_<category>` shape.
- Fixtures: `keyOrdinal`, `keyContextWithOrdinal` (demonstrates the export data loss on main), `keyPluralCardinalAndOrdinalMixed`. First commit adds them red, second makes them green.

Verified end-to-end with `@inlang/paraglide-js` 2.18.2: `m.place({ count: 1 })` → `"1st place"`, `count: 2` → `"2nd place"`, `count: 3` → `"3rd place"`, `count: 11` → `"11th place"`; the generated code uses `registry.plural(locale, count, { type: "ordinal" })` and the bogus `context: "ordinal"` input is gone.
