### PR TITLE
[codex] Fix RTL editor action layout

### DIFF
--- a/.changeset/tidy-rtl-editor-actions.md
+++ b/.changeset/tidy-rtl-editor-actions.md
@@ -1,0 +1,5 @@
+---
+"@inlang/editor-component": patch
+---
+
+Keep editor row controls stable when RTL direction is applied while preserving automatic text direction in pattern inputs.

--- a/packages/ui-components/editor-component/src/stories/message/inlang-message.ts
+++ b/packages/ui-components/editor-component/src/stories/message/inlang-message.ts
@@ -29,6 +29,7 @@ export default class InlangMessage extends LitElement {
 			:host {
 				position: relative;
 				display: flex;
+				direction: ltr;
 				min-height: 44px;
 				border: 1px solid var(--sl-input-border-color) !important;
 				border-top: none !important;

--- a/packages/ui-components/editor-component/src/stories/pattern-editor/inlang-pattern-editor.ts
+++ b/packages/ui-components/editor-component/src/stories/pattern-editor/inlang-pattern-editor.ts
@@ -294,6 +294,7 @@ export default class InlangPatternEditor extends LitElement {
 				<div
 					class="inlang-pattern-editor-contenteditable"
 					contenteditable
+					dir="auto"
 					${ref(this.contentEditableElementRef)}
 				></div>
 				${this._patternState === undefined ||

--- a/packages/ui-components/editor-component/src/stories/variant/inlang-variant.ts
+++ b/packages/ui-components/editor-component/src/stories/variant/inlang-variant.ts
@@ -29,6 +29,7 @@ export default class InlangVariant extends LitElement {
       }
       :host {
         border-top: 1px solid var(--sl-input-border-color) !important;
+        direction: ltr;
       }
       :host(:first-child) {
         border-top: none !important;
@@ -148,6 +149,23 @@ export default class InlangVariant extends LitElement {
 
     //get all sl-inputs and set the color to the inlang colors
     overridePrimitiveColors();
+    await this._syncMatchInputDirections();
+  }
+
+  override updated() {
+    void this._syncMatchInputDirections();
+  }
+
+  private async _syncMatchInputDirections() {
+    const inputs = Array.from(
+      this.shadowRoot?.querySelectorAll<SlInput>(".match") ?? []
+    );
+
+    await Promise.all(inputs.map((input) => input.updateComplete));
+
+    for (const input of inputs) {
+      input.input?.setAttribute("dir", "auto");
+    }
   }
 
   override render() {
@@ -161,6 +179,7 @@ export default class InlangVariant extends LitElement {
                     id="${this.variant.id}-${match.key}"
                     class="match"
                     size="small"
+                    dir="auto"
                     value=${match.type === "literal-match" ? match.value : "*"}
                     @sl-blur=${(e: Event) => {
 											const element = this.shadowRoot?.getElementById(


### PR DESCRIPTION
## Summary

- Keep editor component row chrome laid out LTR so inherited RTL direction does not move locale labels or action controls.
- Preserve automatic RTL/LTR behavior inside pattern editor content and selector match inputs.
- Add a patch changeset for `@inlang/editor-component`.

## Root Cause

RTL direction could be inherited by `inlang-message` and `inlang-variant`, which flipped the structural flex/absolute-positioned layout. That caused variant actions to appear over the text area instead of staying beside it.

## Validation

- `pnpm --filter @inlang/editor-component test`
- `pnpm --filter @inlang/editor-component build`

Closes https://github.com/opral/sherlock/issues/191

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UI/layout and text-direction attributes in the editor component with no auth, data, or API changes.
> 
> **Overview**
> Fixes editor rows breaking under inherited RTL by forcing **LTR layout chrome** on `inlang-message` and `inlang-variant` (`direction: ltr` on `:host`), so locale labels and absolutely positioned variant actions stay beside the pattern area instead of flipping over the text.
> 
> **Automatic bidirectional text** is preserved where users type: the pattern editor contenteditable and variant selector match inputs use `dir="auto"` (including syncing Shoelace’s inner input after updates).
> 
> Ships a **patch changeset** for `@inlang/editor-component`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d17dca4a5489a835fbdddd93eb803a13513825bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->