### PR TITLE
Feat/add deepl translation api support

### DIFF
--- a/.changeset/sad-gifts-draw.md
+++ b/.changeset/sad-gifts-draw.md
@@ -1,0 +1,9 @@
+---
+"@inlang/cli": minor
+---
+
+Add DeepL API support for `machine translate`.
+
+Set `INLANG_MACHINE_TRANSLATE_PROVIDER=deepl` and `INLANG_DEEPL_API_KEY` to translate with your own DeepL API key. Google Translate remains the default provider when `INLANG_MACHINE_TRANSLATE_PROVIDER` is unset. Free DeepL keys ending in `:fx` automatically use the `api-free.deepl.com` endpoint.
+
+See the updated BYOK guide for setup instructions for both Google and DeepL.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @inlang/cli
 
+## Unreleased
+
+### Minor Changes
+
+- Add DeepL API support for `machine translate`. Set `INLANG_MACHINE_TRANSLATE_PROVIDER=deepl` and `INLANG_DEEPL_API_KEY` to use DeepL. Google Translate remains the default provider.
+
 ## 3.1.15
 
 ### Patch Changes

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -16,7 +16,7 @@ npx @inlang/cli [command]
 
 ## Features
 
-- **Machine Translation** — Translate missing messages automatically with your own Google Cloud Translation API key
+- **Machine Translation** — Translate missing messages automatically with your own Google Cloud Translation or DeepL API key
 - **Validation** — Verify your project config is correct before committing
 - **CI/CD Ready** — Run non-interactively with `--force` for pipelines
 - **Plugin System** — Supports JSON, i18next, next-intl, ICU message format, and more
@@ -72,10 +72,18 @@ Create `messages/en.json`:
 
 **3. Machine translate to other languages**
 
-Set `INLANG_GOOGLE_TRANSLATE_API_KEY` to your own Google Cloud Translation API key first:
+Set your translation provider and API key first. Google Translate is the default provider:
 
 ```bash
+export INLANG_MACHINE_TRANSLATE_PROVIDER="google"
 export INLANG_GOOGLE_TRANSLATE_API_KEY="your-google-api-key"
+```
+
+Or use DeepL:
+
+```bash
+export INLANG_MACHINE_TRANSLATE_PROVIDER="deepl"
+export INLANG_DEEPL_API_KEY="your-deepl-api-key"
 ```
 
 ```bash
@@ -166,7 +174,7 @@ The machine command is used to automate localization processes.
 
 The translate command machine translates all resources.
 
-The CLI requires `INLANG_GOOGLE_TRANSLATE_API_KEY` to be set to your own Google Cloud Translation API key. See the [BYOK setup guide](https://inlang.com/m/2qj2w8pu/app-inlang-cli/byok).
+The CLI requires a translation API key for the configured provider. Set `INLANG_MACHINE_TRANSLATE_PROVIDER` to `google` (default) or `deepl`, then set the matching API key environment variable. See the [BYOK setup guide](https://inlang.com/m/2qj2w8pu/app-inlang-cli/byok).
 
 For many projects, coding agents can produce better translation drafts than generic machine translation because they can use surrounding product and code context. Consider using an agent-driven workflow when translation quality matters more than fully automated CI output.
 
@@ -185,7 +193,7 @@ The translate command has the following options:
 - `--locale <source>`: Specifies the base locale.
 - `--targetLocales <targets...>`: Specifies the target locales as comma seperated list (e.g. sk,zh,pt-BR).
 
-The translations are performed with the Google Cloud Translation API key from `INLANG_GOOGLE_TRANSLATE_API_KEY`. The translated messages are added to the respective language resources. Finally, the updated resources are written back to the file system.
+The translations are performed with the configured provider (`INLANG_MACHINE_TRANSLATE_PROVIDER`) using the API key from `INLANG_GOOGLE_TRANSLATE_API_KEY` or `INLANG_DEEPL_API_KEY`. The translated messages are added to the respective language resources. Finally, the updated resources are written back to the file system.
 
 ## `validate`
 

--- a/packages/cli/docs/byok.md
+++ b/packages/cli/docs/byok.md
@@ -1,15 +1,24 @@
 ---
 title: BYOK
-description: Set your own Google Cloud Translation API key for machine translations with the inlang CLI.
+description: Set your own Google Cloud Translation or DeepL API key for machine translations with the inlang CLI.
 ---
 
-# Bring Your Own Google Translate API Key
+# Bring Your Own Translation API Key
 
-The `machine translate` command requires your own Google Cloud Translation API key. Set it with `INLANG_GOOGLE_TRANSLATE_API_KEY` before running the command.
+The `machine translate` command requires your own translation API key. Choose a provider with `INLANG_MACHINE_TRANSLATE_PROVIDER` and set the matching API key environment variable before running the command.
 
 For many projects, coding agents can produce better translation drafts than generic machine translation because they can use surrounding product and code context. Consider using an agent-driven workflow when translation quality matters more than fully automated CI output.
 
-## Setup
+## Provider selection
+
+Set `INLANG_MACHINE_TRANSLATE_PROVIDER` to choose the translation service:
+
+| Provider | Env var | API key env var |
+| -------- | ------- | --------------- |
+| Google Translate (default) | `google` or unset | `INLANG_GOOGLE_TRANSLATE_API_KEY` |
+| DeepL | `deepl` | `INLANG_DEEPL_API_KEY` |
+
+## Google Translate setup
 
 ### 1. Create a Google Cloud project
 
@@ -27,26 +36,55 @@ Follow the [Cloud Translation setup guide](https://cloud.google.com/translate/do
 2. Click **Create Credentials** and select **API key**
 3. Copy the generated key
 
-### 4. Set the environment variable
-
-Export the API key as `INLANG_GOOGLE_TRANSLATE_API_KEY`:
+### 4. Set the environment variables
 
 ```bash
+export INLANG_MACHINE_TRANSLATE_PROVIDER="google"
 export INLANG_GOOGLE_TRANSLATE_API_KEY="your-google-api-key"
 ```
 
 To make this permanent, add it to your shell profile (`~/.bashrc`, `~/.zshrc`, etc.):
 
 ```bash
+echo 'export INLANG_MACHINE_TRANSLATE_PROVIDER="google"' >> ~/.bashrc
 echo 'export INLANG_GOOGLE_TRANSLATE_API_KEY="your-google-api-key"' >> ~/.bashrc
 source ~/.bashrc
 ```
 
 For CI/CD pipelines, add the key as a secret environment variable in your CI provider's settings.
 
+## DeepL setup
+
+### 1. Create a DeepL API account
+
+Sign up for a [DeepL API plan](https://www.deepl.com/pro#developer) (Free or Pro).
+
+### 2. Generate an API key
+
+Copy your API key from the DeepL account dashboard. Free API keys end with `:fx` and use the `api-free.deepl.com` endpoint automatically.
+
+### 3. Set the environment variables
+
+```bash
+export INLANG_MACHINE_TRANSLATE_PROVIDER="deepl"
+export INLANG_DEEPL_API_KEY="your-deepl-api-key"
+```
+
+To make this permanent, add it to your shell profile (`~/.bashrc`, `~/.zshrc`, etc.):
+
+```bash
+echo 'export INLANG_MACHINE_TRANSLATE_PROVIDER="deepl"' >> ~/.bashrc
+echo 'export INLANG_DEEPL_API_KEY="your-deepl-api-key"' >> ~/.bashrc
+source ~/.bashrc
+```
+
+For CI/CD pipelines, add both variables as secrets in your CI provider's settings.
+
+See the [DeepL API quickstart](https://developers.deepl.com/docs/getting-started/quickstart) for more details.
+
 ## Usage
 
-Once the environment variable is set, the CLI will automatically use your API key:
+Once the environment variables are set, run machine translate:
 
 ```bash
 npx @inlang/cli machine translate --project ./project.inlang

--- a/packages/cli/src/commands/machine/machineTranslateBundle.ts
+++ b/packages/cli/src/commands/machine/machineTranslateBundle.ts
@@ -1,19 +1,22 @@
 import { randomUUID } from "node:crypto";
 import {
   Text,
-  VariableReference,
   type BundleNested,
   type NewBundleNested,
   type Variant,
 } from "@inlang/sdk";
-
-const PRIMARY_API_KEY_ENV = "INLANG_GOOGLE_TRANSLATE_API_KEY";
+import {
+  deserializePattern,
+  findMatchingVariant,
+  serializePattern,
+} from "./patternSerialization.js";
+import type { MachineTranslateProvider } from "./providers/types.js";
 
 type MachineTranslateArgs = {
   bundle: BundleNested;
   sourceLocale: string;
   targetLocales: string[];
-  googleApiKey?: string;
+  provider: MachineTranslateProvider;
 };
 
 export type MachineTranslateResult = {
@@ -22,17 +25,18 @@ export type MachineTranslateResult = {
 };
 
 /**
- * Machine translates the given bundle using the Google Translate API.
+ * Machine translates the given bundle using the configured translation provider.
  *
  * The translation updates or creates variants only for missing translations in
  * the requested target locales. Existing non-empty variants are preserved.
  *
  * @example
+ *   const provider = resolveMachineTranslateProvider();
  *   const result = await machineTranslateBundle({
  *     bundle,
  *     sourceLocale: "en",
  *     targetLocales: ["de"],
- *     googleApiKey: process.env.INLANG_GOOGLE_TRANSLATE_API_KEY,
+ *     provider,
  *   });
  *   if (result.data) {
  *     await upsertBundleNested(project, result.data);
@@ -42,13 +46,6 @@ export async function machineTranslateBundle(
   args: MachineTranslateArgs,
 ): Promise<MachineTranslateResult> {
   try {
-    const apiKey =
-      args.googleApiKey ?? process.env[PRIMARY_API_KEY_ENV];
-
-    if (!apiKey) {
-      return { error: `${PRIMARY_API_KEY_ENV} is not set` };
-    }
-
     const copy = structuredClone(args.bundle);
 
     const sourceMessage = copy.messages.find(
@@ -92,27 +89,17 @@ export async function machineTranslateBundle(
           }
         }
 
-        const response = await fetch(
-          "https://translation.googleapis.com/language/translate/v2?" +
-            new URLSearchParams({
-              q: sourcePattern,
-              target: targetLocale,
-              source: args.sourceLocale,
-              format: "html",
-              key: apiKey,
-            }),
-          { method: "POST" },
-        );
+        const translation = await args.provider.translateText({
+          text: sourcePattern,
+          sourceLocale: args.sourceLocale,
+          targetLocale,
+        });
 
-        if (!response.ok) {
-          const err = `${response.status} ${response.statusText}: translating from ${args.sourceLocale} to ${targetLocale}`;
-          return { error: err };
+        if (!translation.ok) {
+          return { error: translation.error };
         }
 
-        const json = await response.json();
-        const pattern = deserializePattern(
-          json.data.translations[0].translatedText,
-        );
+        const pattern = deserializePattern(translation.translatedText);
 
         if (targetMessage) {
           const existingVariant = findMatchingVariant(
@@ -159,113 +146,4 @@ export async function machineTranslateBundle(
   } catch (error) {
     return { error: error?.toString() ?? "unknown error" };
   }
-}
-
-function findMatchingVariant(
-  variants: Variant[],
-  matches: Variant["matches"],
-): Variant | undefined {
-  if (matches.length === 0) {
-    return variants.find((variant) => variant.matches.length === 0);
-  }
-
-  return variants.find((variant) => {
-    if (variant.matches.length !== matches.length) {
-      return false;
-    }
-
-    return matches.every((sourceMatch) =>
-      variant.matches.some((targetMatch) => {
-        if (
-          targetMatch.key !== sourceMatch.key ||
-          targetMatch.type !== sourceMatch.type
-        ) {
-          return false;
-        }
-
-        if (
-          sourceMatch.type === "literal-match" &&
-          targetMatch.type === "literal-match"
-        ) {
-          return sourceMatch.value === targetMatch.value;
-        }
-
-        return true;
-      }),
-    );
-  });
-}
-
-type PlaceholderMetadata = Record<
-  string,
-  {
-    leadingCharacter?: string;
-    trailingCharacter?: string;
-  }
->;
-
-const escapeStart = `<span class="notranslate">`;
-const escapeEnd = "</span>";
-
-function serializePattern(
-  pattern: Variant["pattern"],
-  placeholderMetadata: PlaceholderMetadata,
-) {
-  let result = "";
-  for (const [index, element] of pattern.entries()) {
-    if (element.type === "text") {
-      result += element.value
-        .replaceAll("\r", "<inlang-CarriageReturn>")
-        .replaceAll("\n", "<inlang-LineFeed>");
-    } else {
-      // @ts-expect-error placeholder metadata is keyed by name at runtime
-      placeholderMetadata[element.name] = {
-        leadingCharacter: result.at(-1) ?? undefined,
-        trailingCharacter:
-          pattern[index + 1]?.type === "text"
-            ? (pattern[index + 1] as Text).value[0]
-            : undefined,
-      };
-      result += `${escapeStart}${JSON.stringify(element)}${escapeEnd}`;
-    }
-  }
-  return result;
-}
-
-function deserializePattern(text: string): Variant["pattern"] {
-  const result: Variant["pattern"] = [];
-  const unescapedText = text
-    .replaceAll("&quot;", '"')
-    .replaceAll("&#39;", "'")
-    .replaceAll("<inlang-CarriageReturn>", "\r")
-    .replaceAll("<inlang-LineFeed> ", "\n")
-    .replaceAll("<inlang-LineFeed>", "\n");
-  let index = 0;
-  while (index < unescapedText.length) {
-    const start = unescapedText.indexOf(escapeStart, index);
-    if (start === -1) {
-      result.push({ type: "text", value: unescapedText.slice(index) });
-      break;
-    } else if (index < start) {
-      result.push({ type: "text", value: unescapedText.slice(index, start) });
-      index = start;
-      continue;
-    }
-    const end = unescapedText.indexOf(escapeEnd, start);
-    if (end === -1) {
-      result.push({ type: "text", value: unescapedText.slice(index) });
-      break;
-    }
-
-    const expressionAsText = unescapedText.slice(
-      start + escapeStart.length,
-      end,
-    );
-    const expression = JSON.parse(expressionAsText) as VariableReference;
-
-    // @ts-expect-error placeholder metadata is preserved at runtime
-    result.push(expression);
-    index = end + escapeEnd.length;
-  }
-  return result;
 }

--- a/packages/cli/src/commands/machine/patternSerialization.ts
+++ b/packages/cli/src/commands/machine/patternSerialization.ts
@@ -1,0 +1,110 @@
+import { Text, VariableReference, type Variant } from "@inlang/sdk";
+
+type PlaceholderMetadata = Record<
+  string,
+  {
+    leadingCharacter?: string;
+    trailingCharacter?: string;
+  }
+>;
+
+const escapeStart = `<span class="notranslate">`;
+const escapeEnd = "</span>";
+
+export function findMatchingVariant(
+  variants: Variant[],
+  matches: Variant["matches"],
+): Variant | undefined {
+  if (matches.length === 0) {
+    return variants.find((variant) => variant.matches.length === 0);
+  }
+
+  return variants.find((variant) => {
+    if (variant.matches.length !== matches.length) {
+      return false;
+    }
+
+    return matches.every((sourceMatch) =>
+      variant.matches.some((targetMatch) => {
+        if (
+          targetMatch.key !== sourceMatch.key ||
+          targetMatch.type !== sourceMatch.type
+        ) {
+          return false;
+        }
+
+        if (
+          sourceMatch.type === "literal-match" &&
+          targetMatch.type === "literal-match"
+        ) {
+          return sourceMatch.value === targetMatch.value;
+        }
+
+        return true;
+      }),
+    );
+  });
+}
+
+export function serializePattern(
+  pattern: Variant["pattern"],
+  placeholderMetadata: PlaceholderMetadata,
+) {
+  let result = "";
+  for (const [index, element] of pattern.entries()) {
+    if (element.type === "text") {
+      result += element.value
+        .replaceAll("\r", "<inlang-CarriageReturn>")
+        .replaceAll("\n", "<inlang-LineFeed>");
+    } else {
+      // @ts-expect-error placeholder metadata is keyed by name at runtime
+      placeholderMetadata[element.name] = {
+        leadingCharacter: result.at(-1) ?? undefined,
+        trailingCharacter:
+          pattern[index + 1]?.type === "text"
+            ? (pattern[index + 1] as Text).value[0]
+            : undefined,
+      };
+      result += `${escapeStart}${JSON.stringify(element)}${escapeEnd}`;
+    }
+  }
+  return result;
+}
+
+export function deserializePattern(text: string): Variant["pattern"] {
+  const result: Variant["pattern"] = [];
+  const unescapedText = text
+    .replaceAll("&quot;", '"')
+    .replaceAll("&#39;", "'")
+    .replaceAll("<inlang-CarriageReturn>", "\r")
+    .replaceAll("<inlang-LineFeed> ", "\n")
+    .replaceAll("<inlang-LineFeed>", "\n");
+  let index = 0;
+  while (index < unescapedText.length) {
+    const start = unescapedText.indexOf(escapeStart, index);
+    if (start === -1) {
+      result.push({ type: "text", value: unescapedText.slice(index) });
+      break;
+    } else if (index < start) {
+      result.push({ type: "text", value: unescapedText.slice(index, start) });
+      index = start;
+      continue;
+    }
+    const end = unescapedText.indexOf(escapeEnd, start);
+    if (end === -1) {
+      result.push({ type: "text", value: unescapedText.slice(index) });
+      break;
+    }
+
+    const expressionAsText = unescapedText.slice(
+      start + escapeStart.length,
+      end,
+    );
+    const expression = JSON.parse(expressionAsText) as VariableReference;
+
+    // @ts-expect-error placeholder metadata is preserved at runtime
+    result.push(expression);
+    index = end + escapeEnd.length;
+  }
+  return result;
+}

--- a/packages/cli/src/commands/machine/providers/deepl.test.ts
+++ b/packages/cli/src/commands/machine/providers/deepl.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import {
+  getDeepLApiUrl,
+  toDeepLSourceLocale,
+  toDeepLTargetLocale,
+  createDeepLTranslateProvider,
+} from "./deepl.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("toDeepLSourceLocale", () => {
+  test("strips region subtag from source locale", () => {
+    expect(toDeepLSourceLocale("en-US")).toBe("en");
+    expect(toDeepLSourceLocale("zh-Hans")).toBe("zh");
+    expect(toDeepLSourceLocale("de")).toBe("de");
+  });
+});
+
+describe("toDeepLTargetLocale", () => {
+  test("passes through target locale", () => {
+    expect(toDeepLTargetLocale("en-US")).toBe("en-US");
+    expect(toDeepLTargetLocale("de")).toBe("de");
+  });
+});
+
+describe("getDeepLApiUrl", () => {
+  test("uses free endpoint for free API keys", () => {
+    expect(getDeepLApiUrl("abc123:fx")).toBe(
+      "https://api-free.deepl.com/v2/translate",
+    );
+  });
+
+  test("uses pro endpoint for pro API keys", () => {
+    expect(getDeepLApiUrl("abc123")).toBe(
+      "https://api.deepl.com/v2/translate",
+    );
+  });
+});
+
+describe("createDeepLTranslateProvider", () => {
+  test("translates text via DeepL API", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        translations: [{ text: "Hallo Welt" }],
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const provider = createDeepLTranslateProvider("test-key:fx");
+    const result = await provider.translateText({
+      text: "Hello World",
+      sourceLocale: "en-US",
+      targetLocale: "de",
+    });
+
+    expect(result).toEqual({ ok: true, translatedText: "Hallo Welt" });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api-free.deepl.com/v2/translate",
+      expect.objectContaining({
+        method: "POST",
+        headers: {
+          Authorization: "DeepL-Auth-Key test-key:fx",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          text: ["Hello World"],
+          source_lang: "en",
+          target_lang: "de",
+          tag_handling: "html",
+        }),
+      }),
+    );
+  });
+
+  test("returns error when API request fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        statusText: "Bad Request",
+      }),
+    );
+
+    const provider = createDeepLTranslateProvider("test-key");
+    const result = await provider.translateText({
+      text: "Hello World",
+      sourceLocale: "en",
+      targetLocale: "xx",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: "400 Bad Request: translating from en to xx",
+    });
+  });
+});

--- a/packages/cli/src/commands/machine/providers/deepl.ts
+++ b/packages/cli/src/commands/machine/providers/deepl.ts
@@ -1,0 +1,54 @@
+import type { MachineTranslateProvider, TranslateTextArgs } from "./types.js";
+
+export function toDeepLSourceLocale(locale: string): string {
+  const [language] = locale.split("-");
+  return language ?? locale;
+}
+
+export function toDeepLTargetLocale(locale: string): string {
+  return locale;
+}
+
+export function getDeepLApiUrl(apiKey: string): string {
+  if (apiKey.endsWith(":fx")) {
+    return "https://api-free.deepl.com/v2/translate";
+  }
+  return "https://api.deepl.com/v2/translate";
+}
+
+export function createDeepLTranslateProvider(
+  apiKey: string,
+): MachineTranslateProvider {
+  const apiUrl = getDeepLApiUrl(apiKey);
+
+  return {
+    async translateText(args: TranslateTextArgs) {
+      const response = await fetch(apiUrl, {
+        method: "POST",
+        headers: {
+          Authorization: `DeepL-Auth-Key ${apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          text: [args.text],
+          source_lang: toDeepLSourceLocale(args.sourceLocale),
+          target_lang: toDeepLTargetLocale(args.targetLocale),
+          tag_handling: "html",
+        }),
+      });
+
+      if (!response.ok) {
+        return {
+          ok: false,
+          error: `${response.status} ${response.statusText}: translating from ${args.sourceLocale} to ${args.targetLocale}`,
+        };
+      }
+
+      const json = await response.json();
+      return {
+        ok: true,
+        translatedText: json.translations[0].text,
+      };
+    },
+  };
+}

--- a/packages/cli/src/commands/machine/providers/google.test.ts
+++ b/packages/cli/src/commands/machine/providers/google.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { createGoogleTranslateProvider } from "./google.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("createGoogleTranslateProvider", () => {
+  test("translates text via Google API", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: { translations: [{ translatedText: "Hallo Welt" }] },
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const provider = createGoogleTranslateProvider("google-key");
+    const result = await provider.translateText({
+      text: "Hello World",
+      sourceLocale: "en",
+      targetLocale: "de",
+    });
+
+    expect(result).toEqual({ ok: true, translatedText: "Hallo Welt" });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://translation.googleapis.com/language/translate/v2?" +
+        new URLSearchParams({
+          q: "Hello World",
+          target: "de",
+          source: "en",
+          format: "html",
+          key: "google-key",
+        }),
+      { method: "POST" },
+    );
+  });
+
+  test("returns error when API request fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        statusText: "Forbidden",
+      }),
+    );
+
+    const provider = createGoogleTranslateProvider("google-key");
+    const result = await provider.translateText({
+      text: "Hello World",
+      sourceLocale: "en",
+      targetLocale: "de",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: "403 Forbidden: translating from en to de",
+    });
+  });
+});

--- a/packages/cli/src/commands/machine/providers/google.ts
+++ b/packages/cli/src/commands/machine/providers/google.ts
@@ -1,0 +1,34 @@
+import type { MachineTranslateProvider, TranslateTextArgs } from "./types.js";
+
+export function createGoogleTranslateProvider(
+  apiKey: string,
+): MachineTranslateProvider {
+  return {
+    async translateText(args: TranslateTextArgs) {
+      const response = await fetch(
+        "https://translation.googleapis.com/language/translate/v2?" +
+          new URLSearchParams({
+            q: args.text,
+            target: args.targetLocale,
+            source: args.sourceLocale,
+            format: "html",
+            key: apiKey,
+          }),
+        { method: "POST" },
+      );
+
+      if (!response.ok) {
+        return {
+          ok: false,
+          error: `${response.status} ${response.statusText}: translating from ${args.sourceLocale} to ${args.targetLocale}`,
+        };
+      }
+
+      const json = await response.json();
+      return {
+        ok: true,
+        translatedText: json.data.translations[0].translatedText,
+      };
+    },
+  };
+}

--- a/packages/cli/src/commands/machine/providers/resolveProvider.test.ts
+++ b/packages/cli/src/commands/machine/providers/resolveProvider.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, test, expect, vi } from "vitest";
+import { resolveMachineTranslateProvider } from "./resolveProvider.js";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+test("defaults to google provider", () => {
+  vi.stubEnv("INLANG_GOOGLE_TRANSLATE_API_KEY", "google-key");
+  vi.stubEnv("INLANG_MACHINE_TRANSLATE_PROVIDER", "");
+
+  const provider = resolveMachineTranslateProvider();
+  expect(provider).toBeDefined();
+});
+
+test("requires INLANG_GOOGLE_TRANSLATE_API_KEY for google provider", () => {
+  vi.stubEnv("INLANG_MACHINE_TRANSLATE_PROVIDER", "google");
+  vi.stubEnv("INLANG_GOOGLE_TRANSLATE_API_KEY", "");
+
+  expect(() => resolveMachineTranslateProvider()).toThrow(
+    "INLANG_GOOGLE_TRANSLATE_API_KEY must be set",
+  );
+});
+
+test("requires INLANG_DEEPL_API_KEY for deepl provider", () => {
+  vi.stubEnv("INLANG_MACHINE_TRANSLATE_PROVIDER", "deepl");
+  vi.stubEnv("INLANG_DEEPL_API_KEY", "");
+
+  expect(() => resolveMachineTranslateProvider()).toThrow(
+    "INLANG_DEEPL_API_KEY must be set",
+  );
+});
+
+test("rejects unsupported provider values", () => {
+  vi.stubEnv("INLANG_MACHINE_TRANSLATE_PROVIDER", "azure");
+
+  expect(() => resolveMachineTranslateProvider()).toThrow(
+    'Unsupported INLANG_MACHINE_TRANSLATE_PROVIDER value: "azure"',
+  );
+});

--- a/packages/cli/src/commands/machine/providers/resolveProvider.ts
+++ b/packages/cli/src/commands/machine/providers/resolveProvider.ts
@@ -1,0 +1,55 @@
+import { createDeepLTranslateProvider } from "./deepl.js";
+import { createGoogleTranslateProvider } from "./google.js";
+import type { MachineTranslateProvider } from "./types.js";
+
+export const PROVIDER_ENV = "INLANG_MACHINE_TRANSLATE_PROVIDER";
+export const GOOGLE_API_KEY_ENV = "INLANG_GOOGLE_TRANSLATE_API_KEY";
+export const DEEPL_API_KEY_ENV = "INLANG_DEEPL_API_KEY";
+
+export type MachineTranslateProviderName = "google" | "deepl";
+
+const BYOK_URL = "https://inlang.com/m/2qj2w8pu/app-inlang-cli/byok";
+const DEEPL_DOCS_URL = "https://developers.deepl.com/docs/getting-started/quickstart";
+
+export function resolveMachineTranslateProvider(): MachineTranslateProvider {
+  const rawProvider = process.env[PROVIDER_ENV]?.trim();
+  const providerName = (
+    rawProvider && rawProvider.length > 0 ? rawProvider : "google"
+  ).toLowerCase() as MachineTranslateProviderName;
+
+  if (providerName !== "google" && providerName !== "deepl") {
+    throw new Error(
+      [
+        `Unsupported ${PROVIDER_ENV} value: "${process.env[PROVIDER_ENV]}".`,
+        "Supported values: google, deepl.",
+      ].join("\n"),
+    );
+  }
+
+  if (providerName === "deepl") {
+    const apiKey = process.env[DEEPL_API_KEY_ENV];
+    if (!apiKey) {
+      throw new Error(
+        [
+          `${DEEPL_API_KEY_ENV} must be set to use machine translate with DeepL.`,
+          "Create your own DeepL API key and export it before running this command.",
+          `See ${DEEPL_DOCS_URL}`,
+          `See ${BYOK_URL}`,
+        ].join("\n"),
+      );
+    }
+    return createDeepLTranslateProvider(apiKey);
+  }
+
+  const apiKey = process.env[GOOGLE_API_KEY_ENV];
+  if (!apiKey) {
+    throw new Error(
+      [
+        `${GOOGLE_API_KEY_ENV} must be set to use machine translate.`,
+        "Create your own Google Cloud Translation API key and export it before running this command.",
+        `See ${BYOK_URL}`,
+      ].join("\n"),
+    );
+  }
+  return createGoogleTranslateProvider(apiKey);
+}

--- a/packages/cli/src/commands/machine/providers/types.ts
+++ b/packages/cli/src/commands/machine/providers/types.ts
@@ -1,0 +1,13 @@
+export type TranslateTextArgs = {
+  text: string;
+  sourceLocale: string;
+  targetLocale: string;
+};
+
+export type TranslateTextResult =
+  | { ok: true; translatedText: string }
+  | { ok: false; error: string };
+
+export type MachineTranslateProvider = {
+  translateText: (args: TranslateTextArgs) => Promise<TranslateTextResult>;
+};

--- a/packages/cli/src/commands/machine/translate.test.ts
+++ b/packages/cli/src/commands/machine/translate.test.ts
@@ -12,6 +12,7 @@ afterEach(() => {
 });
 
 test("requires INLANG_GOOGLE_TRANSLATE_API_KEY", async () => {
+  vi.stubEnv("INLANG_MACHINE_TRANSLATE_PROVIDER", "google");
   vi.stubEnv("INLANG_GOOGLE_TRANSLATE_API_KEY", "");
 
   await expect(
@@ -19,9 +20,87 @@ test("requires INLANG_GOOGLE_TRANSLATE_API_KEY", async () => {
   ).rejects.toThrow("INLANG_GOOGLE_TRANSLATE_API_KEY must be set");
 });
 
+test("requires INLANG_DEEPL_API_KEY when provider is deepl", async () => {
+  vi.stubEnv("INLANG_MACHINE_TRANSLATE_PROVIDER", "deepl");
+  vi.stubEnv("INLANG_DEEPL_API_KEY", "");
+
+  await expect(
+    translateCommandAction({ project: {} as any })
+  ).rejects.toThrow("INLANG_DEEPL_API_KEY must be set");
+});
+
 test.runIf(process.env.INLANG_GOOGLE_TRANSLATE_API_KEY)(
   "should tanslate the missing languages",
   async () => {
+    vi.stubEnv("INLANG_MACHINE_TRANSLATE_PROVIDER", "google");
+
+    const project = await loadProjectInMemory({
+      blob: await newProject({
+        settings: {
+          baseLocale: "en",
+          locales: ["en", "de"],
+        },
+      }),
+    });
+
+    await insertBundleNested(project.db, {
+      id: "mock",
+      messages: [
+        {
+          id: "mock_en",
+          bundleId: "mock",
+          locale: "en",
+          variants: [
+            {
+              id: "mock_en",
+              messageId: "mock_en",
+              pattern: [{ type: "text", value: "Hello World" }],
+            },
+          ],
+        },
+      ],
+    });
+
+    await translateCommandAction({ project });
+
+    const bundles = await selectBundleNested(project.db).execute();
+    const messages = bundles[0]?.messages;
+    const variants = messages?.flatMap((m) => m.variants);
+
+    expect(bundles.length).toBe(1);
+    expect(messages?.length).toBe(2);
+    expect(variants?.length).toBe(2);
+
+    expect(bundles[0]?.id).toBe("mock");
+    expect(messages?.find((m) => m.locale === "en")).toBeDefined();
+    expect(messages?.find((m) => m.locale === "de")).toBeDefined();
+    expect(variants).toStrictEqual([
+      expect.objectContaining({
+        pattern: [
+          {
+            type: "text",
+            value: "Hello World",
+          },
+        ],
+      }),
+      expect.objectContaining({
+        pattern: [
+          {
+            type: "text",
+            value: "Hallo Welt",
+          },
+        ],
+      }),
+    ]);
+  },
+  { timeout: 10000 },
+);
+
+test.runIf(process.env.INLANG_DEEPL_API_KEY)(
+  "should translate missing languages with DeepL",
+  async () => {
+    vi.stubEnv("INLANG_MACHINE_TRANSLATE_PROVIDER", "deepl");
+
     const project = await loadProjectInMemory({
       blob: await newProject({
         settings: {

--- a/packages/cli/src/commands/machine/translate.ts
+++ b/packages/cli/src/commands/machine/translate.ts
@@ -15,6 +15,7 @@ import {
   machineTranslateBundle,
   type MachineTranslateResult,
 } from "./machineTranslateBundle.js";
+import { resolveMachineTranslateProvider } from "./providers/resolveProvider.js";
 
 export const translate = new Command()
   .command("translate")
@@ -43,17 +44,7 @@ export const translate = new Command()
 
 export async function translateCommandAction(args: { project: InlangProject }) {
   const options = translate.opts();
-  const googleApiKey = process.env.INLANG_GOOGLE_TRANSLATE_API_KEY;
-
-  if (!googleApiKey) {
-    throw new Error(
-      [
-        "INLANG_GOOGLE_TRANSLATE_API_KEY must be set to use machine translate.",
-        "Create your own Google Cloud Translation API key and export it before running this command.",
-        "See https://inlang.com/m/2qj2w8pu/app-inlang-cli/byok",
-      ].join("\n")
-    );
-  }
+  const provider = resolveMachineTranslateProvider();
 
   const bar = options.nobar
     ? undefined
@@ -92,7 +83,7 @@ export async function translateCommandAction(args: { project: InlangProject }) {
         bundle,
         sourceLocale: settings.baseLocale,
         targetLocales: targetLocales,
-        googleApiKey,
+        provider,
       });
 
       const trackedPromise = (


### PR DESCRIPTION
As mentioned in #4378, `machine translate` was hardcoded to Google Cloud Translation. This adds DeepL API support so users can choose their preferred translation service while keeping the existing Google setup as the default. 