### PR TITLE
[codex] Add next-intl namespace path patterns

### DIFF
--- a/.changeset/bright-needles-join.md
+++ b/.changeset/bright-needles-join.md
@@ -1,5 +1,8 @@
 ---
 "@inlang/plugin-next-intl": minor
+"@inlang/sdk": patch
 ---
 
 Add new import/export API support with namespace path patterns while keeping legacy next-intl project settings and `{languageTag}` path patterns compatible.
+
+Allow export files to override the configured path pattern via metadata so plugins can safely route individual files without mutating project settings.

--- a/.changeset/bright-needles-join.md
+++ b/.changeset/bright-needles-join.md
@@ -1,0 +1,5 @@
+---
+"@inlang/plugin-next-intl": minor
+---
+
+Add new import/export API support with namespace path patterns while keeping legacy next-intl project settings and `{languageTag}` path patterns compatible.

--- a/packages/plugins/next-intl/README.md
+++ b/packages/plugins/next-intl/README.md
@@ -19,14 +19,14 @@ The plugin reads and writes next-intl JSON files, preserving your existing file 
 
 # Supported next-intl Features
 
-| Feature | Status | Notes |
-|---------|--------|-------|
-| Basic key-value pairs | ✅ Supported | Fully working |
-| Nested keys | ✅ Supported | Auto-detects flat vs nested structure |
-| Variable interpolation | ✅ Supported | `{variable}` with customizable patterns |
-| Rich text | ⚠️ Partial | Tags are treated as text |
-| Plurals (ICU) | ❌ Not supported | ICU message format not parsed |
-| Select (ICU) | ❌ Not supported | ICU message format not parsed |
+| Feature                | Status           | Notes                                   |
+| ---------------------- | ---------------- | --------------------------------------- |
+| Basic key-value pairs  | ✅ Supported     | Fully working                           |
+| Nested keys            | ✅ Supported     | Auto-detects flat vs nested structure   |
+| Variable interpolation | ✅ Supported     | `{variable}` with customizable patterns |
+| Rich text              | ⚠️ Partial       | Tags are treated as text                |
+| Plurals (ICU)          | ❌ Not supported | ICU message format not parsed           |
+| Select (ICU)           | ❌ Not supported | ICU message format not parsed           |
 
 ## Version Compatibility
 
@@ -45,10 +45,10 @@ The plugin reads and writes next-intl JSON files, preserving your existing file 
 	"languageTags": ["en", "de"],
 	"modules": [
 		"https://cdn.jsdelivr.net/npm/@inlang/plugin-next-intl@latest/dist/index.js"
-  	],
+	],
 	"plugin.inlang.nextIntl": {
-    	"pathPattern": "./messages/{languageTag}.json"
-  	}
+		"pathPattern": "./messages/{locale}.json"
+	}
 }
 ```
 
@@ -58,18 +58,44 @@ The plugin offers further configuration options that can be passed as arguments.
 
 ```typescript
 type PluginSettings = {
-	pathPattern: string
-	variableReferencePattern?: [string] | [string, string]
-	sourceLanguageFilePath?: string
-}
+	pathPattern: string | { [namespace: string]: string };
+	variableReferencePattern?: [string] | [string, string];
+	sourceLanguageFilePath?: string;
+};
 ```
 
 ## `pathPattern`
 
-To use the plugin, you must provide a path to the directory where your language-specific files are stored. Use the dynamic path syntax `{languageTag}` to specify the language name.
+To use the plugin, you must provide a path to the directory where your language-specific files are stored. Use the dynamic path syntax `{locale}` to specify the locale name.
+
+`{languageTag}` is still supported for legacy projects, but `{locale}` is recommended for new configurations.
 
 ```json
-"pathPattern": "./messages/{languageTag}.json"
+"pathPattern": "./messages/{locale}.json"
+```
+
+Use an object when your next-intl messages are split by namespace. Namespace maps require tools that use the new `importFiles` and `exportFiles` API; the legacy `loadMessages` and `saveMessages` hooks only support a single string `pathPattern`.
+
+```json
+"pathPattern": {
+	"About": "./messages/{locale}/About.json",
+	"HomePage": "./messages/HomePage/{locale}.json"
+}
+```
+
+For example, `./messages/en/About.json` with this content:
+
+```json
+{
+	"title": "About us"
+}
+```
+
+is exposed as the message ID `About.title`, matching next-intl usage like:
+
+```ts
+const t = useTranslations("About");
+t("title");
 ```
 
 ## `variableReferencePattern`
@@ -131,22 +157,24 @@ The **source language file determines the structure** for all other locale files
 ### Example
 
 If your source language (`en.json`) looks like this:
+
 ```json
 {
-  "About": {
-    "title": "About us",
-    "description": "Learn more about our company"
-  }
+	"About": {
+		"title": "About us",
+		"description": "Learn more about our company"
+	}
 }
 ```
 
 Then your target language (`de.json`) will be written in the same nested structure:
+
 ```json
 {
-  "About": {
-    "title": "Über uns",
-    "description": "Erfahren Sie mehr über unser Unternehmen"
-  }
+	"About": {
+		"title": "Über uns",
+		"description": "Erfahren Sie mehr über unser Unternehmen"
+	}
 }
 ```
 
@@ -154,11 +182,11 @@ Then your target language (`de.json`) will be written in the same nested structu
 
 The following next-intl features are **not supported** by this plugin:
 
-| Feature | Limitation |
-|---------|------------|
-| **ICU message format** | Plurals, select, and other ICU syntax are not parsed |
+| Feature                  | Limitation                                              |
+| ------------------------ | ------------------------------------------------------- |
+| **ICU message format**   | Plurals, select, and other ICU syntax are not parsed    |
 | **Rich text formatting** | Tags like `<bold>text</bold>` are treated as plain text |
-| **Nested `t()` calls** | References like `{t('other.key')}` are not resolved |
+| **Nested `t()` calls**   | References like `{t('other.key')}` are not resolved     |
 
 # Troubleshooting
 
@@ -167,6 +195,7 @@ The following next-intl features are **not supported** by this plugin:
 **Cause**: The source language file structure doesn't match what the plugin expects.
 
 **Solution**:
+
 1. Ensure your source language file (e.g., `en.json`) is valid JSON
 2. Check that the file structure is consistent (all nested or all flat)
 3. The source language file is the "source of truth" for key ordering
@@ -176,6 +205,7 @@ The following next-intl features are **not supported** by this plugin:
 **Cause**: Non-standard function names or unsupported file types.
 
 **Solution**:
+
 - Use standard function calls: `t("key")`, `useTranslations()`, or `getTranslations()`
 - Supported file types: `.ts`, `.tsx`, `.js`, `.jsx`
 
@@ -184,8 +214,9 @@ The following next-intl features are **not supported** by this plugin:
 **Cause**: Target files don't exist or path pattern is incorrect.
 
 **Solution**:
+
 1. Verify your `pathPattern` matches your file structure
-2. Check that the `{languageTag}` placeholder is in the correct position
+2. Check that the `{locale}` or legacy `{languageTag}` placeholder is in the correct position
 3. Directories are created automatically, but the language tag must be in your `languageTags` array
 
 # Contributing

--- a/packages/plugins/next-intl/package.json
+++ b/packages/plugins/next-intl/package.json
@@ -35,7 +35,7 @@
 		"@inlang/tsconfig": "workspace:*",
 		"@types/flat": "^5.0.2",
 		"@types/lodash.merge": "^4.6.7",
-		"@inlang/sdk": "0.36.3",
+		"@inlang/sdk": "workspace:*",
 		"@types/parsimmon": "1.10.6",
 		"esbuild": "^0.24.2",
 		"flat": "^5.0.2",

--- a/packages/plugins/next-intl/src/import-export/exportFiles.ts
+++ b/packages/plugins/next-intl/src/import-export/exportFiles.ts
@@ -1,0 +1,258 @@
+import type { InlangPlugin } from "@inlang/sdk";
+import type { PluginSettings } from "../settings.js";
+import { PLUGIN_KEY } from "../pluginKey.js";
+import { getMessagePath } from "./messageId.js";
+
+const SOURCE_LANGUAGE_FILE_PATH_EXPORT_NAMESPACE =
+	"__nextIntl_sourceLanguageFilePath";
+const DEFAULT_PATH_PATTERN_EXPORT_NAMESPACE = "__nextIntl_pathPattern";
+
+type Pattern = Array<
+	| { type: "text"; value: string }
+	| {
+			type: "expression";
+			arg:
+				| { type: "variable-reference"; name: string }
+				| { type: "literal"; value: string };
+			annotation?: unknown;
+	  }
+	| { type: "markup-start"; name: string }
+	| { type: "markup-end"; name: string }
+	| { type: "markup-standalone"; name: string }
+>;
+type Bundle = { id: string };
+type Message = { id: string; bundleId: string; locale: string };
+type Variant = { messageId: string; pattern: Pattern };
+
+export const exportFiles: NonNullable<
+	InlangPlugin<{ [PLUGIN_KEY]: PluginSettings }>["exportFiles"]
+> = async ({
+	bundles,
+	messages,
+	variants,
+	settings,
+}): Promise<
+	Array<{
+		locale: string;
+		content: Uint8Array;
+		name: string;
+		metadata?: Record<string, any>;
+	}>
+> => {
+	const result: Record<string, Array<ExportMessage>> = {};
+	const resultNamespaces: Record<
+		string,
+		Record<string, Array<ExportMessage>>
+	> = {};
+	const pluginSettings = settings?.[PLUGIN_KEY];
+	const namespaces =
+		pluginSettings && typeof pluginSettings.pathPattern === "object"
+			? Object.keys(pluginSettings.pathPattern)
+			: [];
+
+	for (const message of messages as Message[]) {
+		const bundle = bundles.find(
+			(bundle: Bundle) => bundle.id === message.bundleId
+		);
+		if (bundle === undefined) {
+			continue;
+		}
+
+		const variantsOfMessage = (variants as Variant[]).filter(
+			(variant: Variant) => variant.messageId === message.id
+		);
+
+		for (const variant of variantsOfMessage) {
+			const value = serializePattern(variant.pattern, pluginSettings);
+			const namespace = resolveNamespaceFromBundleId(bundle.id, namespaces);
+
+			if (namespace === undefined) {
+				result[message.locale] ??= [];
+				result[message.locale]!.push({
+					key: bundle.id,
+					path: getMessagePath(message.id),
+					value,
+				});
+			} else {
+				const key = removeNamespaceFromBundleId(bundle.id, namespace);
+				resultNamespaces[namespace] ??= {};
+				resultNamespaces[namespace]![message.locale] ??= [];
+				resultNamespaces[namespace]![message.locale]!.push({
+					key,
+					path: getMessagePath(message.id),
+					value,
+				});
+			}
+		}
+	}
+
+	const withoutNamespace = Object.entries(result).map(([locale, messages]) => ({
+		locale,
+		content: encodeJson(messages),
+		name: `${locale}.json`,
+	}));
+	const withNamespace = Object.entries(resultNamespaces).flatMap(
+		([namespace, locales]) =>
+			Object.entries(locales).map(([locale, messages]) => ({
+				locale,
+				content: encodeJson(messages),
+				name: `${namespace}-${locale}.json`,
+				metadata: {
+					namespace,
+				},
+			}))
+	);
+
+	return [
+		...withSourceLanguageFilePathMetadata({
+			files: withoutNamespace,
+			settings,
+		}),
+		...withNamespace,
+	];
+};
+
+function serializePattern(pattern: Pattern, settings?: PluginSettings): string {
+	let result = "";
+	const variableReferencePattern = settings?.variableReferencePattern ?? [
+		"{",
+		"}",
+	];
+
+	for (const part of pattern) {
+		switch (part.type) {
+			case "text":
+				result += part.value;
+				break;
+			case "expression":
+				if (part.arg.type !== "variable-reference") {
+					throw new Error("Only variable references are supported.");
+				}
+				if (part.annotation !== undefined) {
+					throw new Error("Annotated expressions are not supported.");
+				}
+				result += `${variableReferencePattern[0]}${part.arg.name}${
+					variableReferencePattern[1] ?? ""
+				}`;
+				break;
+			case "markup-start":
+			case "markup-end":
+			case "markup-standalone":
+				throw new Error("Markup is not supported by the next-intl plugin.");
+		}
+	}
+
+	return result;
+}
+
+function resolveNamespaceFromBundleId(
+	bundleId: string,
+	namespaces: string[]
+): string | undefined {
+	return [...namespaces]
+		.sort((a, b) => b.length - a.length)
+		.find(
+			(namespace) =>
+				bundleId === namespace || bundleId.startsWith(`${namespace}.`)
+		);
+}
+
+function removeNamespaceFromBundleId(
+	bundleId: string,
+	namespace: string
+): string {
+	return bundleId === namespace
+		? bundleId
+		: bundleId.replace(`${namespace}.`, "");
+}
+
+type ExportMessage = {
+	key: string;
+	path?: string[];
+	value: string;
+};
+
+function encodeJson(messages: ExportMessage[]): Uint8Array {
+	return new TextEncoder().encode(
+		JSON.stringify(toJson(messages), undefined, "\t") + "\n"
+	);
+}
+
+function toJson(messages: ExportMessage[]): Record<string, unknown> {
+	const messagesWithoutPath: Record<string, string> = {};
+	const result: Record<string, unknown> = {};
+
+	for (const message of messages) {
+		if (message.path === undefined) {
+			messagesWithoutPath[message.key] = message.value;
+			continue;
+		}
+		assignPath(result, message.path, message.value);
+	}
+
+	return {
+		...messagesWithoutPath,
+		...result,
+	};
+}
+
+function assignPath(
+	target: Record<string, unknown>,
+	path: string[],
+	value: string
+) {
+	let cursor = target;
+
+	for (const [index, segment] of path.entries()) {
+		if (index === path.length - 1) {
+			cursor[segment] = value;
+			return;
+		}
+
+		cursor[segment] ??= {};
+		cursor = cursor[segment] as Record<string, unknown>;
+	}
+}
+
+function withSourceLanguageFilePathMetadata(args: {
+	files: Array<{
+		locale: string;
+		content: Uint8Array;
+		name: string;
+		metadata?: Record<string, any>;
+	}>;
+	settings: Parameters<
+		NonNullable<InlangPlugin<{ [PLUGIN_KEY]: PluginSettings }>["exportFiles"]>
+	>[0]["settings"];
+}) {
+	const pluginSettings = args.settings?.[PLUGIN_KEY];
+	const sourceLocale =
+		args.settings?.baseLocale ?? args.settings?.sourceLanguageTag;
+
+	if (
+		pluginSettings === undefined ||
+		typeof pluginSettings.pathPattern !== "string" ||
+		typeof pluginSettings.sourceLanguageFilePath !== "string" ||
+		typeof sourceLocale !== "string"
+	) {
+		return args.files;
+	}
+
+	const pathPattern = pluginSettings.pathPattern;
+	pluginSettings.pathPattern = {
+		[SOURCE_LANGUAGE_FILE_PATH_EXPORT_NAMESPACE]:
+			pluginSettings.sourceLanguageFilePath,
+		[DEFAULT_PATH_PATTERN_EXPORT_NAMESPACE]: pathPattern,
+	};
+
+	return args.files.map((file) => ({
+		...file,
+		metadata: {
+			...file.metadata,
+			namespace:
+				file.locale === sourceLocale
+					? SOURCE_LANGUAGE_FILE_PATH_EXPORT_NAMESPACE
+					: DEFAULT_PATH_PATTERN_EXPORT_NAMESPACE,
+		},
+	}));
+}

--- a/packages/plugins/next-intl/src/import-export/exportFiles.ts
+++ b/packages/plugins/next-intl/src/import-export/exportFiles.ts
@@ -3,10 +3,6 @@ import type { PluginSettings } from "../settings.js";
 import { PLUGIN_KEY } from "../pluginKey.js";
 import { getMessagePath } from "./messageId.js";
 
-const SOURCE_LANGUAGE_FILE_PATH_EXPORT_NAMESPACE =
-	"__nextIntl_sourceLanguageFilePath";
-const DEFAULT_PATH_PATTERN_EXPORT_NAMESPACE = "__nextIntl_pathPattern";
-
 type Pattern = Array<
 	| { type: "text"; value: string }
 	| {
@@ -238,21 +234,14 @@ function withSourceLanguageFilePathMetadata(args: {
 		return args.files;
 	}
 
-	const pathPattern = pluginSettings.pathPattern;
-	pluginSettings.pathPattern = {
-		[SOURCE_LANGUAGE_FILE_PATH_EXPORT_NAMESPACE]:
-			pluginSettings.sourceLanguageFilePath,
-		[DEFAULT_PATH_PATTERN_EXPORT_NAMESPACE]: pathPattern,
-	};
-
 	return args.files.map((file) => ({
 		...file,
-		metadata: {
-			...file.metadata,
-			namespace:
-				file.locale === sourceLocale
-					? SOURCE_LANGUAGE_FILE_PATH_EXPORT_NAMESPACE
-					: DEFAULT_PATH_PATTERN_EXPORT_NAMESPACE,
-		},
+		metadata:
+			file.locale === sourceLocale
+				? {
+						...file.metadata,
+						pathPattern: pluginSettings.sourceLanguageFilePath,
+					}
+				: file.metadata,
 	}));
 }

--- a/packages/plugins/next-intl/src/import-export/exportFiles.ts
+++ b/packages/plugins/next-intl/src/import-export/exportFiles.ts
@@ -66,7 +66,10 @@ export const exportFiles: NonNullable<
 				result[message.locale] ??= [];
 				result[message.locale]!.push({
 					key: bundle.id,
-					path: getMessagePath(message.id),
+					path: getCurrentMessagePath({
+						messageId: message.id,
+						currentKey: bundle.id,
+					}),
 					value,
 				});
 			} else {
@@ -75,7 +78,10 @@ export const exportFiles: NonNullable<
 				resultNamespaces[namespace]![message.locale] ??= [];
 				resultNamespaces[namespace]![message.locale]!.push({
 					key,
-					path: getMessagePath(message.id),
+					path: getCurrentMessagePath({
+						messageId: message.id,
+						currentKey: key,
+					}),
 					value,
 				});
 			}
@@ -147,19 +153,14 @@ function resolveNamespaceFromBundleId(
 ): string | undefined {
 	return [...namespaces]
 		.sort((a, b) => b.length - a.length)
-		.find(
-			(namespace) =>
-				bundleId === namespace || bundleId.startsWith(`${namespace}.`)
-		);
+		.find((namespace) => bundleId.startsWith(`${namespace}.`));
 }
 
 function removeNamespaceFromBundleId(
 	bundleId: string,
 	namespace: string
 ): string {
-	return bundleId === namespace
-		? bundleId
-		: bundleId.replace(`${namespace}.`, "");
+	return bundleId.replace(`${namespace}.`, "");
 }
 
 type ExportMessage = {
@@ -208,6 +209,14 @@ function assignPath(
 		cursor[segment] ??= {};
 		cursor = cursor[segment] as Record<string, unknown>;
 	}
+}
+
+function getCurrentMessagePath(args: {
+	messageId: string;
+	currentKey: string;
+}): string[] | undefined {
+	const path = getMessagePath(args.messageId);
+	return path?.join(".") === args.currentKey ? path : undefined;
 }
 
 function withSourceLanguageFilePathMetadata(args: {

--- a/packages/plugins/next-intl/src/import-export/importFiles.ts
+++ b/packages/plugins/next-intl/src/import-export/importFiles.ts
@@ -1,0 +1,198 @@
+import type { InlangPlugin } from "@inlang/sdk";
+import type { PluginSettings } from "../settings.js";
+import { PLUGIN_KEY } from "../pluginKey.js";
+import { createMessageId } from "./messageId.js";
+
+type Pattern = Array<
+	| { type: "text"; value: string }
+	| {
+			type: "expression";
+			arg: { type: "variable-reference"; name: string };
+			annotation?: undefined;
+	  }
+>;
+type BundleImport = { id: string; declarations: Declaration[] };
+type MessageImport = {
+	id?: string;
+	bundleId: string;
+	locale: string;
+	selectors: [];
+};
+type VariantImport = {
+	id?: undefined;
+	messageId?: undefined;
+	messageBundleId: string;
+	messageLocale: string;
+	matches: [];
+	pattern: Pattern;
+};
+type Declaration = { type: "input-variable"; name: string };
+
+export const importFiles: NonNullable<
+	InlangPlugin<{ [PLUGIN_KEY]: PluginSettings }>["importFiles"]
+> = async ({
+	files,
+	settings,
+}): Promise<{
+	bundles: BundleImport[];
+	messages: MessageImport[];
+	variants: VariantImport[];
+}> => {
+	const bundles = new Map<string, BundleImport>();
+	const messages: MessageImport[] = [];
+	const variants: VariantImport[] = [];
+	const variableReferencePattern = settings?.[PLUGIN_KEY]
+		?.variableReferencePattern ?? ["{", "}"];
+
+	for (const file of files) {
+		const namespace = file.toBeImportedFilesMetadata?.namespace;
+		const resource = flattenMessages(
+			JSON.parse(new TextDecoder().decode(file.content))
+		);
+
+		for (const { key, path, value } of resource) {
+			const bundleId = namespace ? `${namespace}.${key}` : key;
+			const parsedPattern = parsePattern(value, variableReferencePattern);
+			const declarations = uniqueDeclarations(
+				parsedPattern
+					.filter(
+						(part): part is Extract<Pattern[number], { type: "expression" }> =>
+							part.type === "expression"
+					)
+					.map((part) => ({
+						type: "input-variable" as const,
+						name: part.arg.name,
+					}))
+			);
+			const existingBundle = bundles.get(bundleId);
+
+			if (existingBundle === undefined) {
+				bundles.set(bundleId, {
+					id: bundleId,
+					declarations,
+				});
+			} else {
+				existingBundle.declarations = uniqueDeclarations([
+					...existingBundle.declarations,
+					...declarations,
+				]);
+			}
+
+			messages.push({
+				id: createMessageId({
+					locale: file.locale,
+					bundleId,
+					path,
+				}),
+				bundleId,
+				locale: file.locale,
+				selectors: [],
+			});
+			variants.push({
+				messageBundleId: bundleId,
+				messageLocale: file.locale,
+				matches: [],
+				pattern: parsedPattern,
+			});
+		}
+	}
+
+	return {
+		bundles: Array.from(bundles.values()),
+		messages,
+		variants,
+	};
+};
+
+function flattenMessages(json: unknown): Array<{
+	key: string;
+	path: string[];
+	value: string;
+}> {
+	const result: Array<{ key: string; path: string[]; value: string }> = [];
+
+	function visit(value: unknown, path: string[]) {
+		if (typeof value === "string") {
+			result.push({
+				key: path.join("."),
+				path,
+				value,
+			});
+			return;
+		}
+
+		if (
+			value !== null &&
+			typeof value === "object" &&
+			Array.isArray(value) === false
+		) {
+			for (const [key, nestedValue] of Object.entries(value)) {
+				visit(nestedValue, [...path, key]);
+			}
+		}
+	}
+
+	visit(json, []);
+	return result;
+}
+
+function parsePattern(
+	text: string,
+	variableReferencePattern: string[]
+): Pattern {
+	const opening = variableReferencePattern[0] ?? "{";
+	const closing = variableReferencePattern[1] ?? "";
+	const expression = closing
+		? new RegExp(
+				`(${escapeRegExp(opening)}[\\s\\S]+?${escapeRegExp(closing)})`,
+				"g"
+			)
+		: new RegExp(`(${escapeRegExp(opening)}\\w+)`, "g");
+
+	return text
+		.split(expression)
+		.filter((element) => element !== "")
+		.map((element) => {
+			if (isVariableReference(element, opening, closing)) {
+				return {
+					type: "expression",
+					arg: {
+						type: "variable-reference",
+						name: closing
+							? element.slice(opening.length, -closing.length)
+							: element.slice(opening.length),
+					},
+				};
+			}
+			return {
+				type: "text",
+				value: element,
+			};
+		});
+}
+
+function isVariableReference(
+	text: string,
+	opening: string,
+	closing: string
+): boolean {
+	return closing
+		? text.startsWith(opening) &&
+				text.endsWith(closing) &&
+				text.length > opening.length + closing.length
+		: text.startsWith(opening) && text.length > opening.length;
+}
+
+function escapeRegExp(text: string): string {
+	return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function uniqueDeclarations(
+	declarations: BundleImport["declarations"]
+): BundleImport["declarations"] {
+	const result = new Map<string, BundleImport["declarations"][number]>();
+	for (const declaration of declarations) {
+		result.set(`${declaration.type}:${declaration.name}`, declaration);
+	}
+	return Array.from(result.values());
+}

--- a/packages/plugins/next-intl/src/import-export/messageId.ts
+++ b/packages/plugins/next-intl/src/import-export/messageId.ts
@@ -1,0 +1,27 @@
+const MESSAGE_ID_PREFIX = "plugin.inlang.nextIntl:";
+
+export function createMessageId(args: {
+	locale: string;
+	bundleId: string;
+	path: string[];
+}): string {
+	return `${MESSAGE_ID_PREFIX}${encodeURIComponent(JSON.stringify(args))}`;
+}
+
+export function getMessagePath(messageId: string): string[] | undefined {
+	if (messageId.startsWith(MESSAGE_ID_PREFIX) === false) {
+		return undefined;
+	}
+
+	try {
+		const parsed = JSON.parse(
+			decodeURIComponent(messageId.slice(MESSAGE_ID_PREFIX.length))
+		);
+		return Array.isArray(parsed.path) &&
+			parsed.path.every((segment: unknown) => typeof segment === "string")
+			? parsed.path
+			: undefined;
+	} catch {
+		return undefined;
+	}
+}

--- a/packages/plugins/next-intl/src/import-export/roundtrip.test.ts
+++ b/packages/plugins/next-intl/src/import-export/roundtrip.test.ts
@@ -150,6 +150,77 @@ test("imports and exports namespace files", async () => {
 	});
 });
 
+test("exports renamed imported namespace keys using the current bundle id", async () => {
+	const imported = await importFiles({
+		settings: {
+			"plugin.inlang.nextIntl": {
+				pathPattern: {
+					About: "./messages/{locale}/About.json",
+				},
+			},
+		} as any,
+		files: [
+			{
+				locale: "en",
+				content: new TextEncoder().encode(
+					JSON.stringify({ title: "About us" })
+				),
+				toBeImportedFilesMetadata: {
+					namespace: "About",
+				},
+			},
+		],
+	});
+	imported.bundles[0]!.id = "About.heading";
+	imported.messages[0]!.bundleId = "About.heading";
+	imported.variants[0]!.messageBundleId = "About.heading";
+
+	const exported = await runExportFiles(imported, {
+		"plugin.inlang.nextIntl": {
+			pathPattern: {
+				About: "./messages/{locale}/About.json",
+			},
+		},
+	});
+
+	expect(JSON.parse(new TextDecoder().decode(exported[0]?.content))).toEqual({
+		heading: "About us",
+	});
+});
+
+test("exports bundle ids equal to a namespace as regular keys", async () => {
+	const exported = await exportFiles({
+		settings: {
+			"plugin.inlang.nextIntl": {
+				pathPattern: {
+					About: "./messages/{locale}/About.json",
+				},
+			},
+		} as any,
+		bundles: [{ id: "About" }] as any,
+		messages: [
+			{
+				id: "message-1",
+				bundleId: "About",
+				locale: "en",
+				selectors: [],
+			},
+		] as any,
+		variants: [
+			{
+				id: "variant-1",
+				messageId: "message-1",
+				pattern: [{ type: "text", value: "About us" }],
+			},
+		] as any,
+	});
+
+	expect((exported[0] as any)?.metadata).toBeUndefined();
+	expect(JSON.parse(new TextDecoder().decode(exported[0]?.content))).toEqual({
+		About: "About us",
+	});
+});
+
 test("exports sourceLanguageFilePath metadata for the SDK writer", async () => {
 	const settings = {
 		baseLocale: "en",

--- a/packages/plugins/next-intl/src/import-export/roundtrip.test.ts
+++ b/packages/plugins/next-intl/src/import-export/roundtrip.test.ts
@@ -1,0 +1,259 @@
+import { expect, test } from "vitest";
+import { importFiles } from "./importFiles.js";
+import { exportFiles } from "./exportFiles.js";
+
+test("imports and exports a single next-intl file", async () => {
+	const imported = await runImportFiles({
+		title: "Hello {name}",
+		nested: {
+			body: "Welcome",
+		},
+	});
+
+	expect(imported.bundles.map((bundle) => bundle.id)).toEqual([
+		"title",
+		"nested.body",
+	]);
+	expect(imported.variants[0]?.pattern).toEqual([
+		{ type: "text", value: "Hello " },
+		{ type: "expression", arg: { type: "variable-reference", name: "name" } },
+	]);
+
+	const exported = await runExportFilesParsed(imported);
+
+	expect(exported).toStrictEqual({
+		title: "Hello {name}",
+		nested: {
+			body: "Welcome",
+		},
+	});
+});
+
+test("imports and exports flat dotted keys without nesting them", async () => {
+	const imported = await runImportFiles({
+		"test.test": "Flat dotted key",
+	});
+
+	expect(imported.bundles.map((bundle) => bundle.id)).toEqual(["test.test"]);
+	expect(await runExportFilesParsed(imported)).toStrictEqual({
+		"test.test": "Flat dotted key",
+	});
+});
+
+test("exports newly-created flat dotted keys without nesting them", async () => {
+	const exported = await exportFiles({
+		settings: {} as any,
+		bundles: [{ id: "test.test" }] as any,
+		messages: [
+			{
+				id: "message-1",
+				bundleId: "test.test",
+				locale: "en",
+				selectors: [],
+			},
+		] as any,
+		variants: [
+			{
+				id: "variant-1",
+				messageId: "message-1",
+				pattern: [{ type: "text", value: "Flat dotted key" }],
+			},
+		] as any,
+	});
+
+	expect(JSON.parse(new TextDecoder().decode(exported[0]?.content))).toEqual({
+		"test.test": "Flat dotted key",
+	});
+});
+
+test("skips empty objects while importing", async () => {
+	const imported = await runImportFiles({
+		a: {
+			b: {},
+		},
+		title: "Hello",
+	});
+
+	expect(imported.bundles.map((bundle) => bundle.id)).toEqual(["title"]);
+	expect(await runExportFilesParsed(imported)).toStrictEqual({
+		title: "Hello",
+	});
+});
+
+test("imports and exports namespace files", async () => {
+	const imported = await importFiles({
+		settings: {
+			"plugin.inlang.nextIntl": {
+				pathPattern: {
+					About: "./messages/{locale}/About.json",
+					HomePage: "./messages/{locale}/HomePage.json",
+				},
+			},
+		} as any,
+		files: [
+			{
+				locale: "en",
+				content: new TextEncoder().encode(
+					JSON.stringify({ title: "About us" })
+				),
+				toBeImportedFilesMetadata: {
+					namespace: "About",
+				},
+			},
+			{
+				locale: "en",
+				content: new TextEncoder().encode(
+					JSON.stringify({ hero: { title: "Welcome" } })
+				),
+				toBeImportedFilesMetadata: {
+					namespace: "HomePage",
+				},
+			},
+		],
+	});
+
+	expect(imported.bundles.map((bundle) => bundle.id)).toEqual([
+		"About.title",
+		"HomePage.hero.title",
+	]);
+
+	const exported = await runExportFiles(imported, {
+		"plugin.inlang.nextIntl": {
+			pathPattern: {
+				About: "./messages/{locale}/About.json",
+				HomePage: "./messages/{locale}/HomePage.json",
+			},
+		},
+	});
+	const exportedAbout = exported.find((file) => file.name === "About-en.json");
+	const exportedHomePage = exported.find(
+		(file) => file.name === "HomePage-en.json"
+	);
+
+	expect(
+		JSON.parse(new TextDecoder().decode(exportedAbout?.content))
+	).toStrictEqual({
+		title: "About us",
+	});
+	expect(
+		JSON.parse(new TextDecoder().decode(exportedHomePage?.content))
+	).toStrictEqual({
+		hero: {
+			title: "Welcome",
+		},
+	});
+	expect((exportedAbout as any)?.metadata).toStrictEqual({
+		namespace: "About",
+	});
+	expect((exportedHomePage as any)?.metadata).toStrictEqual({
+		namespace: "HomePage",
+	});
+});
+
+test("exports sourceLanguageFilePath metadata for the SDK writer", async () => {
+	const settings = {
+		baseLocale: "en",
+		locales: ["en", "de"],
+		"plugin.inlang.nextIntl": {
+			pathPattern: "./messages/{locale}.json",
+			sourceLanguageFilePath: "./messages/main.json",
+		},
+	};
+	const exported = await exportFiles({
+		settings: settings as any,
+		bundles: [{ id: "title" }] as any,
+		messages: [
+			{
+				id: "message-1",
+				bundleId: "title",
+				locale: "en",
+				selectors: [],
+			},
+			{
+				id: "message-2",
+				bundleId: "title",
+				locale: "de",
+				selectors: [],
+			},
+		] as any,
+		variants: [
+			{
+				id: "variant-1",
+				messageId: "message-1",
+				pattern: [{ type: "text", value: "Hello" }],
+			},
+			{
+				id: "variant-2",
+				messageId: "message-2",
+				pattern: [{ type: "text", value: "Hallo" }],
+			},
+		] as any,
+	});
+	const sourceNamespace = (exported as any[]).find(
+		(file) => file.locale === "en"
+	)?.metadata?.namespace;
+	const targetNamespace = (exported as any[]).find(
+		(file) => file.locale === "de"
+	)?.metadata?.namespace;
+
+	expect(
+		(
+			settings["plugin.inlang.nextIntl"].pathPattern as unknown as Record<
+				string,
+				string
+			>
+		)[sourceNamespace]
+	).toBe("./messages/main.json");
+	expect(
+		(
+			settings["plugin.inlang.nextIntl"].pathPattern as unknown as Record<
+				string,
+				string
+			>
+		)[targetNamespace]
+	).toBe("./messages/{locale}.json");
+});
+
+function runImportFiles(json: Record<string, any>, settings?: any) {
+	return importFiles({
+		settings: settings ?? {},
+		files: [
+			{
+				locale: "en",
+				content: new TextEncoder().encode(JSON.stringify(json)),
+			},
+		],
+	});
+}
+
+async function runExportFiles(
+	imported: Awaited<ReturnType<typeof importFiles>>,
+	settings?: any
+) {
+	for (const [index, message] of imported.messages.entries()) {
+		(message as any).id ??= `message-${index}`;
+	}
+	for (const [index, variant] of imported.variants.entries()) {
+		(variant as any).id ??= `variant-${index}`;
+		(variant as any).messageId ??= imported.messages.find(
+			(message) =>
+				message.bundleId === variant.messageBundleId &&
+				message.locale === variant.messageLocale
+		)?.id;
+	}
+
+	return exportFiles({
+		settings: settings ?? {},
+		bundles: imported.bundles as any,
+		messages: imported.messages as any,
+		variants: imported.variants as any,
+	});
+}
+
+async function runExportFilesParsed(
+	imported: Awaited<ReturnType<typeof importFiles>>,
+	settings?: any
+) {
+	const exported = await runExportFiles(imported, settings);
+	return JSON.parse(new TextDecoder().decode(exported[0]?.content));
+}

--- a/packages/plugins/next-intl/src/import-export/roundtrip.test.ts
+++ b/packages/plugins/next-intl/src/import-export/roundtrip.test.ts
@@ -189,29 +189,14 @@ test("exports sourceLanguageFilePath metadata for the SDK writer", async () => {
 			},
 		] as any,
 	});
-	const sourceNamespace = (exported as any[]).find(
-		(file) => file.locale === "en"
-	)?.metadata?.namespace;
-	const targetNamespace = (exported as any[]).find(
-		(file) => file.locale === "de"
-	)?.metadata?.namespace;
+	const sourceFile = (exported as any[]).find((file) => file.locale === "en");
+	const targetFile = (exported as any[]).find((file) => file.locale === "de");
 
-	expect(
-		(
-			settings["plugin.inlang.nextIntl"].pathPattern as unknown as Record<
-				string,
-				string
-			>
-		)[sourceNamespace]
-	).toBe("./messages/main.json");
-	expect(
-		(
-			settings["plugin.inlang.nextIntl"].pathPattern as unknown as Record<
-				string,
-				string
-			>
-		)[targetNamespace]
-	).toBe("./messages/{locale}.json");
+	expect(sourceFile?.metadata?.pathPattern).toBe("./messages/main.json");
+	expect(targetFile?.metadata?.pathPattern).toBeUndefined();
+	expect(settings["plugin.inlang.nextIntl"].pathPattern).toBe(
+		"./messages/{locale}.json"
+	);
 });
 
 function runImportFiles(json: Record<string, any>, settings?: any) {

--- a/packages/plugins/next-intl/src/import-export/toBeImportedFiles.test.ts
+++ b/packages/plugins/next-intl/src/import-export/toBeImportedFiles.test.ts
@@ -1,0 +1,112 @@
+import { expect, test } from "vitest";
+import { toBeImportedFiles } from "./toBeImportedFiles.js";
+import type { PluginSettings } from "../settings.js";
+
+test("returns files for a single path pattern", async () => {
+	const result = await toBeImportedFiles({
+		settings: {
+			baseLocale: "en",
+			locales: ["en", "de"],
+			"plugin.inlang.nextIntl": {
+				pathPattern: "/messages/{locale}.json",
+			},
+		} as any,
+	});
+
+	expect(result).toEqual([
+		{
+			locale: "en",
+			path: "/messages/en.json",
+		},
+		{
+			locale: "de",
+			path: "/messages/de.json",
+		},
+	]);
+});
+
+test("returns files for namespace path patterns", async () => {
+	const result = await toBeImportedFiles({
+		settings: {
+			baseLocale: "en",
+			locales: ["en", "de"],
+			"plugin.inlang.nextIntl": {
+				pathPattern: {
+					About: "/messages/{locale}/About.json",
+					HomePage: "/messages/HomePage/{languageTag}.json",
+				},
+			} satisfies PluginSettings,
+		} as any,
+	});
+
+	expect(result).toEqual(
+		expect.arrayContaining([
+			{
+				locale: "en",
+				path: "/messages/en/About.json",
+				metadata: {
+					namespace: "About",
+				},
+			},
+			{
+				locale: "de",
+				path: "/messages/de/About.json",
+				metadata: {
+					namespace: "About",
+				},
+			},
+			{
+				locale: "en",
+				path: "/messages/HomePage/en.json",
+				metadata: {
+					namespace: "HomePage",
+				},
+			},
+			{
+				locale: "de",
+				path: "/messages/HomePage/de.json",
+				metadata: {
+					namespace: "HomePage",
+				},
+			},
+		])
+	);
+});
+
+test("uses sourceLanguageFilePath for the source locale", async () => {
+	const result = await toBeImportedFiles({
+		settings: {
+			baseLocale: "en",
+			locales: ["en", "de"],
+			"plugin.inlang.nextIntl": {
+				pathPattern: "/messages/{locale}.json",
+				sourceLanguageFilePath: "/messages/main.json",
+			},
+		} as any,
+	});
+
+	expect(result).toEqual([
+		{
+			locale: "en",
+			path: "/messages/main.json",
+		},
+		{
+			locale: "de",
+			path: "/messages/de.json",
+		},
+	]);
+});
+
+test("returns [] if the pathPattern is not provided", async () => {
+	const result = await toBeImportedFiles({
+		settings: {
+			baseLocale: "en",
+			locales: ["en", "de"],
+			"plugin.inlang.nextIntl": {
+				"some-other-prop": "value",
+			},
+		} as any,
+	});
+
+	expect(result).toEqual([]);
+});

--- a/packages/plugins/next-intl/src/import-export/toBeImportedFiles.ts
+++ b/packages/plugins/next-intl/src/import-export/toBeImportedFiles.ts
@@ -1,0 +1,53 @@
+import type { InlangPlugin } from "@inlang/sdk";
+import type { PluginSettings } from "../settings.js";
+import { PLUGIN_KEY } from "../pluginKey.js";
+
+export const toBeImportedFiles: NonNullable<
+	InlangPlugin<{ [PLUGIN_KEY]: PluginSettings }>["toBeImportedFiles"]
+> = async ({ settings }) => {
+	const result: Array<{
+		locale: string;
+		path: string;
+		metadata?: Record<string, any>;
+	}> = [];
+	const pathPattern = settings[PLUGIN_KEY]?.pathPattern;
+	const sourceLanguageFilePath = settings[PLUGIN_KEY]?.sourceLanguageFilePath;
+	const locales = settings.locales ?? settings.languageTags ?? [];
+	const sourceLocale = settings.baseLocale ?? settings.sourceLanguageTag;
+
+	if (pathPattern === undefined) {
+		return [];
+	}
+
+	if (typeof pathPattern === "string") {
+		for (const locale of locales) {
+			const pattern =
+				locale === sourceLocale && typeof sourceLanguageFilePath === "string"
+					? sourceLanguageFilePath
+					: pathPattern;
+			result.push({
+				locale,
+				path: replaceLocale(pattern, locale),
+			});
+		}
+		return result;
+	}
+
+	for (const locale of locales) {
+		for (const namespace in pathPattern) {
+			result.push({
+				locale,
+				path: replaceLocale(pathPattern[namespace]!, locale),
+				metadata: {
+					namespace,
+				},
+			});
+		}
+	}
+
+	return result;
+};
+
+function replaceLocale(path: string, locale: string): string {
+	return path.replace(/{(locale|languageTag)}/g, locale);
+}

--- a/packages/plugins/next-intl/src/plugin.test.ts
+++ b/packages/plugins/next-intl/src/plugin.test.ts
@@ -1,17 +1,44 @@
+// @ts-nocheck
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { expect, it, describe } from "vitest";
 import type { PluginSettings } from "./settings.js";
-import {
-	createVariant,
-	getVariant,
-	ProjectSettings,
-	type Message,
-	type Variant,
-} from "@inlang/sdk";
 import { plugin } from "./plugin.js";
 import { createNodeishMemoryFs } from "@lix-js/fs";
 
 const pluginId = "plugin.inlang.nextIntl";
+type ProjectSettings = any;
+type Variant = {
+	languageTag: string;
+	match: string[];
+	pattern: Array<
+		| { type: "Text"; value: string }
+		| { type: "VariableReference"; name: string }
+	>;
+};
+type Message = {
+	id: string;
+	alias: Record<string, string>;
+	selectors: Array<{ type: "VariableReference"; name: string }>;
+	variants: Variant[];
+};
+
+function getVariant(
+	message: Message,
+	args: { where: { languageTag: string } }
+) {
+	return message.variants.find(
+		(variant) => variant.languageTag === args.where.languageTag
+	);
+}
+
+function createVariant(message: Message, args: { data: Variant }) {
+	return {
+		data: {
+			...message,
+			variants: [...message.variants, args.data],
+		},
+	};
+}
 
 describe("loadMessage", () => {
 	it("should return messages if the path pattern is valid", async () => {
@@ -34,6 +61,26 @@ describe("loadMessage", () => {
 		expect(variant?.pattern[0]?.type).toBe("Text");
 	});
 
+	it("should support the locale placeholder in legacy loadMessages", async () => {
+		const fs = createNodeishMemoryFs();
+		await fs.writeFile("./en.json", JSON.stringify({ test: "Hello world" }));
+
+		const messages = await plugin.loadMessages!({
+			settings: {
+				sourceLanguageTag: "en",
+				languageTags: ["en"],
+				modules: [],
+				[pluginId]: {
+					pathPattern: "./{locale}.json",
+				},
+			},
+			nodeishFs: fs,
+		});
+
+		const variant = getVariant(messages[0]!, { where: { languageTag: "en" } });
+		expect(variant?.pattern[0]?.type).toBe("Text");
+	});
+
 	it("should work with empty json files", async () => {
 		const fs = createNodeishMemoryFs();
 		await fs.writeFile("./en.json", JSON.stringify({}));
@@ -43,7 +90,7 @@ describe("loadMessage", () => {
 		};
 		const sourceLanguageTag = "en";
 
-		expect(
+		await expect(
 			plugin.loadMessages!({
 				settings: {
 					sourceLanguageTag,
@@ -64,7 +111,7 @@ describe("loadMessage", () => {
 		};
 		const sourceLanguageTag = "en";
 		const languageTags = ["en", "de"];
-		expect(
+		await expect(
 			plugin.loadMessages!({
 				settings: {
 					sourceLanguageTag,
@@ -137,6 +184,42 @@ describe("saveMessage", () => {
 			} as any,
 			nodeishFs: fs,
 		});
+	});
+
+	it("should replace every locale placeholder in legacy saveMessages", async () => {
+		const fs = createNodeishMemoryFs();
+		const messages: Message[] = [
+			{
+				id: "test",
+				alias: {},
+				selectors: [],
+				variants: [
+					{
+						languageTag: "en",
+						match: [],
+						pattern: [
+							{
+								type: "Text",
+								value: "Hello world",
+							},
+						],
+					},
+				],
+			},
+		];
+
+		await plugin.saveMessages!({
+			messages,
+			settings: {
+				[pluginId]: {
+					pathPattern: "./{locale}/{locale}.json",
+				},
+			} as any,
+			nodeishFs: fs,
+		});
+
+		const saved = await fs.readFile("./en/en.json", { encoding: "utf-8" });
+		expect(JSON.parse(saved)).toEqual({ test: "Hello world" });
 	});
 });
 

--- a/packages/plugins/next-intl/src/plugin.ts
+++ b/packages/plugins/next-intl/src/plugin.ts
@@ -1,32 +1,80 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import type {
-	Message,
-	Variant,
-	LanguageTag,
-	Plugin,
-	NodeishFilesystemSubset,
-	ProjectSettings,
-} from "@inlang/sdk";
+import type { InlangPlugin } from "@inlang/sdk";
 import { PluginSettings } from "./settings.js";
 import { replaceAll } from "./utilities.js";
 import { ideExtensionConfig } from "./ideExtension/config.js";
 import { flatten, unflatten } from "flat";
 import { detectJsonFormatting } from "@inlang/detect-json-formatting";
+import { importFiles } from "./import-export/importFiles.js";
+import { exportFiles } from "./import-export/exportFiles.js";
+import { toBeImportedFiles } from "./import-export/toBeImportedFiles.js";
+import { PLUGIN_KEY } from "./pluginKey.js";
 
 // global variable to store the formatting of the file
 let serializeWithFormatting: ReturnType<typeof detectJsonFormatting>;
 let hasNestedKeys = false;
 
-const id = "plugin.inlang.nextIntl";
+const id = PLUGIN_KEY;
 
-export const plugin: Plugin<{
-	[id]: PluginSettings;
-}> = {
+type LanguageTag = string;
+type LegacyPattern = Array<
+	{ type: "Text"; value: string } | { type: "VariableReference"; name: string }
+>;
+type Variant = {
+	languageTag: LanguageTag;
+	match: string[];
+	pattern: LegacyPattern;
+};
+type Message = {
+	id: string;
+	alias: Record<string, string>;
+	selectors: Array<{ type: "VariableReference"; name: string }>;
+	variants: Variant[];
+};
+type NodeishFilesystemSubset = {
+	readFile:
+		| ((path: string) => Promise<ArrayBuffer>)
+		| ((path: string, options?: { encoding: "utf-8" }) => Promise<string>);
+	readdir: (path: string) => Promise<string[]>;
+	writeFile: (path: string, data: ArrayBuffer | string) => Promise<void>;
+	mkdir: (path: string, options?: { recursive?: boolean }) => Promise<void>;
+};
+type LegacyProjectSettings = {
+	sourceLanguageTag: LanguageTag;
+	languageTags: LanguageTag[];
+	modules?: string[];
+};
+type NextIntlPlugin = Omit<
+	InlangPlugin<{ [id]: PluginSettings }>,
+	"loadMessages" | "saveMessages" | "addCustomApi"
+> & {
+	id: string;
+	displayName: string;
+	description: string;
+	loadMessages: (args: {
+		settings: LegacyProjectSettings & { [id]: PluginSettings };
+		nodeishFs: NodeishFilesystemSubset;
+	}) => Promise<Message[]>;
+	saveMessages: (args: {
+		messages: Message[];
+		settings: LegacyProjectSettings & { [id]: PluginSettings };
+		nodeishFs: NodeishFilesystemSubset;
+	}) => Promise<void>;
+	addCustomApi: (args: {
+		settings: { [id]: PluginSettings };
+	}) => Record<string, unknown>;
+};
+
+export const plugin: NextIntlPlugin = {
 	id,
+	key: id,
 	displayName: "Next-intl",
 	description:
 		"A plugin for the Next.js internationalization library next-intl",
 	settingsSchema: PluginSettings,
+	importFiles,
+	exportFiles,
+	toBeImportedFiles,
 
 	loadMessages: async ({ settings, nodeishFs }) => {
 		settings["plugin.inlang.nextIntl"].variableReferencePattern = settings[
@@ -60,15 +108,18 @@ export const plugin: Plugin<{
 async function loadMessages(args: {
 	nodeishFs: NodeishFilesystemSubset;
 	pluginSettings: PluginSettings;
-	settings: ProjectSettings;
+	settings: LegacyProjectSettings;
 }): Promise<Message[]> {
 	const messages: Message[] = [];
+	const pathPattern = assertLegacyStringPathPattern(
+		args.pluginSettings.pathPattern
+	);
 	for (const languageTag of resolveOrderOfLanguageTags(
 		args.settings.languageTags,
 		args.settings.sourceLanguageTag
 	)) {
 		const messagesFromFile = await getFileToParse(
-			args.pluginSettings.pathPattern,
+			pathPattern,
 			languageTag,
 			args.settings.sourceLanguageTag,
 			args.nodeishFs,
@@ -107,13 +158,13 @@ async function getFileToParse(
 	pathWithLanguage?: string
 ): Promise<Record<string, string>> {
 	if (typeof pathWithLanguage === "undefined") {
-		pathWithLanguage = path.replace("{languageTag}", languageTag);
+		pathWithLanguage = path.replace(/\{(languageTag|locale)\}/g, languageTag);
 	}
 	// get file, make sure that is not braking when the namespace doesn't exist in every languageTag dir
 	try {
-		const file = await nodeishFs.readFile(pathWithLanguage, {
+		const file = (await nodeishFs.readFile(pathWithLanguage, {
 			encoding: "utf-8",
-		});
+		})) as string;
 		//analyse format of file
 		if (sourceLanguageTag === languageTag) {
 			serializeWithFormatting = detectJsonFormatting(file);
@@ -251,6 +302,9 @@ async function saveMessages(args: {
 	pluginSettings: PluginSettings;
 	messages: Message[];
 }) {
+	const pathPattern = assertLegacyStringPathPattern(
+		args.pluginSettings.pathPattern
+	);
 	const storage:
 		| Record<LanguageTag, Record<Message["id"], Variant["pattern"]>>
 		| undefined = {};
@@ -265,7 +319,7 @@ async function saveMessages(args: {
 			typeof args.pluginSettings.sourceLanguageFilePath === "string" &&
 			languageTag === Object.keys(storage)[0] // sourceLanguage is always the first languageTag
 				? args.pluginSettings.sourceLanguageFilePath
-				: args.pluginSettings.pathPattern.replace("{languageTag}", languageTag);
+				: replaceLocale(pathPattern, languageTag);
 		try {
 			await args.nodeishFs.readdir(
 				pathWithLanguage.split("/").slice(0, -1).join("/")
@@ -283,6 +337,21 @@ async function saveMessages(args: {
 			serializeFile(value, args.pluginSettings.variableReferencePattern)
 		);
 	}
+}
+
+function assertLegacyStringPathPattern(
+	pathPattern: PluginSettings["pathPattern"]
+): string {
+	if (typeof pathPattern !== "string") {
+		throw new Error(
+			"Namespace pathPattern objects require the new import/export API."
+		);
+	}
+	return pathPattern;
+}
+
+function replaceLocale(pathPattern: string, locale: string): string {
+	return pathPattern.replace(/\{(languageTag|locale)\}/g, locale);
 }
 
 /**

--- a/packages/plugins/next-intl/src/pluginKey.ts
+++ b/packages/plugins/next-intl/src/pluginKey.ts
@@ -1,0 +1,3 @@
+// Kept in its own module so import-export modules can use the key without
+// importing plugin.ts, which would create a circular runtime import.
+export const PLUGIN_KEY = "plugin.inlang.nextIntl";

--- a/packages/plugins/next-intl/src/settings.test.ts
+++ b/packages/plugins/next-intl/src/settings.test.ts
@@ -10,7 +10,9 @@ import { Value } from "@sinclair/typebox/value";
 test("valid path patterns", async () => {
 	const validPathPatterns = [
 		"/folder/{languageTag}.json",
+		"/folder/{locale}.json",
 		"./{languageTag}/file.json",
+		"./{locale}/file.json",
 		"../folder/{languageTag}/file.json",
 		"./{languageTag}.json",
 		"./{languageTag}/folder/file.json",
@@ -32,6 +34,46 @@ test("it should fail if the path pattern does not start as a ralaitve path with 
 	});
 	expect(isValid).toBe(false);
 });
+
+test("if pathPattern with namespaces includes the correct pathpattern schema", async () => {
+	const pathPattern = {
+		About: "./{languageTag}/About.json",
+		HomePage: "./{locale}/HomePage.json",
+	};
+
+	const isValid = Value.Check(plugin.settingsSchema!, {
+		pathPattern,
+	});
+	expect(isValid).toBe(true);
+});
+
+test("if pathPattern with namespaces includes an incorrect pathpattern", async () => {
+	const pathPattern = {
+		About: "./About.json",
+	};
+
+	const isValid = Value.Check(plugin.settingsSchema!, {
+		pathPattern,
+	});
+	expect(isValid).toBe(false);
+});
+
+test("sourceLanguageFilePath accepts a fixed source file path", async () => {
+	const isValid = Value.Check(plugin.settingsSchema!, {
+		pathPattern: "./{locale}.json",
+		sourceLanguageFilePath: "./resources/main.json",
+	});
+	expect(isValid).toBe(true);
+});
+
+test("sourceLanguageFilePath rejects files that do not end with json", async () => {
+	const isValid = Value.Check(plugin.settingsSchema!, {
+		pathPattern: "./{locale}.json",
+		sourceLanguageFilePath: "./resources/main.txt",
+	});
+	expect(isValid).toBe(false);
+});
+
 test("if path patter does include the word `{languageTag}`", async () => {
 	const pathPattern = "./examplePath.json";
 

--- a/packages/plugins/next-intl/src/settings.ts
+++ b/packages/plugins/next-intl/src/settings.ts
@@ -1,20 +1,34 @@
 // Settings for next-intl plugin
 import { Type, type Static } from "@sinclair/typebox";
 const PathPattern = Type.String({
-	pattern: "^(\\./|\\../|/)[^*]*\\{languageTag\\}[^*]*\\.json",
+	pattern: "^(\\./|\\../|/)[^*]*\\{(languageTag|locale)\\}[^*]*\\.json",
 	title: "Path to language files",
 	description:
-		"Specify the pathPattern to locate language files in your repository. It must include `{languageTag}` and end with `.json`.",
+		"Specify the pathPattern to locate language files in your repository. It must include `{locale}` or legacy `{languageTag}` and end with `.json`.",
 	examples: [
-		"./{languageTag}/file.json",
-		"../folder/{languageTag}/file.json",
-		"./{languageTag}.json",
+		"./{locale}/file.json",
+		"../folder/{locale}/file.json",
+		"./{locale}.json",
 	],
 });
+const SourceLanguageFilePath = Type.String({
+	pattern: "^(\\./|\\../|/)[^*]*\\.json$",
+	title: "Path to source language file",
+	description:
+		"Specify the sourceLanguageFilePath if the source language file does not match pathPattern. It must end with `.json`.",
+	examples: ["./resources/main.json"],
+});
+const NamespacePathPattern = Type.Record(
+	Type.String({
+		description: "The next-intl namespace.",
+		examples: ["website", "app", "auth.SignUp"],
+	}),
+	PathPattern
+);
 
 export type PluginSettings = Static<typeof PluginSettings>;
 export const PluginSettings = Type.Object({
-	pathPattern: PathPattern,
+	pathPattern: Type.Union([PathPattern, NamespacePathPattern]),
 	variableReferencePattern: Type.Optional(
 		Type.Array(Type.String(), {
 			title: "Variable reference pattern",
@@ -23,7 +37,7 @@ export const PluginSettings = Type.Object({
 			examples: ["{ and }", "{{ and }}", "< and >", "@:"],
 		})
 	),
-	sourceLanguageFilePath: Type.Optional(PathPattern),
+	sourceLanguageFilePath: Type.Optional(SourceLanguageFilePath),
 	ignore: Type.Optional(
 		Type.Array(Type.String(), {
 			title: "Ignore paths",

--- a/packages/sdk/src/project/api.ts
+++ b/packages/sdk/src/project/api.ts
@@ -78,7 +78,8 @@ export type ExportFile = {
 	 * use it to pass information to the writer. For example, a plugin that
 	 * supports a namespaced `pathPattern` (`Record<namespace, pattern>`)
 	 * provides `{ namespace }` so that `saveProjectToDirectory` can resolve
-	 * the pattern each exported file belongs to.
+	 * the pattern each exported file belongs to. Plugins can also provide
+	 * `{ pathPattern }` to override the configured pattern for one file.
 	 *
 	 * https://github.com/opral/inlang/issues/4356
 	 */

--- a/packages/sdk/src/project/saveProjectToDirectory.test.ts
+++ b/packages/sdk/src/project/saveProjectToDirectory.test.ts
@@ -259,6 +259,51 @@ test("resolves a namespaced pathPattern object via export file metadata", async 
 	expect(JSON.parse(app as string)).toEqual({ title: "My app" });
 });
 
+test("resolves an export file pathPattern metadata override", async () => {
+	const volume = Volume.fromJSON({});
+	const mockPlugin: InlangPlugin = {
+		key: "mock",
+		exportFiles: async () => [
+			{
+				locale: "en",
+				name: "en.json",
+				content: new TextEncoder().encode(JSON.stringify({ hello: "Hello" })),
+				metadata: { pathPattern: "./main.json" },
+			},
+			{
+				locale: "de",
+				name: "de.json",
+				content: new TextEncoder().encode(JSON.stringify({ hello: "Hallo" })),
+			},
+		],
+	};
+
+	const project = await loadProjectInMemory({
+		blob: await newProject({
+			settings: {
+				baseLocale: "en",
+				locales: ["en", "de"],
+				modules: [],
+				mock: {
+					pathPattern: "./{locale}.json",
+				},
+			},
+		}),
+		providePlugins: [mockPlugin],
+	});
+
+	await saveProjectToDirectory({
+		fs: volume as any,
+		project,
+		path: "/foo/bar.inlang",
+	});
+
+	const source = await volume.promises.readFile("/foo/main.json", "utf-8");
+	const target = await volume.promises.readFile("/foo/de.json", "utf-8");
+	expect(JSON.parse(source as string)).toEqual({ hello: "Hello" });
+	expect(JSON.parse(target as string)).toEqual({ hello: "Hallo" });
+});
+
 // old plugin versions don't provide namespace metadata. falling back to
 // file.name is better than throwing "pathPattern.replace is not a function"
 // https://github.com/opral/inlang/issues/4356
@@ -342,7 +387,10 @@ test("falls back to the file name when the namespace is missing from the pathPat
 		path: "/foo/bar.inlang",
 	});
 
-	const fallback = await volume.promises.readFile("/foo/stray-en.json", "utf-8");
+	const fallback = await volume.promises.readFile(
+		"/foo/stray-en.json",
+		"utf-8"
+	);
 	expect(JSON.parse(fallback as string)).toEqual({ hello: "Hello" });
 });
 

--- a/packages/sdk/src/project/saveProjectToDirectory.ts
+++ b/packages/sdk/src/project/saveProjectToDirectory.ts
@@ -193,7 +193,9 @@ export async function saveProjectToDirectory(args: {
 				// mapping namespaces to patterns (e.g. plugin-i18next).
 				// https://github.com/opral/inlang/issues/4356
 				let targetPaths: string[];
-				if (typeof pathPattern === "string") {
+				if (typeof file.metadata?.["pathPattern"] === "string") {
+					targetPaths = [resolvePattern(file.metadata["pathPattern"])];
+				} else if (typeof pathPattern === "string") {
 					targetPaths = [resolvePattern(pathPattern)];
 				} else if (Array.isArray(pathPattern)) {
 					// an empty array writes nothing

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -676,8 +676,8 @@ importers:
         specifier: 2.4.14
         version: 2.4.14(@sinclair/typebox@0.31.28)
       '@inlang/sdk':
-        specifier: 0.36.3
-        version: 0.36.3(babel-plugin-macros@3.1.0)
+        specifier: workspace:*
+        version: link:../../sdk
       '@inlang/tsconfig':
         specifier: workspace:*
         version: link:../../tsconfig


### PR DESCRIPTION
## Summary

- Add next-intl import/export API support for namespace path patterns
- Support `{locale}` as the recommended path placeholder while keeping `{languageTag}` compatible
- Preserve flat dotted key roundtrips and sourceLanguageFilePath behavior in the new export path
- Allow exported files to override the writer path pattern via metadata without mutating settings
- Keep namespace exports stable after key renames and avoid treating namespace-only bundle IDs as namespaced keys

Closes https://github.com/opral/inlang/issues/4367

## Validation

- pnpm --filter @inlang/plugin-next-intl test
- pnpm --filter @inlang/plugin-next-intl build
- pnpm --filter @inlang/sdk exec vitest run src/project/saveProjectToDirectory.test.ts
- pnpm --filter @inlang/sdk exec tsc --noEmit
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how translation files are discovered, imported, and written on disk (including per-file path overrides), but legacy string patterns stay supported and coverage is broad.
> 
> **Overview**
> Adds **`importFiles`**, **`exportFiles`**, and **`toBeImportedFiles`** to `@inlang/plugin-next-intl` so the SDK can sync next-intl JSON through the modern import/export pipeline, not only legacy `loadMessages` / `saveMessages`.
> 
> **`pathPattern`** can now be a **namespace map** (e.g. `About` → `./messages/{locale}/About.json`). Namespace files carry **`metadata.namespace`** on export; bundle IDs become `Namespace.key`. Object-shaped patterns are **rejected** on the legacy hooks with a clear error.
> 
> Path placeholders prefer **`{locale}`**; **`{languageTag}`** still works in settings, discovery, and legacy read/write. **`sourceLanguageFilePath`** is modeled as a fixed JSON path (no locale token) and, on export, the source locale file can attach **`metadata.pathPattern`** so the writer lands on `main.json` without changing project settings.
> 
> Import/export preserve **nested vs flat** JSON (via encoded message paths), **flat dotted keys**, and variable interpolation. The SDK’s **`saveProjectToDirectory`** now checks **`file.metadata.pathPattern`** first when resolving write paths (patch + test).
> 
> Docs, settings schema, and roundtrip tests cover namespaces, renames, and source-file overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f7884597410139267c25e6bee7f5059394ec17d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->