### PR TITLE
Fix next-intl translator alias matching

### DIFF
--- a/.changeset/fuzzy-next-intl-aliases.md
+++ b/.changeset/fuzzy-next-intl-aliases.md
@@ -1,0 +1,7 @@
+---
+"@inlang/plugin-next-intl": minor
+---
+
+Improve Sherlock message reference matching for next-intl translator aliases and quoted object namespace assignments.
+
+The matcher now resolves simple aliases like `const translate = t`, chained aliases, renamed destructured translation functions, and direct `getTranslations({ namespace })` assignments with single- or double-quoted namespace values.

--- a/packages/plugins/next-intl/src/ideExtension/messageReferenceMatchers.test.ts
+++ b/packages/plugins/next-intl/src/ideExtension/messageReferenceMatchers.test.ts
@@ -398,6 +398,103 @@ it("should stop resolving an alias after a later non-translator declaration shad
 	expect(matches).toHaveLength(0);
 });
 
+it("should stop resolving an alias when a block shadow uses property access", async () => {
+	const sourceCode = `
+		const t = useTranslations("DirectoryPage");
+		const translate = t;
+		{
+			const translate = t.rich;
+			<p>{translate("title")}</p>
+		}
+	`;
+	const settings: PluginSettings = {
+		pathPattern: "./{language}.json",
+	};
+	const matches = parse(sourceCode, settings);
+	expect(matches).toHaveLength(0);
+});
+
+it("should stop resolving an alias when a block shadow uses a fallback expression", async () => {
+	const sourceCode = `
+		const t = useTranslations("DirectoryPage");
+		const translate = t;
+		{
+			const translate = t ?? fallback;
+			<p>{translate("title")}</p>
+		}
+	`;
+	const settings: PluginSettings = {
+		pathPattern: "./{language}.json",
+	};
+	const matches = parse(sourceCode, settings);
+	expect(matches).toHaveLength(0);
+});
+
+it("should stop resolving an alias when a block shadow uses an object literal", async () => {
+	const sourceCode = `
+		const t = useTranslations("DirectoryPage");
+		const translate = t;
+		{
+			const translate = { t };
+			<p>{translate("title")}</p>
+		}
+	`;
+	const settings: PluginSettings = {
+		pathPattern: "./{language}.json",
+	};
+	const matches = parse(sourceCode, settings);
+	expect(matches).toHaveLength(0);
+});
+
+it("should stop resolving an alias when a block shadow uses an array literal", async () => {
+	const sourceCode = `
+		const t = useTranslations("DirectoryPage");
+		const translate = t;
+		{
+			const translate = [t];
+			<p>{translate("title")}</p>
+		}
+	`;
+	const settings: PluginSettings = {
+		pathPattern: "./{language}.json",
+	};
+	const matches = parse(sourceCode, settings);
+	expect(matches).toHaveLength(0);
+});
+
+it("should stop resolving an alias when a block shadow uses a function literal", async () => {
+	const sourceCode = `
+		const t = useTranslations("DirectoryPage");
+		const translate = t;
+		{
+			const translate = () => t("button");
+			<p>{translate("title")}</p>
+		}
+	`;
+	const settings: PluginSettings = {
+		pathPattern: "./{language}.json",
+	};
+	const matches = parse(sourceCode, settings);
+	expect(matches).toHaveLength(0);
+});
+
+it("should only match the initializer call when a block shadow uses a call expression", async () => {
+	const sourceCode = `
+		const t = useTranslations("DirectoryPage");
+		const translate = t;
+		{
+			const translate = t("button");
+			<p>{translate("title")}</p>
+		}
+	`;
+	const settings: PluginSettings = {
+		pathPattern: "./{language}.json",
+	};
+	const matches = parse(sourceCode, settings);
+	expect(matches).toHaveLength(1);
+	expect(matches[0]?.messageId).toBe("DirectoryPage.button");
+});
+
 it("should restore an outer alias after a block-local shadow ends", async () => {
 	const sourceCode = `
 		const t = useTranslations("DirectoryPage");
@@ -413,6 +510,123 @@ it("should restore an outer alias after a block-local shadow ends", async () => 
 	const matches = parse(sourceCode, settings);
 	expect(matches).toHaveLength(1);
 	expect(matches[0]?.messageId).toBe("DirectoryPage.title");
+});
+
+it("should restore an outer alias after a template interpolation shadow ends", async () => {
+	const sourceCode = `
+		const t = useTranslations("DirectoryPage");
+		const translate = t;
+		const value = \`\${(() => { const translate = other; })()}\`;
+		<p>{translate("title")}</p>
+	`;
+	const settings: PluginSettings = {
+		pathPattern: "./{language}.json",
+	};
+	const matches = parse(sourceCode, settings);
+	expect(matches).toHaveLength(1);
+	expect(matches[0]?.messageId).toBe("DirectoryPage.title");
+});
+
+it("should ignore fake alias shadows in template literal text", async () => {
+	const sourceCode = `
+		const t = useTranslations("DirectoryPage");
+		const translate = t;
+		const value = \`{ const translate = other; translate("title") }\`;
+		<p>{translate("after")}</p>
+	`;
+	const settings: PluginSettings = {
+		pathPattern: "./{language}.json",
+	};
+	const matches = parse(sourceCode, settings);
+	expect(matches).toHaveLength(1);
+	expect(matches[0]?.messageId).toBe("DirectoryPage.after");
+});
+
+it("should ignore fake alias shadows in comments", async () => {
+	const sourceCode = `
+		const t = useTranslations("DirectoryPage");
+		const translate = t;
+		// { const translate = other; translate("title") }
+		<p>{translate("after")}</p>
+	`;
+	const settings: PluginSettings = {
+		pathPattern: "./{language}.json",
+	};
+	const matches = parse(sourceCode, settings);
+	expect(matches).toHaveLength(1);
+	expect(matches[0]?.messageId).toBe("DirectoryPage.after");
+});
+
+it("should not match calls to a block-local shadow of the canonical translator", async () => {
+	const sourceCode = `
+		const t = useTranslations("DirectoryPage");
+		{
+			const t = other;
+			<p>{t("title")}</p>
+		}
+	`;
+	const settings: PluginSettings = {
+		pathPattern: "./{language}.json",
+	};
+	const matches = parse(sourceCode, settings);
+	expect(matches).toHaveLength(0);
+});
+
+it("should not match calls to a function-local shadow of the canonical translator", async () => {
+	const sourceCode = `
+		const t = useTranslations("DirectoryPage");
+		function renderTitle() {
+			const t = other;
+			return <p>{t("title")}</p>;
+		}
+	`;
+	const settings: PluginSettings = {
+		pathPattern: "./{language}.json",
+	};
+	const matches = parse(sourceCode, settings);
+	expect(matches).toHaveLength(0);
+});
+
+it("should not match calls to a callback parameter shadowing the canonical translator", async () => {
+	const sourceCode = `
+		const t = useTranslations("DirectoryPage");
+		items.map((t) => <p>{t("title")}</p>);
+	`;
+	const settings: PluginSettings = {
+		pathPattern: "./{language}.json",
+	};
+	const matches = parse(sourceCode, settings);
+	expect(matches).toHaveLength(0);
+});
+
+it("should not match calls to a catch parameter shadowing the canonical translator", async () => {
+	const sourceCode = `
+		const t = useTranslations("DirectoryPage");
+		try {
+			render();
+		} catch (t) {
+			t("title");
+		}
+	`;
+	const settings: PluginSettings = {
+		pathPattern: "./{language}.json",
+	};
+	const matches = parse(sourceCode, settings);
+	expect(matches).toHaveLength(0);
+});
+
+it("should not match calls to a for-loop binding shadowing the canonical translator", async () => {
+	const sourceCode = `
+		const t = useTranslations("DirectoryPage");
+		for (const t of translators) {
+			t("title");
+		}
+	`;
+	const settings: PluginSettings = {
+		pathPattern: "./{language}.json",
+	};
+	const matches = parse(sourceCode, settings);
+	expect(matches).toHaveLength(0);
 });
 
 it("should not treat property access as a translator alias", async () => {
@@ -447,6 +661,110 @@ it("should not treat fallback expressions as translator aliases", async () => {
 		const t = useTranslations("DirectoryPage");
 		const translate = t ?? fallback;
 		<p>{translate("title")}</p>
+	`;
+	const settings: PluginSettings = {
+		pathPattern: "./{language}.json",
+	};
+	const matches = parse(sourceCode, settings);
+	expect(matches).toHaveLength(0);
+});
+
+it("should not resolve an alias inside a destructured block shadow", async () => {
+	const sourceCode = `
+		const { t: translate } = useTranslations("DirectoryPage");
+		{
+			const { t: translate } = other;
+			<p>{translate("title")}</p>
+		}
+	`;
+	const settings: PluginSettings = {
+		pathPattern: "./{language}.json",
+	};
+	const matches = parse(sourceCode, settings);
+	expect(matches).toHaveLength(0);
+});
+
+it("should not resolve an alias shadowed by a function parameter", async () => {
+	const sourceCode = `
+		const t = useTranslations("DirectoryPage");
+		const translate = t;
+		function render(translate) {
+			return translate("title");
+		}
+	`;
+	const settings: PluginSettings = {
+		pathPattern: "./{language}.json",
+	};
+	const matches = parse(sourceCode, settings);
+	expect(matches).toHaveLength(0);
+});
+
+it("should not resolve an alias shadowed by a local function declaration", async () => {
+	const sourceCode = `
+		const t = useTranslations("DirectoryPage");
+		const translate = t;
+		function translate(key) {
+			return key;
+		}
+		translate("title");
+	`;
+	const settings: PluginSettings = {
+		pathPattern: "./{language}.json",
+	};
+	const matches = parse(sourceCode, settings);
+	expect(matches).toHaveLength(0);
+});
+
+it("should not resolve an alias after it is reassigned away from the translator", async () => {
+	const sourceCode = `
+		const t = useTranslations("DirectoryPage");
+		let translate = t;
+		translate = other;
+		<p>{translate("title")}</p>
+	`;
+	const settings: PluginSettings = {
+		pathPattern: "./{language}.json",
+	};
+	const matches = parse(sourceCode, settings);
+	expect(matches).toHaveLength(0);
+});
+
+it("should resolve a translator assigned through a later assignment", async () => {
+	const sourceCode = `
+		const t = useTranslations("DirectoryPage");
+		let translate;
+		translate = t;
+		<p>{translate("title")}</p>
+	`;
+	const settings: PluginSettings = {
+		pathPattern: "./{language}.json",
+	};
+	const matches = parse(sourceCode, settings);
+	expect(matches).toHaveLength(1);
+	expect(matches[0]?.messageId).toBe("DirectoryPage.title");
+});
+
+it("should not match t calls inside a function parameter shadow", async () => {
+	const sourceCode = `
+		const t = useTranslations("DirectoryPage");
+		function render(t) {
+			return t("title");
+		}
+	`;
+	const settings: PluginSettings = {
+		pathPattern: "./{language}.json",
+	};
+	const matches = parse(sourceCode, settings);
+	expect(matches).toHaveLength(0);
+});
+
+it("should not match t calls inside a local function declaration shadow", async () => {
+	const sourceCode = `
+		const t = useTranslations("DirectoryPage");
+		function t(key) {
+			return key;
+		}
+		t("title");
 	`;
 	const settings: PluginSettings = {
 		pathPattern: "./{language}.json",

--- a/packages/plugins/next-intl/src/ideExtension/messageReferenceMatchers.test.ts
+++ b/packages/plugins/next-intl/src/ideExtension/messageReferenceMatchers.test.ts
@@ -314,6 +314,156 @@ it("should add the defined namespace by useTranslations hook", async () => {
 	expect(matches[0]?.messageId).toBe("DirectoryPage.title");
 });
 
+it("should add the defined namespace for renamed destructured useTranslations hook", async () => {
+	const sourceCode = `
+		const { t: translate } = useTranslations("DirectoryPage");
+		<p>{translate("title")}</p>
+	`;
+	const settings: PluginSettings = {
+		pathPattern: "./{language}.json",
+	};
+	const matches = parse(sourceCode, settings);
+	expect(matches).toHaveLength(1);
+	expect(matches[0]?.messageId).toBe("DirectoryPage.title");
+});
+
+it("should resolve simple aliases of namespaced translation functions", async () => {
+	const sourceCode = `
+		const t = useTranslations("DirectoryPage");
+		const translate = t;
+		<p>{translate("title")}</p>
+	`;
+	const settings: PluginSettings = {
+		pathPattern: "./{language}.json",
+	};
+	const matches = parse(sourceCode, settings);
+	expect(matches).toHaveLength(1);
+	expect(matches[0]?.messageId).toBe("DirectoryPage.title");
+});
+
+it("should resolve chained aliases of namespaced translation functions", async () => {
+	const sourceCode = `
+		const t = useTranslations("DirectoryPage");
+		const translate = t;
+		const label = translate;
+		<p>{label("title")}</p>
+	`;
+	const settings: PluginSettings = {
+		pathPattern: "./{language}.json",
+	};
+	const matches = parse(sourceCode, settings);
+	expect(matches).toHaveLength(1);
+	expect(matches[0]?.messageId).toBe("DirectoryPage.title");
+});
+
+it("should not resolve aliases declared before the namespaced translation function", async () => {
+	const sourceCode = `
+		const translate = t;
+		const t = useTranslations("DirectoryPage");
+		<p>{translate("title")}</p>
+	`;
+	const settings: PluginSettings = {
+		pathPattern: "./{language}.json",
+	};
+	const matches = parse(sourceCode, settings);
+	expect(matches).toHaveLength(0);
+});
+
+it("should not emit raw matches for alias calls before the alias declaration", async () => {
+	const sourceCode = `
+		<p>{translate("title")}</p>
+		const t = useTranslations("DirectoryPage");
+		const translate = t;
+	`;
+	const settings: PluginSettings = {
+		pathPattern: "./{language}.json",
+	};
+	const matches = parse(sourceCode, settings);
+	expect(matches).toHaveLength(0);
+});
+
+it("should stop resolving an alias after a later non-translator declaration shadows it", async () => {
+	const sourceCode = `
+		const t = useTranslations("DirectoryPage");
+		const translate = t;
+		{
+			const translate = other;
+			<p>{translate("title")}</p>
+		}
+	`;
+	const settings: PluginSettings = {
+		pathPattern: "./{language}.json",
+	};
+	const matches = parse(sourceCode, settings);
+	expect(matches).toHaveLength(0);
+});
+
+it("should not treat property access as a translator alias", async () => {
+	const sourceCode = `
+		const t = useTranslations("DirectoryPage");
+		const translate = t.rich;
+		<p>{translate("title")}</p>
+	`;
+	const settings: PluginSettings = {
+		pathPattern: "./{language}.json",
+	};
+	const matches = parse(sourceCode, settings);
+	expect(matches).toHaveLength(0);
+});
+
+it("should not treat function calls as translator aliases", async () => {
+	const sourceCode = `
+		const t = useTranslations("DirectoryPage");
+		const translate = t("button");
+		<p>{translate("title")}</p>
+	`;
+	const settings: PluginSettings = {
+		pathPattern: "./{language}.json",
+	};
+	const matches = parse(sourceCode, settings);
+	expect(matches).toHaveLength(1);
+	expect(matches[0]?.messageId).toBe("DirectoryPage.button");
+});
+
+it("should not treat fallback expressions as translator aliases", async () => {
+	const sourceCode = `
+		const t = useTranslations("DirectoryPage");
+		const translate = t ?? fallback;
+		<p>{translate("title")}</p>
+	`;
+	const settings: PluginSettings = {
+		pathPattern: "./{language}.json",
+	};
+	const matches = parse(sourceCode, settings);
+	expect(matches).toHaveLength(0);
+});
+
+it("should add the defined namespace for direct getTranslations object assignment", async () => {
+	const sourceCode = `
+		const t = await getTranslations({ locale: "en", namespace: "Metadata" });
+		<p>{t("title")}</p>
+	`;
+	const settings: PluginSettings = {
+		pathPattern: "./{language}.json",
+	};
+	const matches = parse(sourceCode, settings);
+	expect(matches).toHaveLength(1);
+	expect(matches[0]?.messageId).toBe("Metadata.title");
+});
+
+it("should add the defined namespace for single-quoted getTranslations object assignment", async () => {
+	const sourceCode = `
+		const t = await getTranslations({ locale: 'en', namespace: 'Metadata' });
+		<p>{t("title")}</p>
+	`;
+	const settings: PluginSettings = {
+		pathPattern: "./{language}.json",
+	};
+	const matches = parse(sourceCode, settings);
+	expect(matches).toHaveLength(1);
+	expect(matches[0]?.messageId).toBe("Metadata.title");
+});
+
 
 it("should correctly reference messages with multiple useTranslations hooks", async () => {
 	const sourceCode = `

--- a/packages/plugins/next-intl/src/ideExtension/messageReferenceMatchers.test.ts
+++ b/packages/plugins/next-intl/src/ideExtension/messageReferenceMatchers.test.ts
@@ -475,7 +475,8 @@ it("should stop resolving an alias when a block shadow uses a function literal",
 		pathPattern: "./{language}.json",
 	};
 	const matches = parse(sourceCode, settings);
-	expect(matches).toHaveLength(0);
+	expect(matches).toHaveLength(1);
+	expect(matches[0]?.messageId).toBe("DirectoryPage.button");
 });
 
 it("should only match the initializer call when a block shadow uses a call expression", async () => {
@@ -798,7 +799,6 @@ it("should add the defined namespace for single-quoted getTranslations object as
 	expect(matches).toHaveLength(1);
 	expect(matches[0]?.messageId).toBe("Metadata.title");
 });
-
 
 it("should correctly reference messages with multiple useTranslations hooks", async () => {
 	const sourceCode = `

--- a/packages/plugins/next-intl/src/ideExtension/messageReferenceMatchers.test.ts
+++ b/packages/plugins/next-intl/src/ideExtension/messageReferenceMatchers.test.ts
@@ -90,6 +90,19 @@ it("should detect t('id', ...args)", async () => {
 	).toBe("'some-id'");
 });
 
+it("should keep matching unprefixed messages for non-next-intl t bindings", async () => {
+	const sourceCode = `
+		const t = other;
+		<p>{t("title")}</p>
+	`;
+	const settings: PluginSettings = {
+		pathPattern: "./{language}.json",
+	};
+	const matches = parse(sourceCode, settings);
+	expect(matches).toHaveLength(1);
+	expect(matches[0]?.messageId).toBe("title");
+});
+
 it("should not mismatch a string with different quotation marks", async () => {
 	const sourceCode = `
     <p>{t("yes')}</p>

--- a/packages/plugins/next-intl/src/ideExtension/messageReferenceMatchers.test.ts
+++ b/packages/plugins/next-intl/src/ideExtension/messageReferenceMatchers.test.ts
@@ -398,6 +398,23 @@ it("should stop resolving an alias after a later non-translator declaration shad
 	expect(matches).toHaveLength(0);
 });
 
+it("should restore an outer alias after a block-local shadow ends", async () => {
+	const sourceCode = `
+		const t = useTranslations("DirectoryPage");
+		const translate = t;
+		{
+			const translate = other;
+		}
+		<p>{translate("title")}</p>
+	`;
+	const settings: PluginSettings = {
+		pathPattern: "./{language}.json",
+	};
+	const matches = parse(sourceCode, settings);
+	expect(matches).toHaveLength(1);
+	expect(matches[0]?.messageId).toBe("DirectoryPage.title");
+});
+
 it("should not treat property access as a translator alias", async () => {
 	const sourceCode = `
 		const t = useTranslations("DirectoryPage");

--- a/packages/plugins/next-intl/src/ideExtension/messageReferenceMatchers.ts
+++ b/packages/plugins/next-intl/src/ideExtension/messageReferenceMatchers.ts
@@ -4,7 +4,7 @@ import type { PluginSettings } from "../settings.js";
 
 type FunctionNameToNamespaces = Record<
 	string,
-	Array<{ ns?: string; declarationPosition: number }>
+	Array<{ ns?: string; declarationPosition: number; scopeEnd: number }>
 >;
 
 type NamespaceBinding = {
@@ -12,6 +12,11 @@ type NamespaceBinding = {
 	declarationPosition: number;
 	ns?: string;
 	aliasOf?: string;
+};
+
+type ScopeRange = {
+	start: number;
+	end: number;
 };
 
 const createParser = (
@@ -339,6 +344,7 @@ function parseNameSpaces(sourceCode: string): FunctionNameToNamespaces {
 	const parsedDeclarations = namespaceParser.entry!.tryParse(
 		sourceCode
 	) as NamespaceBinding[];
+	const scopeRanges = getScopeRanges(sourceCode);
 
 	const functionNameToNamespaces: FunctionNameToNamespaces = {};
 
@@ -351,6 +357,10 @@ function parseNameSpaces(sourceCode: string): FunctionNameToNamespaces {
 			declaration.varName &&
 			typeof declaration.declarationPosition === "number"
 		) {
+			const scopeEnd = getDeclarationScopeEnd(
+				declaration.declarationPosition,
+				scopeRanges
+			);
 			const namespace =
 				declaration.ns ??
 				(declaration.aliasOf
@@ -367,6 +377,7 @@ function parseNameSpaces(sourceCode: string): FunctionNameToNamespaces {
 			functionNameToNamespaces[declaration.varName]!.push({
 				ns: namespace,
 				declarationPosition: declaration.declarationPosition,
+				scopeEnd,
 			});
 		}
 	}
@@ -392,6 +403,7 @@ const getNamespaceForFunctionName = (
 	let latestDeclarationBeforeCall = null;
 	for (const declaration of declarations) {
 		if (declaration.declarationPosition >= startOffset) continue;
+		if (declaration.scopeEnd < startOffset) continue;
 
 		if (
 			latestDeclarationBeforeCall === null ||
@@ -404,6 +416,107 @@ const getNamespaceForFunctionName = (
 
 	return latestDeclarationBeforeCall?.ns;
 };
+
+function getDeclarationScopeEnd(
+	declarationPosition: number,
+	scopeRanges: ScopeRange[]
+) {
+	const containingScopes = scopeRanges.filter(
+		(scope) =>
+			scope.start < declarationPosition && declarationPosition < scope.end
+	);
+	const innermostScope = containingScopes.sort((a, b) => b.start - a.start)[0];
+	return innermostScope?.end ?? Number.POSITIVE_INFINITY;
+}
+
+function getScopeRanges(sourceCode: string): ScopeRange[] {
+	const scopeStack: number[] = [];
+	const scopeRanges: ScopeRange[] = [];
+	let state:
+		| "code"
+		| "singleQuoteString"
+		| "doubleQuoteString"
+		| "templateString"
+		| "lineComment"
+		| "blockComment" = "code";
+	let escaped = false;
+
+	for (let index = 0; index < sourceCode.length; index += 1) {
+		const char = sourceCode[index];
+		const nextChar = sourceCode[index + 1];
+
+		if (state === "lineComment") {
+			if (char === "\n") state = "code";
+			continue;
+		}
+
+		if (state === "blockComment") {
+			if (char === "*" && nextChar === "/") {
+				state = "code";
+				index += 1;
+			}
+			continue;
+		}
+
+		if (
+			state === "singleQuoteString" ||
+			state === "doubleQuoteString" ||
+			state === "templateString"
+		) {
+			if (escaped) {
+				escaped = false;
+				continue;
+			}
+			if (char === "\\") {
+				escaped = true;
+				continue;
+			}
+			if (
+				(state === "singleQuoteString" && char === "'") ||
+				(state === "doubleQuoteString" && char === '"') ||
+				(state === "templateString" && char === "`")
+			) {
+				state = "code";
+			}
+			continue;
+		}
+
+		if (char === "/" && nextChar === "/") {
+			state = "lineComment";
+			index += 1;
+			continue;
+		}
+		if (char === "/" && nextChar === "*") {
+			state = "blockComment";
+			index += 1;
+			continue;
+		}
+		if (char === "'") {
+			state = "singleQuoteString";
+			continue;
+		}
+		if (char === '"') {
+			state = "doubleQuoteString";
+			continue;
+		}
+		if (char === "`") {
+			state = "templateString";
+			continue;
+		}
+		if (char === "{") {
+			scopeStack.push(index);
+			continue;
+		}
+		if (char === "}") {
+			const scopeStart = scopeStack.pop();
+			if (scopeStart !== undefined) {
+				scopeRanges.push({ start: scopeStart, end: index });
+			}
+		}
+	}
+
+	return scopeRanges;
+}
 
 // Parse the expression
 export function parse(sourceCode: string, settings: PluginSettings) {

--- a/packages/plugins/next-intl/src/ideExtension/messageReferenceMatchers.ts
+++ b/packages/plugins/next-intl/src/ideExtension/messageReferenceMatchers.ts
@@ -59,15 +59,23 @@ function parseBindings(
 	].sort((a, b) => a.declarationPosition - b.declarationPosition);
 
 	for (const candidate of candidates) {
-		const namespace =
-			candidate.ns ??
-			(candidate.aliasOf
-				? getVisibleBinding(
-						candidate.aliasOf,
-						candidate.declarationPosition,
-						bindings
-					)?.ns
-				: undefined);
+		const aliasedBinding = candidate.aliasOf
+			? getVisibleBinding(
+					candidate.aliasOf,
+					candidate.declarationPosition,
+					bindings
+				)
+			: undefined;
+		const namespace = candidate.ns ?? aliasedBinding?.ns;
+		const visibleSelfBinding = getVisibleBinding(
+			candidate.name,
+			candidate.declarationPosition,
+			bindings
+		);
+
+		if (!namespace && !visibleSelfBinding?.ns) {
+			continue;
+		}
 
 		if (!bindings[candidate.name]) {
 			bindings[candidate.name] = [];

--- a/packages/plugins/next-intl/src/ideExtension/messageReferenceMatchers.ts
+++ b/packages/plugins/next-intl/src/ideExtension/messageReferenceMatchers.ts
@@ -1,427 +1,566 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
-import Parsimmon from "parsimmon";
 import type { PluginSettings } from "../settings.js";
 
-type FunctionNameToNamespaces = Record<
-	string,
-	Array<{ ns?: string; declarationPosition: number; scopeEnd: number }>
->;
-
-type NamespaceBinding = {
-	varName: string;
+type Binding = {
+	name: string;
 	declarationPosition: number;
+	scopeEnd: number;
 	ns?: string;
 	aliasOf?: string;
 };
+
+type ResolvedBinding = {
+	declarationPosition: number;
+	scopeEnd: number;
+	ns?: string;
+};
+
+type BindingsByName = Record<string, ResolvedBinding[]>;
 
 type ScopeRange = {
 	start: number;
 	end: number;
 };
 
-const createParser = (
-	settings: PluginSettings,
-	functionNameToNamespaces: FunctionNameToNamespaces
-) => {
-	return Parsimmon.createLanguage({
-		entry: (r) => {
-			return Parsimmon.alt(r.FunctionCall!, Parsimmon.any)
-				.many()
-				.map((matches) => {
-					return matches.filter(
-						(match) => match !== null && typeof match === "object"
-					);
-				});
-		},
-
-		stringLiteral: (r) => {
-			return Parsimmon.alt(r.doubleQuotedString!, r.singleQuotedString!);
-		},
-
-		doubleQuotedString: () => {
-			return Parsimmon.string('"')
-				.then(Parsimmon.regex(/[^"]*/))
-				.skip(Parsimmon.string('"'));
-		},
-
-		singleQuotedString: () => {
-			return Parsimmon.string("'")
-				.then(Parsimmon.regex(/[^']*/))
-				.skip(Parsimmon.string("'"));
-		},
-
-		whitespace: () => {
-			return Parsimmon.optWhitespace;
-		},
-
-		colon: (r) => {
-			return Parsimmon.string(":").trim(r.whitespace!);
-		},
-
-		comma: (r) => {
-			return Parsimmon.string(",").trim(r.whitespace!);
-		},
-
-		FunctionCall: function (r) {
-			return Parsimmon.seqMap(
-				Parsimmon.regex(/[^a-zA-Z0-9]/), // no preceding letters or numbers
-				Parsimmon.regex(/(?!(?:use|get)Translations\b)[a-zA-Z_][a-zA-Z0-9_]*/), // Match function name (like 't') but exclude useTranslations/getTranslations which are handled separately
-				Parsimmon.string("("), // then an opening parenthesis
-				Parsimmon.index, // start position of the message id
-				r.stringLiteral!, // message id
-				Parsimmon.index, // end position of the message id
-				Parsimmon.regex(/[^)]*/), // ignore the rest of the function call
-				Parsimmon.string(")"), // end with a closing parenthesis
-				(_, invokedFuncName, __, keyStartIndex, messageId, keyEndIndex) => {
-					// If the invoked function name is not "t" (our common case for global/default translations)
-					// AND it's not found in our map of explicitly namespaced translation functions,
-					// then we consider it not a match.
-					if (
-						invokedFuncName !== "t" &&
-						!functionNameToNamespaces[invokedFuncName]
-					) {
-						return null;
-					}
-
-					const namespace = getNamespaceForFunctionName(
-						invokedFuncName,
-						keyStartIndex.offset,
-						functionNameToNamespaces
-					);
-					if (invokedFuncName !== "t" && !namespace) {
-						return null;
-					}
-
-					const finalMessageId = namespace
-						? `${namespace}.${messageId}`
-						: messageId;
-
-					return {
-						messageId: finalMessageId,
-						position: {
-							start: {
-								line: keyStartIndex.line,
-								character: keyStartIndex.column,
-							},
-							end: {
-								line: keyEndIndex.line,
-								character: keyEndIndex.column,
-							},
-						},
-					};
-				}
-			);
-		},
-	});
+type LexicalInfo = {
+	code: boolean[];
+	scopes: ScopeRange[];
 };
 
-const createNamespaceParser = () => {
-	return Parsimmon.createLanguage({
-		entry: (r) => {
-			return Parsimmon.alt(
-				r.TranslationFunctionDeclaration!,
-				r.TranslationFunctionAlias!,
-				Parsimmon.any
-			)
-				.many()
-				.map((matches) => {
-					// Filter for matches that have varName and ns
-					return matches.filter(
-						(match) =>
-							typeof match === "object" &&
-							match &&
-							match.varName &&
-							(match.ns || match.aliasOf)
-					);
-				});
-		},
-
-		stringLiteral: (r) => {
-			return Parsimmon.alt(r.doubleQuotedString!, r.singleQuotedString!);
-		},
-
-		doubleQuotedString: () => {
-			return Parsimmon.string('"')
-				.then(Parsimmon.regex(/[^"]*/))
-				.skip(Parsimmon.string('"'));
-		},
-
-		singleQuotedString: () => {
-			return Parsimmon.string("'")
-				.then(Parsimmon.regex(/[^']*/))
-				.skip(Parsimmon.string("'"));
-		},
-
-		comma: (r) => {
-			return Parsimmon.string(",").trim(r.whitespace!);
-		},
-
-		whitespace: () => {
-			return Parsimmon.optWhitespace;
-		},
-
-		colon: (r) => {
-			return Parsimmon.string(":").trim(r.whitespace!);
-		},
-
-		identifier: () => Parsimmon.regex(/[a-zA-Z_][a-zA-Z0-9_]*/),
-
-		// Parser for variable name, supporting direct assignment and simple object destructuring like { t } or { t: alias }
-		variableDeclarationName: (r) =>
-			Parsimmon.alt(
-				r.identifier!, // Direct assignment: const t = ...
-				Parsimmon.seqMap(
-					// Destructured assignment: const { t } = ... or const { t: tc } = ...
-					Parsimmon.string("{"),
-					r.whitespace!,
-					r.identifier!, // Original name (e.g., 't')
-					Parsimmon.alt(
-						// Optional alias
-						Parsimmon.seqMap(
-							r.whitespace!,
-							Parsimmon.string(":"),
-							r.whitespace!,
-							r.identifier!,
-							(_, __, ___, alias) => alias
-						),
-						Parsimmon.succeed(null) // No alias
-					),
-					r.whitespace!,
-					Parsimmon.string("}"),
-					(_obr, _ws1, id, alias, _ws2, _cbr) => alias || id // Return alias if present, else original id
-				)
-			),
-
-		stringParser: () => {
-			return Parsimmon.alt(
-				Parsimmon.regexp(/'([^']*)'/, 1).map((str) => ({
-					type: "string",
-					value: str,
-				})),
-				Parsimmon.regexp(/"([^"]*)"/, 1).map((str) => ({
-					type: "string",
-					value: str,
-				}))
-			);
-		},
-
-		objectParser: () => {
-			const x = {
-				stringLiteral: Parsimmon.regexp(/"([^"\\]|\\.)*"/).map((value) =>
-					JSON.parse(value)
-				), // Match double-quoted strings and parse them
-				singleQuotedStringLiteral: Parsimmon.regexp(/'([^'\\]|\\.)*'/).map(
-					(value) => value.slice(1, -1)
-				),
-				variableName: Parsimmon.regexp(
-					/[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)*/
-				), // Match variable names
-				functionLiteral: Parsimmon.regexp(/function\s*\([^)]*\)\s*\{[^}]*\}/), // Match function literals
-			};
-
-			const valueParser = Parsimmon.alt(
-				x.stringLiteral,
-				x.singleQuotedStringLiteral,
-				x.variableName,
-				x.functionLiteral
-			);
-
-			const propertyParser = Parsimmon.seq(
-				Parsimmon.regexp(/[\w]+/).skip(Parsimmon.optWhitespace), // Property name
-				Parsimmon.string(":")
-					.then(Parsimmon.optWhitespace)
-					.then(valueParser)
-					.fallback(undefined) // Optional colon and value
-			).map(([key, value]) =>
-				value !== null ? [key, value] : [key, undefined]
-			);
-
-			return Parsimmon.optWhitespace.then(
-				Parsimmon.seq(
-					Parsimmon.string("{").then(Parsimmon.optWhitespace),
-					Parsimmon.sepBy(
-						propertyParser,
-						Parsimmon.string(",").then(Parsimmon.optWhitespace)
-					),
-					Parsimmon.optWhitespace.then(Parsimmon.string("}"))
-				).map(([, entries]) => {
-					const obj = Object.fromEntries(entries);
-					return { type: "object", value: obj };
-				})
-			);
-		},
-
-		TranslationFunctionDeclaration: function (r) {
-			// Parser for the useTranslations() or getTranslations() call itself
-			const useOrGetTranslationsCall = Parsimmon.seqMap(
-				// Parsimmon.regex(/\b(?:use|get)Translations\b/), // OLD: no await
-				Parsimmon.regex(/\b(?:await\s+)?(?:use|get)Translations\b/), // NEW: optional await
-				Parsimmon.string("("),
-				r.whitespace!,
-				Parsimmon.alt(r.stringParser!, r.objectParser!), // Namespace string or object
-				r.whitespace!,
-				Parsimmon.regex(/[^)]*/), // Ignore rest of args
-				Parsimmon.string(")"),
-				(_, __, ___, parsedArgument) => {
-					let namespace: string | undefined;
-
-					// Case 1: Argument is a string literal e.g. useTranslations("myNamespace")
-					if (
-						parsedArgument.type === "string" &&
-						typeof parsedArgument.value === "string"
-					) {
-						namespace = parsedArgument.value;
-					}
-					// Case 2: Argument is an object e.g. useTranslations({ namespace: "myNamespace" })
-					else if (parsedArgument.type === "object") {
-						const optionsObject = parsedArgument.value; // This is the object like { namespace: "..." }
-						// Check if optionsObject exists and has a 'namespace' property that is a string
-						if (optionsObject && typeof optionsObject.namespace === "string") {
-							namespace = optionsObject.namespace;
-						}
-					}
-					return { namespace };
-				}
-			);
-
-			// Parser for the variable assignment: const myVar = useTranslations(...);
-			return Parsimmon.seqMap(
-				Parsimmon.index, // Capture the starting position of the declaration
-				Parsimmon.regex(/\b(?:const|let|var)\b\s+/), // Matches 'const ', 'let ', or 'var '
-				// r.identifier!, // The variable name (e.g., "tc", "t") // OLD: simple identifier
-				r.variableDeclarationName!, // NEW: supports destructuring { t } or direct t
-				r.whitespace!,
-				Parsimmon.string("="), // Equals sign
-				r.whitespace!,
-				useOrGetTranslationsCall, // The useTranslations() or getTranslations() call
-				// Callback function for seqMap
-				(declPosition, _keyword, varName, _ws1, _eq, _ws2, callDetails) => {
-					// callDetails is the result from useOrGetTranslationsCall, which is { namespace: "..." }
-					if (callDetails && typeof callDetails.namespace === "string") {
-						return {
-							varName: varName,
-							ns: callDetails.namespace,
-							declarationPosition: declPosition.offset, // Store the declaration position
-						};
-					}
-					return null; // Return null if parsing wasn't successful or namespace not found
-				}
-			);
-		},
-
-		TranslationFunctionAlias: function (r) {
-			return Parsimmon.seqMap(
-				Parsimmon.index,
-				Parsimmon.regex(/\b(?:const|let|var)\b\s+/),
-				r.identifier!,
-				r.whitespace!,
-				Parsimmon.string("="),
-				r.whitespace!,
-				r.identifier!,
-				Parsimmon.regex(/[ \t]*(?=;|\r?\n|$)/),
-				(
-					declPosition,
-					_keyword,
-					varName,
-					_ws1,
-					_eq,
-					_ws2,
-					aliasOf,
-					_trailing
-				) => ({
-					varName,
-					aliasOf,
-					declarationPosition: declPosition.offset,
-				})
-			);
-		},
-	});
+type Position = {
+	line: number;
+	character: number;
 };
 
-function parseNameSpaces(sourceCode: string): FunctionNameToNamespaces {
-	const namespaceParser = createNamespaceParser();
-	// parsedDeclarations will be an array of { varName: string, ns: string, declarationPosition: number }
-	const parsedDeclarations = namespaceParser.entry!.tryParse(
-		sourceCode
-	) as NamespaceBinding[];
-	const scopeRanges = getScopeRanges(sourceCode);
+const identifierPattern = /[a-zA-Z_$][a-zA-Z0-9_$]*/y;
 
-	const functionNameToNamespaces: FunctionNameToNamespaces = {};
+export function parse(sourceCode: string, _settings: PluginSettings) {
+	try {
+		const lexicalInfo = getLexicalInfo(sourceCode);
+		const bindings = parseBindings(sourceCode, lexicalInfo);
+		return parseFunctionCalls(sourceCode, lexicalInfo, bindings);
+	} catch (error) {
+		console.error("Parsing error:", error);
+		return [];
+	}
+}
 
-	for (const declaration of parsedDeclarations.sort(
-		(a, b) => a.declarationPosition - b.declarationPosition
-	)) {
-		// Ensure declaration is not null and has the expected properties
+function parseBindings(
+	sourceCode: string,
+	lexicalInfo: LexicalInfo
+): BindingsByName {
+	const bindings: BindingsByName = {};
+	const candidates = [
+		...parseVariableBindings(sourceCode, lexicalInfo),
+		...parseAssignmentBindings(sourceCode, lexicalInfo),
+		...parseFunctionDeclarationBindings(sourceCode, lexicalInfo),
+		...parseFunctionParameterBindings(sourceCode, lexicalInfo),
+		...parseCatchParameterBindings(sourceCode, lexicalInfo),
+		...parseForLoopBindings(sourceCode, lexicalInfo),
+	].sort((a, b) => a.declarationPosition - b.declarationPosition);
+
+	for (const candidate of candidates) {
+		const namespace =
+			candidate.ns ??
+			(candidate.aliasOf
+				? getVisibleBinding(
+						candidate.aliasOf,
+						candidate.declarationPosition,
+						bindings
+					)?.ns
+				: undefined);
+
+		if (!bindings[candidate.name]) {
+			bindings[candidate.name] = [];
+		}
+
+		bindings[candidate.name]!.push({
+			declarationPosition: candidate.declarationPosition,
+			scopeEnd: candidate.scopeEnd,
+			ns: namespace,
+		});
+	}
+
+	return bindings;
+}
+
+function parseFunctionCalls(
+	sourceCode: string,
+	lexicalInfo: LexicalInfo,
+	bindings: BindingsByName
+) {
+	const matches = [];
+	const lineStarts = getLineStarts(sourceCode);
+
+	for (let index = 0; index < sourceCode.length; index += 1) {
 		if (
-			declaration &&
-			declaration.varName &&
-			typeof declaration.declarationPosition === "number"
+			!isIdentifierStart(sourceCode[index]) ||
+			!isCodeAt(lexicalInfo, index)
 		) {
-			const scopeEnd = getDeclarationScopeEnd(
-				declaration.declarationPosition,
-				scopeRanges
-			);
-			const namespace =
-				declaration.ns ??
-				(declaration.aliasOf
-					? getNamespaceForFunctionName(
-							declaration.aliasOf,
-							declaration.declarationPosition,
-							functionNameToNamespaces
-						)
-					: undefined);
+			continue;
+		}
 
-			if (!functionNameToNamespaces[declaration.varName]) {
-				functionNameToNamespaces[declaration.varName] = [];
+		const nameStart = index;
+		const functionName = readIdentifier(sourceCode, index);
+		if (!functionName || /^(?:use|get)Translations$/.test(functionName)) {
+			continue;
+		}
+		index = nameStart + functionName.length - 1;
+
+		const openParen = skipWhitespaceOnly(
+			sourceCode,
+			nameStart + functionName.length
+		);
+		if (sourceCode[openParen] !== "(") continue;
+
+		const firstArgStart = skipWhitespaceOnly(sourceCode, openParen + 1);
+		const quote = sourceCode[firstArgStart];
+		if (quote !== '"' && quote !== "'") continue;
+
+		const firstArgEnd = findStringEnd(sourceCode, firstArgStart);
+		if (firstArgEnd === undefined) continue;
+
+		const messageId = sourceCode.slice(firstArgStart + 1, firstArgEnd);
+		const binding = getVisibleBinding(functionName, nameStart, bindings);
+		let finalMessageId: string | undefined;
+
+		if (functionName === "t") {
+			if (binding && !binding.ns) continue;
+			finalMessageId = binding?.ns ? `${binding.ns}.${messageId}` : messageId;
+		} else {
+			if (!binding?.ns) continue;
+			finalMessageId = `${binding.ns}.${messageId}`;
+		}
+
+		matches.push({
+			messageId: finalMessageId,
+			position: {
+				start: getPosition(firstArgStart, lineStarts),
+				end: getPosition(firstArgEnd + 1, lineStarts),
+			},
+		});
+	}
+
+	return matches;
+}
+
+function parseVariableBindings(
+	sourceCode: string,
+	lexicalInfo: LexicalInfo
+): Binding[] {
+	const bindings: Binding[] = [];
+	const declarationPattern = /\b(?:const|let|var)\b/g;
+
+	for (const match of sourceCode.matchAll(declarationPattern)) {
+		const declarationPosition = match.index;
+		if (!isCodeAt(lexicalInfo, declarationPosition)) continue;
+
+		let cursor = skipWhitespace(
+			sourceCode,
+			declarationPosition + match[0].length,
+			lexicalInfo
+		);
+		const lhsStart = cursor;
+		let lhsEnd: number | undefined;
+
+		if (sourceCode[cursor] === "{") {
+			lhsEnd = findMatchingDelimiter(sourceCode, cursor, "{", "}", lexicalInfo);
+			if (lhsEnd === undefined) continue;
+			cursor = lhsEnd + 1;
+		} else {
+			const name = readIdentifier(sourceCode, cursor);
+			if (!name) continue;
+			lhsEnd = cursor + name.length;
+			cursor = lhsEnd;
+		}
+
+		cursor = skipWhitespace(sourceCode, cursor, lexicalInfo);
+		const lhs = sourceCode.slice(lhsStart, lhsEnd + 1);
+		const bindingName = getBindingNameFromPattern(lhs);
+		if (!bindingName) continue;
+
+		const scopeEnd = getDeclarationScopeEnd(declarationPosition, lexicalInfo);
+
+		if (sourceCode[cursor] !== "=") {
+			if (sourceCode[cursor] === ";" || sourceCode[cursor] === "\n") {
+				bindings.push({
+					name: bindingName,
+					declarationPosition,
+					scopeEnd,
+				});
 			}
-			functionNameToNamespaces[declaration.varName]!.push({
-				ns: namespace,
-				declarationPosition: declaration.declarationPosition,
-				scopeEnd,
+			continue;
+		}
+
+		const expressionStart = skipWhitespace(sourceCode, cursor + 1, lexicalInfo);
+		const expressionEnd = findStatementEnd(
+			sourceCode,
+			expressionStart,
+			lexicalInfo
+		);
+		const expression = sourceCode.slice(expressionStart, expressionEnd).trim();
+		const namespace = getTranslationNamespace(expression);
+		const aliasOf = getSimpleIdentifierExpression(expression);
+		if (
+			!namespace &&
+			!aliasOf &&
+			bindingName === "t" &&
+			isRawTFactory(expression)
+		) {
+			continue;
+		}
+
+		bindings.push({
+			name: bindingName,
+			declarationPosition,
+			scopeEnd,
+			ns: namespace,
+			aliasOf: namespace ? undefined : aliasOf,
+		});
+	}
+
+	return bindings;
+}
+
+function parseAssignmentBindings(
+	sourceCode: string,
+	lexicalInfo: LexicalInfo
+): Binding[] {
+	const bindings: Binding[] = [];
+
+	for (let index = 0; index < sourceCode.length; index += 1) {
+		if (
+			!isIdentifierStart(sourceCode[index]) ||
+			!isCodeAt(lexicalInfo, index)
+		) {
+			continue;
+		}
+
+		const nameStart = index;
+		const name = readIdentifier(sourceCode, index);
+		if (!name) continue;
+		index = nameStart + name.length - 1;
+
+		if (isDeclarationIdentifier(sourceCode, nameStart, lexicalInfo)) continue;
+		if (previousNonWhitespace(sourceCode, nameStart - 1) === ".") continue;
+
+		const equalsIndex = skipWhitespace(
+			sourceCode,
+			nameStart + name.length,
+			lexicalInfo
+		);
+		if (sourceCode[equalsIndex] !== "=") continue;
+		if (
+			sourceCode[equalsIndex + 1] === ">" ||
+			sourceCode[equalsIndex + 1] === "="
+		) {
+			continue;
+		}
+		if (
+			sourceCode[equalsIndex - 1] === "!" ||
+			sourceCode[equalsIndex - 1] === "<" ||
+			sourceCode[equalsIndex - 1] === ">"
+		) {
+			continue;
+		}
+
+		const expressionStart = skipWhitespace(
+			sourceCode,
+			equalsIndex + 1,
+			lexicalInfo
+		);
+		const expressionEnd = findStatementEnd(
+			sourceCode,
+			expressionStart,
+			lexicalInfo
+		);
+		const expression = sourceCode.slice(expressionStart, expressionEnd).trim();
+		const namespace = getTranslationNamespace(expression);
+		const aliasOf = getSimpleIdentifierExpression(expression);
+
+		bindings.push({
+			name,
+			declarationPosition: nameStart,
+			scopeEnd: getDeclarationScopeEnd(nameStart, lexicalInfo),
+			ns: namespace,
+			aliasOf: namespace ? undefined : aliasOf,
+		});
+	}
+
+	return bindings;
+}
+
+function parseFunctionDeclarationBindings(
+	sourceCode: string,
+	lexicalInfo: LexicalInfo
+): Binding[] {
+	const bindings: Binding[] = [];
+	const functionPattern = /\bfunction\s+([a-zA-Z_$][a-zA-Z0-9_$]*)\s*\(/g;
+
+	for (const match of sourceCode.matchAll(functionPattern)) {
+		const declarationPosition = match.index;
+		if (!isCodeAt(lexicalInfo, declarationPosition)) continue;
+		const name = match[1];
+		if (!name) continue;
+
+		bindings.push({
+			name,
+			declarationPosition,
+			scopeEnd: getDeclarationScopeEnd(declarationPosition, lexicalInfo),
+		});
+	}
+
+	return bindings;
+}
+
+function parseFunctionParameterBindings(
+	sourceCode: string,
+	lexicalInfo: LexicalInfo
+): Binding[] {
+	const bindings: Binding[] = [];
+
+	for (const match of sourceCode.matchAll(
+		/\bfunction(?:\s+[a-zA-Z_$][a-zA-Z0-9_$]*)?\s*\(/g
+	)) {
+		const openParen = sourceCode.indexOf("(", match.index);
+		if (!isCodeAt(lexicalInfo, match.index)) continue;
+		const closeParen = findMatchingDelimiter(
+			sourceCode,
+			openParen,
+			"(",
+			")",
+			lexicalInfo
+		);
+		if (closeParen === undefined) continue;
+		const bodyStart = skipWhitespace(sourceCode, closeParen + 1, lexicalInfo);
+		if (sourceCode[bodyStart] !== "{") continue;
+		const bodyEnd = findMatchingDelimiter(
+			sourceCode,
+			bodyStart,
+			"{",
+			"}",
+			lexicalInfo
+		);
+		if (bodyEnd === undefined) continue;
+
+		for (const parameter of getParameterBindings(
+			sourceCode,
+			openParen + 1,
+			closeParen
+		)) {
+			bindings.push({
+				name: parameter.name,
+				declarationPosition: parameter.position,
+				scopeEnd: bodyEnd,
 			});
 		}
 	}
 
-	// Optionally sort declarations by position for potentially faster lookup, though linear scan is fine for few items.
-	for (const varName in functionNameToNamespaces) {
-		functionNameToNamespaces[varName]!.sort(
-			(a, b) => a.declarationPosition - b.declarationPosition
+	for (const match of sourceCode.matchAll(/\(([^()]*)\)\s*=>/g)) {
+		const openParen = match.index;
+		if (!isCodeAt(lexicalInfo, openParen)) continue;
+		const closeParen = sourceCode.indexOf(")", openParen);
+		const bodyStart = skipWhitespace(
+			sourceCode,
+			openParen + match[0].length,
+			lexicalInfo
 		);
-	}
+		const bodyEnd = getArrowBodyEnd(sourceCode, bodyStart, lexicalInfo);
 
-	return functionNameToNamespaces;
-}
-
-const getNamespaceForFunctionName = (
-	functionName: string,
-	startOffset: number,
-	functionNameToNamespaces: FunctionNameToNamespaces
-): string | undefined => {
-	const declarations = functionNameToNamespaces[functionName];
-	if (!declarations) return undefined;
-
-	let latestDeclarationBeforeCall = null;
-	for (const declaration of declarations) {
-		if (declaration.declarationPosition >= startOffset) continue;
-		if (declaration.scopeEnd < startOffset) continue;
-
-		if (
-			latestDeclarationBeforeCall === null ||
-			declaration.declarationPosition >
-				latestDeclarationBeforeCall.declarationPosition
-		) {
-			latestDeclarationBeforeCall = declaration;
+		for (const parameter of getParameterBindings(
+			sourceCode,
+			openParen + 1,
+			closeParen
+		)) {
+			bindings.push({
+				name: parameter.name,
+				declarationPosition: parameter.position,
+				scopeEnd: bodyEnd,
+			});
 		}
 	}
 
-	return latestDeclarationBeforeCall?.ns;
-};
+	for (const match of sourceCode.matchAll(
+		/\b([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=>/g
+	)) {
+		const name = match[1];
+		const nameStart = match.index;
+		if (!name || !isCodeAt(lexicalInfo, nameStart)) continue;
+		if (previousNonWhitespace(sourceCode, nameStart - 1) === ")") continue;
+		const bodyStart = skipWhitespace(
+			sourceCode,
+			nameStart + match[0].length,
+			lexicalInfo
+		);
+		bindings.push({
+			name,
+			declarationPosition: nameStart,
+			scopeEnd: getArrowBodyEnd(sourceCode, bodyStart, lexicalInfo),
+		});
+	}
+
+	return bindings;
+}
+
+function parseCatchParameterBindings(
+	sourceCode: string,
+	lexicalInfo: LexicalInfo
+): Binding[] {
+	const bindings: Binding[] = [];
+	const catchPattern = /\bcatch\s*\(\s*([a-zA-Z_$][a-zA-Z0-9_$]*)\s*\)\s*\{/g;
+
+	for (const match of sourceCode.matchAll(catchPattern)) {
+		const declarationPosition = match.index;
+		if (!isCodeAt(lexicalInfo, declarationPosition)) continue;
+		const bodyStart = sourceCode.indexOf("{", declarationPosition);
+		const bodyEnd = findMatchingDelimiter(
+			sourceCode,
+			bodyStart,
+			"{",
+			"}",
+			lexicalInfo
+		);
+		if (bodyEnd === undefined || !match[1]) continue;
+
+		bindings.push({
+			name: match[1],
+			declarationPosition,
+			scopeEnd: bodyEnd,
+		});
+	}
+
+	return bindings;
+}
+
+function parseForLoopBindings(
+	sourceCode: string,
+	lexicalInfo: LexicalInfo
+): Binding[] {
+	const bindings: Binding[] = [];
+	const forPattern =
+		/\bfor\s*\(\s*(?:const|let|var)\s+([a-zA-Z_$][a-zA-Z0-9_$]*)\b[^)]*\)\s*\{/g;
+
+	for (const match of sourceCode.matchAll(forPattern)) {
+		const declarationPosition = match.index;
+		if (!isCodeAt(lexicalInfo, declarationPosition)) continue;
+		const bodyStart = sourceCode.indexOf("{", declarationPosition);
+		const bodyEnd = findMatchingDelimiter(
+			sourceCode,
+			bodyStart,
+			"{",
+			"}",
+			lexicalInfo
+		);
+		if (bodyEnd === undefined || !match[1]) continue;
+
+		bindings.push({
+			name: match[1],
+			declarationPosition,
+			scopeEnd: bodyEnd,
+		});
+	}
+
+	return bindings;
+}
+
+function getVisibleBinding(
+	name: string,
+	offset: number,
+	bindings: BindingsByName
+): ResolvedBinding | undefined {
+	const nameBindings = bindings[name];
+	if (!nameBindings) return undefined;
+
+	let visibleBinding: ResolvedBinding | undefined;
+	for (const binding of nameBindings) {
+		if (binding.declarationPosition >= offset) continue;
+		if (binding.scopeEnd < offset) continue;
+		if (
+			!visibleBinding ||
+			binding.declarationPosition > visibleBinding.declarationPosition
+		) {
+			visibleBinding = binding;
+		}
+	}
+
+	return visibleBinding;
+}
+
+function getBindingNameFromPattern(pattern: string): string | undefined {
+	const trimmed = pattern.trim();
+	if (/^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(trimmed)) {
+		return trimmed;
+	}
+
+	const destructured =
+		/^\{\s*([a-zA-Z_$][a-zA-Z0-9_$]*)(?:\s*:\s*([a-zA-Z_$][a-zA-Z0-9_$]*))?\s*\}$/.exec(
+			trimmed
+		);
+	return destructured?.[2] ?? destructured?.[1];
+}
+
+function getTranslationNamespace(expression: string): string | undefined {
+	const call = /^(?:await\s+)?(?:use|get)Translations\s*\(([\s\S]*)\)\s*$/.exec(
+		expression
+	);
+	if (!call) return undefined;
+
+	const argument = call[1]?.trim() ?? "";
+	const literalNamespace = /^["']([^"']*)["']/.exec(argument);
+	if (literalNamespace) return literalNamespace[1];
+
+	const objectNamespace = /\bnamespace\s*:\s*["']([^"']*)["']/.exec(argument);
+	return objectNamespace?.[1];
+}
+
+function getSimpleIdentifierExpression(expression: string): string | undefined {
+	const trimmed = expression.trim();
+	return /^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(trimmed) ? trimmed : undefined;
+}
+
+function isRawTFactory(expression: string) {
+	return /^useTranslation\s*\(/.test(expression.trim());
+}
+
+function getParameterBindings(
+	sourceCode: string,
+	start: number,
+	end: number
+): Array<{ name: string; position: number }> {
+	const parameters = sourceCode.slice(start, end);
+	const bindings = [];
+	const parameterPattern = /[a-zA-Z_$][a-zA-Z0-9_$]*/g;
+
+	for (const match of parameters.matchAll(parameterPattern)) {
+		if (!match[0]) continue;
+		bindings.push({
+			name: match[0],
+			position: start + match.index,
+		});
+	}
+
+	return bindings;
+}
+
+function getArrowBodyEnd(
+	sourceCode: string,
+	bodyStart: number,
+	lexicalInfo: LexicalInfo
+) {
+	if (sourceCode[bodyStart] === "{") {
+		return (
+			findMatchingDelimiter(sourceCode, bodyStart, "{", "}", lexicalInfo) ??
+			Number.POSITIVE_INFINITY
+		);
+	}
+
+	return findStatementEnd(sourceCode, bodyStart, lexicalInfo);
+}
 
 function getDeclarationScopeEnd(
 	declarationPosition: number,
-	scopeRanges: ScopeRange[]
+	lexicalInfo: LexicalInfo
 ) {
-	const containingScopes = scopeRanges.filter(
+	const containingScopes = lexicalInfo.scopes.filter(
 		(scope) =>
 			scope.start < declarationPosition && declarationPosition < scope.end
 	);
@@ -429,40 +568,40 @@ function getDeclarationScopeEnd(
 	return innermostScope?.end ?? Number.POSITIVE_INFINITY;
 }
 
-function getScopeRanges(sourceCode: string): ScopeRange[] {
+function getLexicalInfo(sourceCode: string): LexicalInfo {
+	const code = Array.from({ length: sourceCode.length }, () => true);
+	const scopes: ScopeRange[] = [];
 	const scopeStack: number[] = [];
-	const scopeRanges: ScopeRange[] = [];
-	let state:
-		| "code"
-		| "singleQuoteString"
-		| "doubleQuoteString"
-		| "templateString"
-		| "lineComment"
-		| "blockComment" = "code";
+	const templateStack: Array<{ expressionDepth: number }> = [];
+	let state: "code" | "single" | "double" | "template" | "line" | "block" =
+		"code";
 	let escaped = false;
 
 	for (let index = 0; index < sourceCode.length; index += 1) {
 		const char = sourceCode[index];
 		const nextChar = sourceCode[index + 1];
 
-		if (state === "lineComment") {
-			if (char === "\n") state = "code";
-			continue;
-		}
-
-		if (state === "blockComment") {
-			if (char === "*" && nextChar === "/") {
+		if (state === "line") {
+			code[index] = false;
+			if (char === "\n") {
+				code[index] = true;
 				state = "code";
-				index += 1;
 			}
 			continue;
 		}
 
-		if (
-			state === "singleQuoteString" ||
-			state === "doubleQuoteString" ||
-			state === "templateString"
-		) {
+		if (state === "block") {
+			code[index] = false;
+			if (char === "*" && nextChar === "/") {
+				code[index + 1] = false;
+				index += 1;
+				state = "code";
+			}
+			continue;
+		}
+
+		if (state === "single" || state === "double") {
+			code[index] = false;
 			if (escaped) {
 				escaped = false;
 				continue;
@@ -472,35 +611,69 @@ function getScopeRanges(sourceCode: string): ScopeRange[] {
 				continue;
 			}
 			if (
-				(state === "singleQuoteString" && char === "'") ||
-				(state === "doubleQuoteString" && char === '"') ||
-				(state === "templateString" && char === "`")
+				(state === "single" && char === "'") ||
+				(state === "double" && char === '"')
 			) {
 				state = "code";
 			}
 			continue;
 		}
 
+		if (state === "template") {
+			code[index] = false;
+			if (escaped) {
+				escaped = false;
+				continue;
+			}
+			if (char === "\\") {
+				escaped = true;
+				continue;
+			}
+			if (char === "`") {
+				state = "code";
+				continue;
+			}
+			if (char === "$" && nextChar === "{") {
+				code[index] = true;
+				code[index + 1] = true;
+				scopeStack.push(index + 1);
+				templateStack.push({ expressionDepth: scopeStack.length });
+				state = "code";
+				index += 1;
+			}
+			continue;
+		}
+
 		if (char === "/" && nextChar === "/") {
-			state = "lineComment";
+			code[index] = false;
+			code[index + 1] = false;
 			index += 1;
+			state = "line";
 			continue;
 		}
 		if (char === "/" && nextChar === "*") {
-			state = "blockComment";
+			code[index] = false;
+			code[index + 1] = false;
 			index += 1;
+			state = "block";
 			continue;
 		}
 		if (char === "'") {
-			state = "singleQuoteString";
+			code[index] = false;
+			state = "single";
+			escaped = false;
 			continue;
 		}
 		if (char === '"') {
-			state = "doubleQuoteString";
+			code[index] = false;
+			state = "double";
+			escaped = false;
 			continue;
 		}
 		if (char === "`") {
-			state = "templateString";
+			code[index] = false;
+			state = "template";
+			escaped = false;
 			continue;
 		}
 		if (char === "{") {
@@ -510,24 +683,179 @@ function getScopeRanges(sourceCode: string): ScopeRange[] {
 		if (char === "}") {
 			const scopeStart = scopeStack.pop();
 			if (scopeStart !== undefined) {
-				scopeRanges.push({ start: scopeStart, end: index });
+				scopes.push({ start: scopeStart, end: index });
+			}
+			const templateExpression = templateStack[templateStack.length - 1];
+			if (
+				templateExpression &&
+				scopeStack.length < templateExpression.expressionDepth
+			) {
+				templateStack.pop();
+				state = "template";
 			}
 		}
 	}
 
-	return scopeRanges;
+	return { code, scopes };
 }
 
-// Parse the expression
-export function parse(sourceCode: string, settings: PluginSettings) {
-	try {
-		const functionNameToNamespaces = parseNameSpaces(sourceCode);
+function findStatementEnd(
+	sourceCode: string,
+	start: number,
+	lexicalInfo: LexicalInfo
+) {
+	let depth = 0;
 
-		const parser = createParser(settings, functionNameToNamespaces);
-		const result = parser.entry!.tryParse(sourceCode);
-		return result;
-	} catch (error) {
-		console.error("Parsing error:", error);
-		return [];
+	for (let index = start; index < sourceCode.length; index += 1) {
+		if (!isCodeAt(lexicalInfo, index)) continue;
+		const char = sourceCode[index];
+
+		if (char === "(" || char === "{" || char === "[") depth += 1;
+		if (char === ")" || char === "}" || char === "]") {
+			if (depth === 0) return index;
+			depth -= 1;
+		}
+		if (depth === 0 && (char === ";" || char === "\n")) return index;
 	}
+
+	return sourceCode.length;
+}
+
+function findMatchingDelimiter(
+	sourceCode: string,
+	start: number,
+	open: string,
+	close: string,
+	lexicalInfo: LexicalInfo
+): number | undefined {
+	let depth = 0;
+
+	for (let index = start; index < sourceCode.length; index += 1) {
+		if (!isCodeAt(lexicalInfo, index)) continue;
+		if (sourceCode[index] === open) depth += 1;
+		if (sourceCode[index] === close) {
+			depth -= 1;
+			if (depth === 0) return index;
+		}
+	}
+
+	return undefined;
+}
+
+function skipWhitespace(
+	sourceCode: string,
+	start: number,
+	lexicalInfo: LexicalInfo
+) {
+	let index = start;
+	while (
+		index < sourceCode.length &&
+		(!isCodeAt(lexicalInfo, index) || /\s/.test(sourceCode[index] ?? ""))
+	) {
+		index += 1;
+	}
+	return index;
+}
+
+function skipWhitespaceOnly(sourceCode: string, start: number) {
+	let index = start;
+	while (index < sourceCode.length && /\s/.test(sourceCode[index] ?? "")) {
+		index += 1;
+	}
+	return index;
+}
+
+function isDeclarationIdentifier(
+	sourceCode: string,
+	nameStart: number,
+	lexicalInfo: LexicalInfo
+) {
+	const previousWord = getPreviousWord(sourceCode, nameStart);
+	if (
+		previousWord === "const" ||
+		previousWord === "let" ||
+		previousWord === "var"
+	) {
+		return true;
+	}
+	if (previousWord === "function") return true;
+
+	const nextIndex = skipWhitespace(
+		sourceCode,
+		nameStart + (readIdentifier(sourceCode, nameStart)?.length ?? 0),
+		lexicalInfo
+	);
+	return (
+		sourceCode[nextIndex] === ")" &&
+		sourceCode.slice(nextIndex).startsWith(") =>")
+	);
+}
+
+function getPreviousWord(sourceCode: string, end: number) {
+	let cursor = end - 1;
+	while (cursor >= 0 && /\s/.test(sourceCode[cursor] ?? "")) cursor -= 1;
+	let wordEnd = cursor + 1;
+	while (cursor >= 0 && /[a-zA-Z_$]/.test(sourceCode[cursor] ?? ""))
+		cursor -= 1;
+	return sourceCode.slice(cursor + 1, wordEnd);
+}
+
+function previousNonWhitespace(sourceCode: string, start: number) {
+	let index = start;
+	while (index >= 0 && /\s/.test(sourceCode[index] ?? "")) index -= 1;
+	return sourceCode[index];
+}
+
+function readIdentifier(sourceCode: string, start: number) {
+	identifierPattern.lastIndex = start;
+	return identifierPattern.exec(sourceCode)?.[0];
+}
+
+function isIdentifierStart(char: string | undefined) {
+	return Boolean(char && /[a-zA-Z_$]/.test(char));
+}
+
+function isCodeAt(lexicalInfo: LexicalInfo, index: number) {
+	return lexicalInfo.code[index] === true;
+}
+
+function findStringEnd(sourceCode: string, start: number) {
+	const quote = sourceCode[start];
+	let escaped = false;
+
+	for (let index = start + 1; index < sourceCode.length; index += 1) {
+		const char = sourceCode[index];
+		if (escaped) {
+			escaped = false;
+			continue;
+		}
+		if (char === "\\") {
+			escaped = true;
+			continue;
+		}
+		if (char === quote) return index;
+	}
+
+	return undefined;
+}
+
+function getLineStarts(sourceCode: string) {
+	const lineStarts = [0];
+	for (let index = 0; index < sourceCode.length; index += 1) {
+		if (sourceCode[index] === "\n") lineStarts.push(index + 1);
+	}
+	return lineStarts;
+}
+
+function getPosition(offset: number, lineStarts: number[]): Position {
+	let line = 0;
+	for (let index = 0; index < lineStarts.length; index += 1) {
+		if (lineStarts[index]! > offset) break;
+		line = index;
+	}
+
+	return {
+		line: line + 1,
+		character: offset - lineStarts[line]! + 1,
+	};
 }

--- a/packages/plugins/next-intl/src/ideExtension/messageReferenceMatchers.ts
+++ b/packages/plugins/next-intl/src/ideExtension/messageReferenceMatchers.ts
@@ -4,8 +4,15 @@ import type { PluginSettings } from "../settings.js";
 
 type FunctionNameToNamespaces = Record<
 	string,
-	Array<{ ns: string; declarationPosition: number }>
+	Array<{ ns?: string; declarationPosition: number }>
 >;
+
+type NamespaceBinding = {
+	varName: string;
+	declarationPosition: number;
+	ns?: string;
+	aliasOf?: string;
+};
 
 const createParser = (
 	settings: PluginSettings,
@@ -71,12 +78,18 @@ const createParser = (
 						return null;
 					}
 
-					const finalMessageId = getFinalMessageId(
+					const namespace = getNamespaceForFunctionName(
 						invokedFuncName,
-						messageId,
 						keyStartIndex.offset,
 						functionNameToNamespaces
 					);
+					if (invokedFuncName !== "t" && !namespace) {
+						return null;
+					}
+
+					const finalMessageId = namespace
+						? `${namespace}.${messageId}`
+						: messageId;
 
 					return {
 						messageId: finalMessageId,
@@ -100,13 +113,20 @@ const createParser = (
 const createNamespaceParser = () => {
 	return Parsimmon.createLanguage({
 		entry: (r) => {
-			return Parsimmon.alt(r.FunctionCall!, Parsimmon.any)
+			return Parsimmon.alt(
+				r.TranslationFunctionDeclaration!,
+				r.TranslationFunctionAlias!,
+				Parsimmon.any
+			)
 				.many()
 				.map((matches) => {
 					// Filter for matches that have varName and ns
 					return matches.filter(
 						(match) =>
-							typeof match === "object" && match && match.varName && match.ns
+							typeof match === "object" &&
+							match &&
+							match.varName &&
+							(match.ns || match.aliasOf)
 					);
 				});
 		},
@@ -185,6 +205,9 @@ const createNamespaceParser = () => {
 				stringLiteral: Parsimmon.regexp(/"([^"\\]|\\.)*"/).map((value) =>
 					JSON.parse(value)
 				), // Match double-quoted strings and parse them
+				singleQuotedStringLiteral: Parsimmon.regexp(/'([^'\\]|\\.)*'/).map(
+					(value) => value.slice(1, -1)
+				),
 				variableName: Parsimmon.regexp(
 					/[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)*/
 				), // Match variable names
@@ -193,6 +216,7 @@ const createNamespaceParser = () => {
 
 			const valueParser = Parsimmon.alt(
 				x.stringLiteral,
+				x.singleQuotedStringLiteral,
 				x.variableName,
 				x.functionLiteral
 			);
@@ -222,7 +246,7 @@ const createNamespaceParser = () => {
 			);
 		},
 
-		FunctionCall: function (r) {
+		TranslationFunctionDeclaration: function (r) {
 			// Parser for the useTranslations() or getTranslations() call itself
 			const useOrGetTranslationsCall = Parsimmon.seqMap(
 				// Parsimmon.regex(/\b(?:use|get)Translations\b/), // OLD: no await
@@ -279,29 +303,69 @@ const createNamespaceParser = () => {
 				}
 			);
 		},
+
+		TranslationFunctionAlias: function (r) {
+			return Parsimmon.seqMap(
+				Parsimmon.index,
+				Parsimmon.regex(/\b(?:const|let|var)\b\s+/),
+				r.identifier!,
+				r.whitespace!,
+				Parsimmon.string("="),
+				r.whitespace!,
+				r.identifier!,
+				Parsimmon.regex(/[ \t]*(?=;|\r?\n|$)/),
+				(
+					declPosition,
+					_keyword,
+					varName,
+					_ws1,
+					_eq,
+					_ws2,
+					aliasOf,
+					_trailing
+				) => ({
+					varName,
+					aliasOf,
+					declarationPosition: declPosition.offset,
+				})
+			);
+		},
 	});
 };
 
 function parseNameSpaces(sourceCode: string): FunctionNameToNamespaces {
 	const namespaceParser = createNamespaceParser();
 	// parsedDeclarations will be an array of { varName: string, ns: string, declarationPosition: number }
-	const parsedDeclarations = namespaceParser.entry!.tryParse(sourceCode);
+	const parsedDeclarations = namespaceParser.entry!.tryParse(
+		sourceCode
+	) as NamespaceBinding[];
 
 	const functionNameToNamespaces: FunctionNameToNamespaces = {};
 
-	for (const declaration of parsedDeclarations) {
+	for (const declaration of parsedDeclarations.sort(
+		(a, b) => a.declarationPosition - b.declarationPosition
+	)) {
 		// Ensure declaration is not null and has the expected properties
 		if (
 			declaration &&
 			declaration.varName &&
-			declaration.ns &&
 			typeof declaration.declarationPosition === "number"
 		) {
+			const namespace =
+				declaration.ns ??
+				(declaration.aliasOf
+					? getNamespaceForFunctionName(
+							declaration.aliasOf,
+							declaration.declarationPosition,
+							functionNameToNamespaces
+						)
+					: undefined);
+
 			if (!functionNameToNamespaces[declaration.varName]) {
 				functionNameToNamespaces[declaration.varName] = [];
 			}
 			functionNameToNamespaces[declaration.varName]!.push({
-				ns: declaration.ns,
+				ns: namespace,
 				declarationPosition: declaration.declarationPosition,
 			});
 		}
@@ -317,44 +381,28 @@ function parseNameSpaces(sourceCode: string): FunctionNameToNamespaces {
 	return functionNameToNamespaces;
 }
 
-/**
- * Returns the fully qualified messageId by prepending the correct namespace, if available.
- * Looks up the most recent namespace declaration for the given variable name that appears before the function call.
- * If no suitable declaration is found, returns the original messageId.
- */
-const getFinalMessageId = (
-	invokedFuncName: string,
-	messageId: string,
+const getNamespaceForFunctionName = (
+	functionName: string,
 	startOffset: number,
 	functionNameToNamespaces: FunctionNameToNamespaces
-): string => {
-	// Get all namespace declarations for the invoked function variable
-	const declarations = functionNameToNamespaces[invokedFuncName];
-	if (!declarations) return messageId; // No declarations found, return as is
+): string | undefined => {
+	const declarations = functionNameToNamespaces[functionName];
+	if (!declarations) return undefined;
 
-	// Track the most recent (latest) declaration before the function call
 	let latestDeclarationBeforeCall = null;
 	for (const declaration of declarations) {
-		// Skip declarations that appear after or at the function call
-		const isDeclarationAfterOrAtCall =
-			declaration.declarationPosition >= startOffset;
-		if (isDeclarationAfterOrAtCall) continue;
+		if (declaration.declarationPosition >= startOffset) continue;
 
-		// If this is the first valid declaration, or it's closer to the function call than the previous one, update
-		const isFirstOrCloser =
+		if (
 			latestDeclarationBeforeCall === null ||
 			declaration.declarationPosition >
-				latestDeclarationBeforeCall.declarationPosition;
-
-		if (isFirstOrCloser) {
+				latestDeclarationBeforeCall.declarationPosition
+		) {
 			latestDeclarationBeforeCall = declaration;
 		}
 	}
 
-	// If no valid declaration was found, return the original messageId
-	if (latestDeclarationBeforeCall === null) return messageId;
-	// Prepend the namespace to the messageId
-	return `${latestDeclarationBeforeCall.ns}.${messageId}`;
+	return latestDeclarationBeforeCall?.ns;
 };
 
 // Parse the expression


### PR DESCRIPTION
## Summary
- resolve simple and chained aliases for namespaced next-intl translation functions
- avoid raw matches before aliases are declared and block stale aliases after shadow declarations
- support renamed destructured translators and direct `getTranslations({ namespace })` assignments with quoted namespace values
- add a minor changeset for `@inlang/plugin-next-intl`

Closes opral/sherlock#124

## Tests
- pnpm --filter @inlang/plugin-next-intl test
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large parser rewrite in IDE-only matching logic; wrong bindings could mis-link message IDs in the editor, but behavior is heavily test-covered and does not affect runtime app code.
> 
> **Overview**
> **Replaces** the Parsimmon-based Sherlock message matcher in `@inlang/plugin-next-intl` with a custom lexer plus scope-aware binding analysis so IDE references stay accurate for more real-world next-intl patterns.
> 
> The matcher now **resolves** simple and chained aliases (e.g. `const translate = t`), renamed destructuring (`{ t: translate }`), and **direct** `const t = await getTranslations({ namespace: "..." })` with single- or double-quoted `namespace` values—not only destructured `{ t }` from translation hooks.
> 
> It also **tightens** when matches are emitted: no matches before an alias exists, no stale aliases after shadowing (blocks, parameters, catch/for bindings, reassignment), while **still** treating non–next-intl `t` bindings (e.g. `const t = other`) as unprefixed keys. Extensive new Vitest coverage documents these rules; a **minor** changeset records the plugin bump.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0936e1521e3c857ab4282acb7f79977226d50d7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->