### PR TITLE
Fix saveProjectToDirectory for namespaced pathPattern objects

### DIFF
--- a/.changeset/wild-poets-clap.md
+++ b/.changeset/wild-poets-clap.md
@@ -1,0 +1,10 @@
+---
+"@inlang/sdk": minor
+"@inlang/plugin-i18next": minor
+---
+
+fix `saveProjectToDirectory` throwing `pathPattern.replace is not a function` when a plugin's `pathPattern` is a namespace object (https://github.com/opral/inlang/issues/4356)
+
+- `ExportFile` has a new optional `metadata` field — the counterpart of `ImportFile.toBeImportedFilesMetadata`. Plugins can use it to pass information to the writer, e.g. the namespace an exported file belongs to.
+- `saveProjectToDirectory` resolves namespaced `pathPattern` objects (`Record<namespace, pattern>`) via `ExportFile.metadata.namespace` and writes each exported file to the path its namespace pattern describes. Files without a resolvable namespace fall back to being written by `file.name` instead of throwing.
+- `@inlang/plugin-i18next` now provides `metadata: { namespace }` for namespaced export files. Saving a multi-namespace i18next project requires this plugin version (older plugin versions no longer crash but fall back to writing `{namespace}-{locale}.json` files relative to the project directory).

--- a/packages/plugins/i18next/src/import-export/exportFiles.ts
+++ b/packages/plugins/i18next/src/import-export/exportFiles.ts
@@ -67,6 +67,12 @@ export const exportFiles: NonNullable<(typeof plugin)["exportFiles"]> = async ({
 					JSON.stringify(unflatten(messages), undefined, "\t") + "\n"
 				),
 				name: `${namespace}-${locale}.json`,
+				// mirrors toBeImportedFiles metadata so that the SDK can resolve
+				// the namespaced pathPattern when writing the file back to disk
+				// https://github.com/opral/inlang/issues/4356
+				metadata: {
+					namespace,
+				},
 			}))
 	);
 	return [...withoutNamespace, ...withNamespace];

--- a/packages/plugins/i18next/src/import-export/namespace-write-back.test.ts
+++ b/packages/plugins/i18next/src/import-export/namespace-write-back.test.ts
@@ -1,0 +1,85 @@
+import { expect, test } from "vitest";
+import nodeFs from "node:fs";
+import nodeOs from "node:os";
+import nodePath from "node:path";
+import {
+	loadProjectFromDirectory,
+	saveProjectToDirectory,
+	type InlangPlugin,
+} from "@inlang/sdk";
+import { plugin } from "../plugin.js";
+
+// kept separate from roundtrip.test.ts on purpose: that file imports
+// ./importFiles.js before ../plugin.js, and under vite's module transform
+// the circular (type-only) imports between plugin.ts and the import-export
+// modules then leave plugin.importFiles undefined, which makes the sdk
+// silently treat the plugin as a legacy loadMessages/saveMessages plugin.
+//
+// https://github.com/opral/inlang/issues/4356
+test("saveProjectToDirectory writes namespaced files back to their pathPattern", async () => {
+	const dir = nodeFs.mkdtempSync(
+		nodePath.join(nodeOs.tmpdir(), "i18next-namespace-write-back-")
+	);
+	nodeFs.mkdirSync(nodePath.join(dir, "en"), { recursive: true });
+	nodeFs.mkdirSync(nodePath.join(dir, "project.inlang"), { recursive: true });
+	nodeFs.writeFileSync(
+		nodePath.join(dir, "en/common.json"),
+		JSON.stringify({ hello: "Hello world" })
+	);
+	nodeFs.writeFileSync(
+		nodePath.join(dir, "en/app.json"),
+		JSON.stringify({ title: "My app" })
+	);
+	nodeFs.writeFileSync(
+		nodePath.join(dir, "project.inlang/settings.json"),
+		JSON.stringify({
+			baseLocale: "en",
+			locales: ["en"],
+			"plugin.inlang.i18next": {
+				pathPattern: {
+					common: "./{locale}/common.json",
+					app: "./{locale}/app.json",
+				},
+			},
+		})
+	);
+
+	const project = await loadProjectFromDirectory({
+		path: nodePath.join(dir, "project.inlang"),
+		fs: nodeFs,
+		providePlugins: [plugin as unknown as InlangPlugin],
+	});
+
+	try {
+		// update a message to prove that saving writes the change back
+		// to the path the namespace pattern describes
+		const message = await project.db
+			.selectFrom("message")
+			.selectAll()
+			.where("bundleId", "=", "common:hello")
+			.executeTakeFirstOrThrow();
+		await project.db
+			.updateTable("variant")
+			.set({ pattern: [{ type: "text", value: "Hello updated" }] })
+			.where("messageId", "=", message.id)
+			.execute();
+
+		await saveProjectToDirectory({
+			project,
+			path: nodePath.join(dir, "project.inlang"),
+			fs: nodeFs,
+		});
+
+		expect(
+			JSON.parse(
+				nodeFs.readFileSync(nodePath.join(dir, "en/common.json"), "utf-8")
+			)
+		).toStrictEqual({ hello: "Hello updated" });
+		expect(
+			JSON.parse(nodeFs.readFileSync(nodePath.join(dir, "en/app.json"), "utf-8"))
+		).toStrictEqual({ title: "My app" });
+	} finally {
+		await project.close();
+		nodeFs.rmSync(dir, { recursive: true, force: true });
+	}
+});

--- a/packages/plugins/i18next/src/import-export/roundtrip.test.ts
+++ b/packages/plugins/i18next/src/import-export/roundtrip.test.ts
@@ -519,6 +519,16 @@ test("it should handle namespaces", async () => {
 	expect(exportedLogin).toStrictEqual({
 		button: "value2",
 	});
+
+	// the namespace metadata enables the SDK to resolve namespaced
+	// pathPatterns when writing files back to disk
+	// https://github.com/opral/inlang/issues/4356
+	expect(
+		exported.find((e) => e.name === "common-en.json")?.metadata
+	).toStrictEqual({ namespace: "common" });
+	expect(
+		exported.find((e) => e.name === "login-en.json")?.metadata
+	).toStrictEqual({ namespace: "login" });
 });
 
 test("it should put new entities into the file without a namespace", async () => {

--- a/packages/sdk/src/project/api.ts
+++ b/packages/sdk/src/project/api.ts
@@ -71,6 +71,18 @@ export type ExportFile = {
 	name: string;
 	/** The binary content of the resource */
 	content: Uint8Array;
+	/**
+	 * Metadata of the exported file.
+	 *
+	 * The counterpart of `ImportFile.toBeImportedFilesMetadata`. Plugins can
+	 * use it to pass information to the writer. For example, a plugin that
+	 * supports a namespaced `pathPattern` (`Record<namespace, pattern>`)
+	 * provides `{ namespace }` so that `saveProjectToDirectory` can resolve
+	 * the pattern each exported file belongs to.
+	 *
+	 * https://github.com/opral/inlang/issues/4356
+	 */
+	metadata?: Record<string, any>;
 };
 
 /**

--- a/packages/sdk/src/project/saveProjectToDirectory.test.ts
+++ b/packages/sdk/src/project/saveProjectToDirectory.test.ts
@@ -130,6 +130,222 @@ test("creates exporter target directories from pathPattern", async () => {
 	expect(JSON.parse(exported as string)).toEqual({ greeting: "Hi" });
 });
 
+test("writes exported files to every pattern of a pathPattern array", async () => {
+	const volume = Volume.fromJSON({});
+	const mockPlugin: InlangPlugin = {
+		key: "mock",
+		exportFiles: async () => [
+			{
+				locale: "en",
+				name: "en.json",
+				content: new TextEncoder().encode(JSON.stringify({ greeting: "Hi" })),
+			},
+		],
+	};
+
+	const project = await loadProjectInMemory({
+		blob: await newProject({
+			settings: {
+				baseLocale: "en",
+				locales: ["en"],
+				modules: [],
+				mock: {
+					pathPattern: ["./messages/{locale}.json", "./backup/{locale}.json"],
+				},
+			},
+		}),
+		providePlugins: [mockPlugin],
+	});
+
+	await saveProjectToDirectory({
+		fs: volume as any,
+		project,
+		path: "/foo/bar.inlang",
+	});
+
+	const messages = await volume.promises.readFile(
+		"/foo/messages/en.json",
+		"utf-8"
+	);
+	const backup = await volume.promises.readFile("/foo/backup/en.json", "utf-8");
+	expect(JSON.parse(messages as string)).toEqual({ greeting: "Hi" });
+	expect(JSON.parse(backup as string)).toEqual({ greeting: "Hi" });
+});
+
+test("an empty pathPattern array writes nothing", async () => {
+	const volume = Volume.fromJSON({});
+	const mockPlugin: InlangPlugin = {
+		key: "mock",
+		exportFiles: async () => [
+			{
+				locale: "en",
+				name: "en.json",
+				content: new TextEncoder().encode(JSON.stringify({ greeting: "Hi" })),
+			},
+		],
+	};
+
+	const project = await loadProjectInMemory({
+		blob: await newProject({
+			settings: {
+				baseLocale: "en",
+				locales: ["en"],
+				modules: [],
+				mock: {
+					pathPattern: [],
+				},
+			},
+		}),
+		providePlugins: [mockPlugin],
+	});
+
+	await saveProjectToDirectory({
+		fs: volume as any,
+		project,
+		path: "/foo/bar.inlang",
+	});
+
+	const files = await volume.promises.readdir("/foo");
+	expect(files).not.toContain("en.json");
+});
+
+// https://github.com/opral/inlang/issues/4356
+test("resolves a namespaced pathPattern object via export file metadata", async () => {
+	const volume = Volume.fromJSON({});
+	const mockPlugin: InlangPlugin = {
+		key: "mock",
+		exportFiles: async () => [
+			{
+				locale: "en",
+				name: "common-en.json",
+				content: new TextEncoder().encode(JSON.stringify({ hello: "Hello" })),
+				metadata: { namespace: "common" },
+			},
+			{
+				locale: "en",
+				name: "app-en.json",
+				content: new TextEncoder().encode(JSON.stringify({ title: "My app" })),
+				metadata: { namespace: "app" },
+			},
+		],
+	};
+
+	const project = await loadProjectInMemory({
+		blob: await newProject({
+			settings: {
+				baseLocale: "en",
+				locales: ["en"],
+				modules: [],
+				mock: {
+					pathPattern: {
+						common: "./{locale}/common.json",
+						app: "./{locale}/app.json",
+					},
+				},
+			},
+		}),
+		providePlugins: [mockPlugin],
+	});
+
+	await saveProjectToDirectory({
+		fs: volume as any,
+		project,
+		path: "/foo/bar.inlang",
+	});
+
+	const common = await volume.promises.readFile("/foo/en/common.json", "utf-8");
+	const app = await volume.promises.readFile("/foo/en/app.json", "utf-8");
+	expect(JSON.parse(common as string)).toEqual({ hello: "Hello" });
+	expect(JSON.parse(app as string)).toEqual({ title: "My app" });
+});
+
+// old plugin versions don't provide namespace metadata. falling back to
+// file.name is better than throwing "pathPattern.replace is not a function"
+// https://github.com/opral/inlang/issues/4356
+test("falls back to the file name when a namespaced pathPattern can't be resolved", async () => {
+	const volume = Volume.fromJSON({});
+	const mockPlugin: InlangPlugin = {
+		key: "mock",
+		exportFiles: async () => [
+			{
+				locale: "en",
+				name: "common-en.json",
+				content: new TextEncoder().encode(JSON.stringify({ hello: "Hello" })),
+				// no metadata, like plugin versions that predate ExportFile.metadata
+			},
+		],
+	};
+
+	const project = await loadProjectInMemory({
+		blob: await newProject({
+			settings: {
+				baseLocale: "en",
+				locales: ["en"],
+				modules: [],
+				mock: {
+					pathPattern: {
+						common: "./{locale}/common.json",
+					},
+				},
+			},
+		}),
+		providePlugins: [mockPlugin],
+	});
+
+	await saveProjectToDirectory({
+		fs: volume as any,
+		project,
+		path: "/foo/bar.inlang",
+	});
+
+	const fallback = await volume.promises.readFile(
+		"/foo/common-en.json",
+		"utf-8"
+	);
+	expect(JSON.parse(fallback as string)).toEqual({ hello: "Hello" });
+});
+
+// https://github.com/opral/inlang/issues/4356
+test("falls back to the file name when the namespace is missing from the pathPattern object", async () => {
+	const volume = Volume.fromJSON({});
+	const mockPlugin: InlangPlugin = {
+		key: "mock",
+		exportFiles: async () => [
+			{
+				locale: "en",
+				name: "stray-en.json",
+				content: new TextEncoder().encode(JSON.stringify({ hello: "Hello" })),
+				metadata: { namespace: "stray" },
+			},
+		],
+	};
+
+	const project = await loadProjectInMemory({
+		blob: await newProject({
+			settings: {
+				baseLocale: "en",
+				locales: ["en"],
+				modules: [],
+				mock: {
+					pathPattern: {
+						common: "./{locale}/common.json",
+					},
+				},
+			},
+		}),
+		providePlugins: [mockPlugin],
+	});
+
+	await saveProjectToDirectory({
+		fs: volume as any,
+		project,
+		path: "/foo/bar.inlang",
+	});
+
+	const fallback = await volume.promises.readFile("/foo/stray-en.json", "utf-8");
+	expect(JSON.parse(fallback as string)).toEqual({ hello: "Hello" });
+});
+
 // Users were confused by project_id, and without sync a stable id is rarely needed.
 test("it should not write project_id to disk", async () => {
 	const mockFs = Volume.fromJSON({

--- a/packages/sdk/src/project/saveProjectToDirectory.ts
+++ b/packages/sdk/src/project/saveProjectToDirectory.ts
@@ -183,19 +183,37 @@ export async function saveProjectToDirectory(args: {
 			for (const file of files) {
 				const pathPattern = settings[plugin.key]?.pathPattern;
 
-				// We need to check if pathPattern is a string or an array of strings
-				// and handle both cases.
-				const formattedPathPatterns = Array.isArray(pathPattern)
-					? pathPattern
-					: [pathPattern];
+				const resolvePattern = (pattern: string) =>
+					absolutePathFromProject(
+						args.path,
+						pattern.replace(/\{(languageTag|locale)\}/g, file.locale)
+					);
 
-				for (const pathPattern of formattedPathPatterns) {
-					const p = pathPattern
-						? absolutePathFromProject(
-								args.path,
-								pathPattern.replace(/\{(languageTag|locale)\}/g, file.locale)
-							)
-						: absolutePathFromProject(args.path, file.name);
+				// pathPattern can be a string, an array of strings, or a record
+				// mapping namespaces to patterns (e.g. plugin-i18next).
+				// https://github.com/opral/inlang/issues/4356
+				let targetPaths: string[];
+				if (typeof pathPattern === "string") {
+					targetPaths = [resolvePattern(pathPattern)];
+				} else if (Array.isArray(pathPattern)) {
+					// an empty array writes nothing
+					targetPaths = pathPattern.map(resolvePattern);
+				} else if (typeof pathPattern === "object" && pathPattern !== null) {
+					const namespace = file.metadata?.["namespace"];
+					const namespacePattern = namespace
+						? pathPattern[namespace]
+						: undefined;
+					// no pattern for this file (plugin didn't provide namespace
+					// metadata or the namespace is unknown) -> fall back to file.name
+					targetPaths =
+						typeof namespacePattern === "string"
+							? [resolvePattern(namespacePattern)]
+							: [absolutePathFromProject(args.path, file.name)];
+				} else {
+					targetPaths = [absolutePathFromProject(args.path, file.name)];
+				}
+
+				for (const p of targetPaths) {
 					await fsModule.mkdir(path.dirname(p), { recursive: true });
 					if (p.endsWith(".json")) {
 						try {


### PR DESCRIPTION
Closes #4356

## Problem

`saveProjectToDirectory` assumed a plugin's `pathPattern` setting is a `string | string[]` and called `.replace()` on it. plugin-i18next also supports the namespaced object form (`Record<namespace, pattern>`), so saving any multi-namespace i18next project threw `TypeError: pathPattern.replace is not a function`. Import handled namespaces fine — write-back was broken for exactly the projects most likely to migrate from i18next/Locize.

## What changed

- **`@inlang/sdk`**: `ExportFile` gains an optional `metadata` field — the export-side counterpart of `ImportFile.toBeImportedFilesMetadata`. `saveProjectToDirectory` now handles all three `pathPattern` shapes explicitly; for the object form it resolves the target path via `pathPattern[file.metadata.namespace]`.
- **`@inlang/plugin-i18next`**: `exportFiles` provides `metadata: { namespace }` for namespaced files, mirroring what `toBeImportedFiles` already does on import.
- **Graceful degradation**: a new SDK paired with an older pinned plugin (no metadata) no longer crashes — files without a resolvable namespace fall back to being written by `file.name`. Upgrading the plugin URL in `settings.json` restores correct per-namespace paths.

## Notes for review

- An empty `pathPattern` array still writes nothing (pre-existing behavior, now pinned by a test); the previously untested array branch got regression coverage.
- The end-to-end test reproducing the issue lives in its own file (`namespace-write-back.test.ts`) on purpose: `roundtrip.test.ts` imports `./importFiles.js` before `../plugin.js`, and under vite's transform the circular type-only imports leave `plugin.importFiles` undefined, making the SDK silently treat the plugin as legacy. A comment in the file documents this.
- #4355 (plugin export throws on i18next context keys) fires before this code path and can mask the fix for projects containing context keys.

## Tests

- SDK: namespace resolution via metadata, fallback when metadata is missing, fallback when the namespace is missing from settings, array `pathPattern`, empty array.
- plugin-i18next: metadata assertions in the namespace roundtrip test, plus an end-to-end test of the exact issue repro (load → edit message → save → assert `./en/common.json` and `./en/app.json`).
- Full suites pass: SDK 109, plugin 51, `tsc --noEmit` clean on both.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes where translation files are written on disk for multi-namespace projects; incorrect metadata could misplace files, though fallbacks avoid crashes and behavior is heavily tested.
> 
> **Overview**
> Fixes **`saveProjectToDirectory`** crashing with `pathPattern.replace is not a function` when a plugin uses a **namespaced** `pathPattern` (`Record<namespace, pattern>`), as in multi-namespace i18next projects (#4356).
> 
> **`@inlang/sdk`**: `ExportFile` gains optional **`metadata`** (export-side mirror of import metadata). The save path now branches on `pathPattern` shape—string, string array, or namespace object—and for objects resolves the write path via **`metadata.namespace`**. Unresolvable namespaces **fall back to `file.name`** instead of throwing; array patterns still support multi-destination writes (empty array writes nothing).
> 
> **`@inlang/plugin-i18next`**: namespaced exports now attach **`metadata: { namespace }`** so write-back lands on the correct per-namespace paths.
> 
> Tests cover SDK resolution/fallbacks, array `pathPattern`, plugin metadata, and an end-to-end load → edit → save for namespaced i18next layouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6680ac1e5adb83a5af0a4f0dba99744207a1ca0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->