### PR TITLE
fix(sdk): normalize Windows project sync paths

### DIFF
--- a/.changeset/ninety-lights-attend.md
+++ b/.changeset/ninety-lights-attend.md
@@ -1,0 +1,5 @@
+---
+"@inlang/sdk": patch
+---
+
+Fix Windows project sync path normalization to avoid rewriting unchanged files.

--- a/packages/sdk/src/project/loadProjectFromDirectory.test.ts
+++ b/packages/sdk/src/project/loadProjectFromDirectory.test.ts
@@ -473,6 +473,41 @@ describe("it should keep files between the inlang directory and lix in sync", as
 		expect(filesByPath["/settings.json"]).toBe(JSON.stringify(mockSettings));
 	});
 
+	test("does not rewrite unchanged files when nodePath.relative returns Windows separators", async () => {
+		const fs = Volume.fromJSON(mockDirectory);
+		const originalRelative = nodePath.relative.bind(nodePath);
+		const relativeSpy = vi
+			.spyOn(nodePath, "relative")
+			.mockImplementation((from, to) =>
+				originalRelative(from, to)
+					.split(nodePath.posix.sep)
+					.join(nodePath.win32.sep)
+			);
+		const writeFileSyncSpy = vi.spyOn(fs, "writeFileSync");
+		const writeFileSpy = vi.spyOn(fs.promises, "writeFile");
+
+		try {
+			const project = await loadProjectFromDirectory({
+				fs: fs as any,
+				path: "/project.inlang",
+			});
+
+			await project.close();
+
+			const writesToProjectFiles = [
+				...writeFileSyncSpy.mock.calls.map((call) => String(call[0])),
+				...writeFileSpy.mock.calls.map((call) => String(call[0])),
+			].filter((path) => path.startsWith("/project.inlang/"));
+
+			expect(relativeSpy).toHaveBeenCalled();
+			expect(writesToProjectFiles).toEqual([]);
+		} finally {
+			writeFileSpy.mockRestore();
+			writeFileSyncSpy.mockRestore();
+			relativeSpy.mockRestore();
+		}
+	});
+
 	test("file created in fs should be avaialable in lix ", async () => {
 		const syncInterval = 100;
 		const fs = Volume.fromJSON(mockDirectory);

--- a/packages/sdk/src/project/loadProjectFromDirectory.ts
+++ b/packages/sdk/src/project/loadProjectFromDirectory.ts
@@ -318,7 +318,12 @@ async function syncLixFsFiles(args: {
 				// NOTE we could start with comparing the mdate and skip file read completely...
 				const data = args.fs.readFileSync(fullPath) as unknown as ArrayBuffer;
 
-				const relativePath = "/" + nodePath.relative(args.path, fullPath);
+				const relativePath =
+					"/" +
+					nodePath
+						.relative(args.path, fullPath)
+						.split(nodePath.win32.sep)
+						.join(nodePath.posix.sep);
 				if (!shouldSyncPath(relativePath)) {
 					continue;
 				}


### PR DESCRIPTION
## Summary

This fixes a Windows-only path normalization bug in `loadProjectFromDirectory()`.

When project files are scanned from disk, `checkFsStateRecursive()` uses `nodePath.relative()` to build the filesystem sync key. On Windows, that can produce paths such as `/messages\\en.json`, while LIX stores the same file as `/messages/en.json`.

Because those keys do not match, unchanged files can be treated as missing and written back to disk. That updates file mtimes even when file contents are identical, which can trigger watch/recompile loops in downstream tools.

## Root cause

Before this change:

- fs-side keys could contain Windows separators, for example `/messages\\en.json`
- LIX-side keys were normalized to POSIX separators, for example `/messages/en.json`
- the sync layer compared those keys directly and treated them as different files

## Fix

- normalize the relative filesystem path to POSIX separators before using it as a sync key
- add a regression test that simulates `nodePath.relative()` returning Windows-style separators and verifies that unchanged project files are not rewritten

## Why this matters

This prevents false-positive file change events for unchanged files in `project.inlang/`, including message files such as `messages/en.json` and `messages/zh.json`.

In practice, this is especially visible in watch-based workflows because touching unchanged files is enough to trigger another compile cycle.

## Validation

- added targeted regression coverage for the Windows separator case
- I was not able to run the full upstream Vitest flow in this cloned checkout because the local workspace install repeatedly produced a corrupted `vite-node` package on this machine