### PR TITLE
fix(plugin-i18next): restore Sherlock annotations by removing the static meta ide-extension config

### DIFF
--- a/.changeset/i18next-sherlock-meta.md
+++ b/.changeset/i18next-sherlock-meta.md
@@ -1,0 +1,5 @@
+---
+"@inlang/plugin-i18next": patch
+---
+
+Restore Sherlock (inlang.vs-code-extension) inline annotations, hovers, and extraction for i18next projects. The plugin shipped a static `meta["app.inlang.ideExtension"]` whose matchers require per-call settings; Sherlock skips its settings-injecting `addCustomApi` migration when `meta` is already set and invokes matchers without settings, so every match silently returned empty. Removing the static `meta` lets Sherlock's migration bake the plugin settings into the matchers, including namespace inference from `useTranslation('ns')`. Fixes https://github.com/opral/inlang/issues/4368

--- a/packages/plugins/i18next/src/ideExtension/sherlock-contract.test.ts
+++ b/packages/plugins/i18next/src/ideExtension/sherlock-contract.test.ts
@@ -1,33 +1,54 @@
 import { expect, test } from "vitest";
+import type { ProjectSettings } from "@inlang/sdk";
 import { plugin } from "../plugin.js";
 
 // Sherlock obtains the ide-extension api via `plugin.meta` and only migrates
 // `plugin.addCustomApi({ settings })` into `meta` when `meta` is NOT already
 // set (state.ts: `if (plugin.addCustomApi && !plugin.meta)`):
 // https://github.com/opral/sherlock/blob/1bb8b6477/src/utilities/state.ts
-// It then invokes the matchers WITHOUT per-call settings:
+// It then invokes the matchers WITHOUT per-call settings and calls the
+// extraction callback with `bundleId`:
 // https://github.com/opral/sherlock/blob/1bb8b6477/src/decorations/messagePreview.ts
+// https://github.com/opral/sherlock/blob/1bb8b6477/src/commands/extractMessage.ts
 //
 // A static `meta` whose matchers require `args.settings` therefore yields
 // zero matches in Sherlock (the parse error is swallowed by a catch), which
 // disables inline annotations, hovers, and extraction for i18next projects.
 // reproduces https://github.com/opral/inlang/issues/4368
-test("ide-extension matchers work through Sherlock's plugin.meta contract", async () => {
-	const settings = {
-		baseLocale: "en",
-		locales: ["en", "de"],
-		"plugin.inlang.i18next": {
-			pathPattern: { common: "./locales/{locale}/common.json" },
-		},
+
+/** The subset of the ide-extension contract exercised by Sherlock. */
+type IdeExtensionApi = {
+	"app.inlang.ideExtension": {
+		messageReferenceMatchers: Array<
+			(args: { documentText: string }) => Promise<Array<{ messageId: string }>>
+		>;
+		extractMessageOptions: Array<{
+			callback: (args: { bundleId: string; selection: string }) => {
+				bundleId?: string;
+				messageId?: string;
+				messageReplacement: string;
+			};
+		}>;
 	};
+};
 
-	// mirror Sherlock's migration gate exactly
-	const meta =
-		plugin.addCustomApi && !plugin.meta
-			? (plugin.addCustomApi({ settings }) as Record<string, any>)
-			: (plugin.meta as Record<string, any>);
+const settings = {
+	baseLocale: "en",
+	locales: ["en", "de"],
+	"plugin.inlang.i18next": {
+		pathPattern: { common: "./locales/{locale}/common.json" },
+	},
+} satisfies ProjectSettings;
 
-	const matcher = meta["app.inlang.ideExtension"].messageReferenceMatchers[0];
+// mirror Sherlock's migration gate exactly
+const meta = (
+	plugin.addCustomApi && !plugin.meta
+		? plugin.addCustomApi({ settings })
+		: plugin.meta
+) as IdeExtensionApi;
+
+test("ide-extension matchers work through Sherlock's plugin.meta contract", async () => {
+	const matcher = meta["app.inlang.ideExtension"].messageReferenceMatchers[0]!;
 
 	// Sherlock calls matchers with documentText only (no settings)
 	const matches = await matcher({
@@ -38,8 +59,21 @@ test("ide-extension matchers work through Sherlock's plugin.meta contract", asyn
 		].join("\n"),
 	});
 
-	expect(matches.map((match: { messageId: string }) => match.messageId)).toStrictEqual([
+	expect(matches.map((match) => match.messageId)).toStrictEqual([
 		"common:welcome",
 		"common:checkout",
 	]);
+});
+
+test("extraction callback supports Sherlock's bundleId contract", () => {
+	const option = meta["app.inlang.ideExtension"].extractMessageOptions[0]!;
+
+	// Sherlock's extract command calls the callback with `bundleId`
+	const result = option.callback({
+		bundleId: "common:checkout",
+		selection: "Proceed",
+	});
+
+	expect(result.messageReplacement).toBe('{t("common:checkout")}');
+	expect(result.bundleId).toBe("common:checkout");
 });

--- a/packages/plugins/i18next/src/ideExtension/sherlock-contract.test.ts
+++ b/packages/plugins/i18next/src/ideExtension/sherlock-contract.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "vitest";
+import { plugin } from "../plugin.js";
+
+// Sherlock obtains the ide-extension api via `plugin.meta` and only migrates
+// `plugin.addCustomApi({ settings })` into `meta` when `meta` is NOT already
+// set (state.ts: `if (plugin.addCustomApi && !plugin.meta)`):
+// https://github.com/opral/sherlock/blob/1bb8b6477/src/utilities/state.ts
+// It then invokes the matchers WITHOUT per-call settings:
+// https://github.com/opral/sherlock/blob/1bb8b6477/src/decorations/messagePreview.ts
+//
+// A static `meta` whose matchers require `args.settings` therefore yields
+// zero matches in Sherlock (the parse error is swallowed by a catch), which
+// disables inline annotations, hovers, and extraction for i18next projects.
+// reproduces https://github.com/opral/inlang/issues/4368
+test("ide-extension matchers work through Sherlock's plugin.meta contract", async () => {
+	const settings = {
+		baseLocale: "en",
+		locales: ["en", "de"],
+		"plugin.inlang.i18next": {
+			pathPattern: { common: "./locales/{locale}/common.json" },
+		},
+	};
+
+	// mirror Sherlock's migration gate exactly
+	const meta =
+		plugin.addCustomApi && !plugin.meta
+			? (plugin.addCustomApi({ settings }) as Record<string, any>)
+			: (plugin.meta as Record<string, any>);
+
+	const matcher = meta["app.inlang.ideExtension"].messageReferenceMatchers[0];
+
+	// Sherlock calls matchers with documentText only (no settings)
+	const matches = await matcher({
+		documentText: [
+			"const { t } = useTranslation('common')",
+			"t('welcome')",
+			"t('common:checkout')",
+		].join("\n"),
+	});
+
+	expect(matches.map((match: { messageId: string }) => match.messageId)).toStrictEqual([
+		"common:welcome",
+		"common:checkout",
+	]);
+});

--- a/packages/plugins/i18next/src/legacy/plugin.v4.ts
+++ b/packages/plugins/i18next/src/legacy/plugin.v4.ts
@@ -462,10 +462,18 @@ const ideExtensionConfig = (
 		],
 		extractMessageOptions: [
 			{
-				callback: (args: { messageId: string }) => ({
-					messageId: args.messageId,
-					messageReplacement: `{t("${args.messageId}")}`,
-				}),
+				// Sherlock passes `bundleId` (the current ide-extension
+				// contract); older consumers passed `messageId`. Accept both
+				// and return both so neither contract breaks.
+				// https://github.com/opral/inlang/issues/4368
+				callback: (args: { bundleId?: string; messageId?: string }) => {
+					const id = args.bundleId ?? args.messageId;
+					return {
+						bundleId: id,
+						messageId: id,
+						messageReplacement: `{t("${id}")}`,
+					};
+				},
 			},
 		],
 		documentSelectors: [

--- a/packages/plugins/i18next/src/plugin.ts
+++ b/packages/plugins/i18next/src/plugin.ts
@@ -1,6 +1,5 @@
 import type { InlangPlugin } from "@inlang/sdk";
 import type { PluginSettings } from "./settings.js";
-import { config } from "./ideExtension/config.js";
 import { pluginV4 } from "./legacy/plugin.v4.js";
 import { importFiles } from "./import-export/importFiles.js";
 import { exportFiles } from "./import-export/exportFiles.js";
@@ -24,7 +23,10 @@ export const plugin: InlangPlugin<{
 	importFiles,
 	exportFiles,
 	toBeImportedFiles,
-	meta: {
-		"app.inlang.ideExtension": config,
-	},
+	// NOTE: no static `meta` here on purpose. Sherlock only migrates
+	// `addCustomApi({ settings })` into `meta` when `meta` is unset — and the
+	// ide-extension matchers need the plugin settings (pathPattern) baked in
+	// for namespace inference. A static meta shadows that migration and
+	// silently disables all Sherlock features for i18next projects, see
+	// https://github.com/opral/inlang/issues/4368
 };


### PR DESCRIPTION
Fixes #4368

## Problem

Sherlock shows no inline annotations, hovers, or extraction lenses for i18next projects — silently. The plugin ships a static `meta["app.inlang.ideExtension"]` whose matchers require `args.settings`; Sherlock skips its settings-injecting `addCustomApi` migration when `meta` is already set (state.ts: `if (plugin.addCustomApi && !plugin.meta)`) and invokes matchers without per-call settings, so the matcher throws on `settings.pathPattern` and the silent catch in `parse()` returns `[]` for everything. Full forensics with permalinks and probe outputs in #4368. Not a 6.2.0 regression — 6.1.x ships the same `meta`.

## Change

- Remove the static `meta` block from `plugin.ts` (with a comment explaining why it must stay absent). Sherlock's migration then calls `addCustomApi({ settings })` and the legacy implementation bakes the `plugin.inlang.i18next` settings slice into the matcher closure — full namespace inference (`useTranslation('common')` + `t('welcome')` → `common:welcome`) included.
- New `sherlock-contract.test.ts` that mirrors Sherlock's exact behavior (the `!plugin.meta` migration gate, then `matcher({ documentText })` with no settings). First commit adds it red, second makes it green.
- No other consumer of `plugin.meta` exists in the SDK or Sherlock beyond this lookup.

## Verification

Beyond the unit test: simulated Sherlock's code path against the built dist (7/7 matches on a realistic file) and confirmed in the real Sherlock UI with a locally patched build — inline annotations and en/de hover tooltips render on a scaffolded `init --inlang` project.

Optional follow-ups (not in this PR, noted in the issue): a `settings?.pathPattern` guard in `parseNameSpaces` so missing settings degrade to prefix-only matching instead of silent zero; and/or Sherlock passing `settings[plugin.key]` when invoking meta matchers.
