### PR TITLE
Modernize JSON plugin resource API

### DIFF
--- a/.changeset/modern-json-plugin.md
+++ b/.changeset/modern-json-plugin.md
@@ -1,0 +1,6 @@
+---
+"@inlang/plugin-json": patch
+---
+
+Add the modern resource-plugin contract while retaining the legacy JSON API.
+This enables plugin-driven file watching, including namespaced JSON resources.

--- a/packages/plugins/json/README.md
+++ b/packages/plugins/json/README.md
@@ -4,9 +4,10 @@
 
 This plugin is a general purpose plugin to read and write messages of json files.
 
-> The plugin uses the inlang SDK v1 API but can be used in V2 projects.
->
-> A slight difference is that `languageTag` is called `locale` in v2 projects. Use `languageTag` for this plugin.
+> The plugin implements the current resource-plugin API (`toBeImportedFiles`,
+> `importFiles`, and `exportFiles`) and retains its legacy callbacks for older
+> consumers. In v2 projects, use `locale`; `{languageTag}` remains supported
+> for existing configurations.
 
 ## Manual Installation
 
@@ -22,7 +23,7 @@ This plugin is a general purpose plugin to read and write messages of json files
 	"languageTags": ["en", "de"],
 	"modules": ["https://cdn.jsdelivr.net/npm/@inlang/plugin-json@latest/dist/index.js"],
 	"plugin.inlang.json": {
-		"pathPattern": "./resources/{languageTag}.json"
+		"pathPattern": "./resources/{locale}.json"
 	}
 }
 ```
@@ -63,13 +64,13 @@ type PluginSettings = {
 
 ## `pathPattern`
 
-To use our plugin, you need to provide a path to the directory where your language-specific files are stored. Use the dynamic path syntax `{languageTag}` to specify the language name.
+To use our plugin, you need to provide a path to the directory where your language-specific files are stored. Use the dynamic path syntax `{locale}` to specify the language name. The legacy `{languageTag}` placeholder remains supported.
 
 ### Without namespaces
 
 ```json
 "plugin.inlang.json": {
-	"pathPattern": "./resources/{languageTag}.json"
+	"pathPattern": "./resources/{locale}.json"
 }
 ```
 
@@ -80,8 +81,8 @@ To use our plugin, you need to provide a path to the directory where your langua
 ```json
 "plugin.inlang.json": {
 	"pathPattern": {
-		"website": "./resources/{languageTag}/website.json",
-		"app": "./resources/{languageTag}/app.json"
+		"website": "./resources/{locale}/website.json",
+		"app": "./resources/{locale}/app.json"
 	}
 }
 ```

--- a/packages/plugins/json/package.json
+++ b/packages/plugins/json/package.json
@@ -33,7 +33,7 @@
 	"devDependencies": {
 		"@inlang/tsconfig": "workspace:*",
 		"@types/flat": "^5.0.2",
-		"@inlang/sdk": "0.36.3",
+		"@inlang/sdk": "workspace:*",
 		"@types/lodash.merge": "4.6.7",
 		"esbuild": "^0.24.2",
 		"flat": "^5.0.2",

--- a/packages/plugins/json/src/import-export/exportFiles.ts
+++ b/packages/plugins/json/src/import-export/exportFiles.ts
@@ -1,0 +1,199 @@
+import type { ExportFile, InlangPlugin, Pattern } from "@inlang/sdk";
+import type { PluginSettings } from "../settings.js";
+import { PLUGIN_KEY } from "../pluginKey.js";
+import { getMessagePath } from "./messageId.js";
+
+type JsonPlugin = InlangPlugin<{ [PLUGIN_KEY]: PluginSettings }>;
+
+export const exportFiles: NonNullable<JsonPlugin["exportFiles"]> = async ({
+	bundles,
+	messages,
+	variants,
+	settings,
+}) => {
+	const files: Record<string, ExportMessage[]> = {};
+	const namespaceFiles: Record<string, Record<string, ExportMessage[]>> = {};
+	const pathPattern = settings[PLUGIN_KEY]?.pathPattern;
+	const namespaces =
+		pathPattern !== null && typeof pathPattern === "object"
+			? Object.keys(pathPattern)
+			: [];
+	const defaultNamespace = namespaces[0];
+
+	for (const message of messages) {
+		const bundle = bundles.find(
+			(candidate) => candidate.id === message.bundleId
+		);
+		if (bundle === undefined) {
+			continue;
+		}
+
+		const messageVariants = variants.filter(
+			(candidate) => candidate.messageId === message.id
+		);
+		if (
+			message.selectors.length > 0 ||
+			messageVariants.length > 1 ||
+			messageVariants.some((variant) => variant.matches.length > 0)
+		) {
+			throw new Error(
+				"Selectors, matches, and multiple variants are not supported by the JSON plugin."
+			);
+		}
+
+		const namespace =
+			resolveNamespaceFromBundleId(bundle.id, namespaces) ?? defaultNamespace;
+		const key = namespace
+			? removeNamespaceFromBundleId(bundle.id, namespace)
+			: bundle.id;
+		const path = getCurrentMessagePath({
+			messageId: message.id,
+			currentKey: key,
+		});
+
+		for (const variant of messageVariants) {
+			const exportMessage = {
+				key,
+				path,
+				value: serializePattern(variant.pattern, settings[PLUGIN_KEY]),
+			};
+
+			if (namespace === undefined) {
+				files[message.locale] ??= [];
+				files[message.locale]!.push(exportMessage);
+			} else {
+				namespaceFiles[namespace] ??= {};
+				namespaceFiles[namespace]![message.locale] ??= [];
+				namespaceFiles[namespace]![message.locale]!.push(exportMessage);
+			}
+		}
+	}
+
+	const withoutNamespaces: ExportFile[] = Object.entries(files).map(
+		([locale, messages]) => ({
+			locale,
+			content: encodeJson(messages),
+			name: `${locale}.json`,
+		})
+	);
+	const withNamespaces: ExportFile[] = Object.entries(namespaceFiles).flatMap(
+		([namespace, locales]) =>
+			Object.entries(locales).map(([locale, messages]) => ({
+				locale,
+				content: encodeJson(messages),
+				name: `${namespace}-${locale}.json`,
+				metadata: { namespace },
+			}))
+	);
+
+	return [...withoutNamespaces, ...withNamespaces];
+};
+
+function serializePattern(
+	pattern: Pattern,
+	settings: PluginSettings | undefined
+): string {
+	const variableReferencePattern = settings?.variableReferencePattern ?? [
+		"{",
+		"}",
+	];
+	const opening = variableReferencePattern[0] || "{";
+	const closing = variableReferencePattern[1] ?? "";
+	let result = "";
+
+	for (const part of pattern) {
+		switch (part.type) {
+			case "text":
+				result += part.value;
+				break;
+			case "expression":
+				if (
+					part.arg.type !== "variable-reference" ||
+					part.annotation !== undefined
+				) {
+					throw new Error(
+						"Only unannotated variable references are supported by the JSON plugin."
+					);
+				}
+				result += `${opening}${part.arg.name}${closing}`;
+				break;
+			case "markup-start":
+			case "markup-end":
+			case "markup-standalone":
+				throw new Error("Markup is not supported by the JSON plugin.");
+		}
+	}
+
+	return result;
+}
+
+function resolveNamespaceFromBundleId(
+	bundleId: string,
+	namespaces: string[]
+): string | undefined {
+	return [...namespaces]
+		.sort((left, right) => right.length - left.length)
+		.find((namespace) => bundleId.startsWith(`${namespace}:`));
+}
+
+function removeNamespaceFromBundleId(
+	bundleId: string,
+	namespace: string
+): string {
+	return bundleId.startsWith(`${namespace}:`)
+		? bundleId.slice(namespace.length + 1)
+		: bundleId;
+}
+
+type ExportMessage = {
+	key: string;
+	path?: string[];
+	value: string;
+};
+
+function encodeJson(messages: ExportMessage[]): Uint8Array {
+	return new TextEncoder().encode(
+		JSON.stringify(toJson(messages), undefined, "\t") + "\n"
+	);
+}
+
+function toJson(messages: ExportMessage[]): Record<string, unknown> {
+	const flatMessages: Record<string, string> = {};
+	const result: Record<string, unknown> = {};
+
+	for (const message of messages) {
+		if (message.path === undefined) {
+			flatMessages[message.key] = message.value;
+			continue;
+		}
+		assignPath(result, message.path, message.value);
+	}
+
+	return { ...flatMessages, ...result };
+}
+
+function assignPath(
+	target: Record<string, unknown>,
+	path: string[],
+	value: string
+) {
+	let cursor = target;
+
+	for (const [index, segment] of path.entries()) {
+		if (index === path.length - 1) {
+			cursor[segment] = value;
+			return;
+		}
+
+		cursor[segment] ??= {};
+		cursor = cursor[segment] as Record<string, unknown>;
+	}
+}
+
+function getCurrentMessagePath(args: {
+	messageId: string;
+	currentKey: string;
+}): string[] | undefined {
+	const path = getMessagePath(args.messageId);
+	return path?.join(".") === args.currentKey ? path : undefined;
+}

--- a/packages/plugins/json/src/import-export/importFiles.ts
+++ b/packages/plugins/json/src/import-export/importFiles.ts
@@ -6,7 +6,7 @@ import type {
 } from "@inlang/sdk";
 import type { PluginSettings } from "../settings.js";
 import { PLUGIN_KEY } from "../pluginKey.js";
-import { createMessageId } from "./messageId.js";
+import { createMessageId, createVariantId } from "./messageId.js";
 
 type JsonPlugin = InlangPlugin<{ [PLUGIN_KEY]: PluginSettings }>;
 type InputDeclaration = { type: "input-variable"; name: string };
@@ -54,19 +54,21 @@ export const importFiles: NonNullable<JsonPlugin["importFiles"]> = async ({
 				]);
 			}
 
+			const messageId = createMessageId({
+				locale: file.locale,
+				bundleId,
+				path,
+			});
+
 			messages.push({
-				id: createMessageId({
-					locale: file.locale,
-					bundleId,
-					path,
-				}),
+				id: messageId,
 				bundleId,
 				locale: file.locale,
 				selectors: [],
 			});
 			variants.push({
-				messageBundleId: bundleId,
-				messageLocale: file.locale,
+				id: createVariantId(messageId),
+				messageId,
 				matches: [],
 				pattern,
 			});

--- a/packages/plugins/json/src/import-export/importFiles.ts
+++ b/packages/plugins/json/src/import-export/importFiles.ts
@@ -1,0 +1,175 @@
+import type {
+	InlangPlugin,
+	MessageImport,
+	Pattern,
+	VariantImport,
+} from "@inlang/sdk";
+import type { PluginSettings } from "../settings.js";
+import { PLUGIN_KEY } from "../pluginKey.js";
+import { createMessageId } from "./messageId.js";
+
+type JsonPlugin = InlangPlugin<{ [PLUGIN_KEY]: PluginSettings }>;
+type InputDeclaration = { type: "input-variable"; name: string };
+type JsonBundleImport = { id: string; declarations: InputDeclaration[] };
+type VariableReferenceExpression = Extract<
+	Pattern[number],
+	{ type: "expression" }
+> & {
+	arg: { type: "variable-reference"; name: string };
+};
+
+export const importFiles: NonNullable<JsonPlugin["importFiles"]> = async ({
+	files,
+	settings,
+}) => {
+	const bundles = new Map<string, JsonBundleImport>();
+	const messages: MessageImport[] = [];
+	const variants: VariantImport[] = [];
+	const variableReferencePattern = settings[PLUGIN_KEY]
+		?.variableReferencePattern ?? ["{", "}"];
+
+	for (const file of files) {
+		const namespace = file.toBeImportedFilesMetadata?.namespace;
+		const resource = flattenMessages(
+			JSON.parse(new TextDecoder().decode(file.content))
+		);
+
+		for (const { key, path, value } of resource) {
+			const bundleId = namespace ? `${namespace}:${key}` : key;
+			const pattern = parsePattern(value, variableReferencePattern);
+			const declarations = uniqueDeclarations(
+				pattern.filter(isVariableReferenceExpression).map((part) => ({
+					type: "input-variable" as const,
+					name: part.arg.name,
+				}))
+			);
+			const existingBundle = bundles.get(bundleId);
+
+			if (existingBundle === undefined) {
+				bundles.set(bundleId, { id: bundleId, declarations });
+			} else {
+				existingBundle.declarations = uniqueDeclarations([
+					...existingBundle.declarations,
+					...declarations,
+				]);
+			}
+
+			messages.push({
+				id: createMessageId({
+					locale: file.locale,
+					bundleId,
+					path,
+				}),
+				bundleId,
+				locale: file.locale,
+				selectors: [],
+			});
+			variants.push({
+				messageBundleId: bundleId,
+				messageLocale: file.locale,
+				matches: [],
+				pattern,
+			});
+		}
+	}
+
+	return {
+		bundles: Array.from(bundles.values()),
+		messages,
+		variants,
+	};
+};
+
+function flattenMessages(json: unknown): Array<{
+	key: string;
+	path: string[];
+	value: string;
+}> {
+	const result: Array<{ key: string; path: string[]; value: string }> = [];
+
+	function visit(value: unknown, path: string[]) {
+		if (typeof value === "string") {
+			if (path.length > 0) {
+				result.push({ key: path.join("."), path, value });
+			}
+			return;
+		}
+
+		if (
+			value !== null &&
+			typeof value === "object" &&
+			Array.isArray(value) === false
+		) {
+			for (const [key, nestedValue] of Object.entries(value)) {
+				visit(nestedValue, [...path, key]);
+			}
+		}
+	}
+
+	visit(json, []);
+	return result;
+}
+
+function parsePattern(
+	text: string,
+	variableReferencePattern: string[]
+): Pattern {
+	const opening = variableReferencePattern[0] || "{";
+	const closing = variableReferencePattern[1] ?? "";
+	const expression = closing
+		? new RegExp(
+				`(${escapeRegExp(opening)}[\\s\\S]+?${escapeRegExp(closing)})`,
+				"g"
+			)
+		: new RegExp(`(${escapeRegExp(opening)}\\w+)`, "g");
+
+	return text
+		.split(expression)
+		.filter((element) => element !== "")
+		.map((element) => {
+			if (isVariableReference(element, opening, closing)) {
+				return {
+					type: "expression" as const,
+					arg: {
+						type: "variable-reference" as const,
+						name: closing
+							? element.slice(opening.length, -closing.length)
+							: element.slice(opening.length),
+					},
+				};
+			}
+			return { type: "text" as const, value: element };
+		});
+}
+
+function isVariableReference(
+	text: string,
+	opening: string,
+	closing: string
+): boolean {
+	return closing
+		? text.startsWith(opening) &&
+				text.endsWith(closing) &&
+				text.length > opening.length + closing.length
+		: text.startsWith(opening) && text.length > opening.length;
+}
+
+function escapeRegExp(text: string): string {
+	return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function isVariableReferenceExpression(
+	part: Pattern[number]
+): part is VariableReferenceExpression {
+	return part.type === "expression" && part.arg.type === "variable-reference";
+}
+
+function uniqueDeclarations(
+	declarations: InputDeclaration[]
+): InputDeclaration[] {
+	const result = new Map<string, InputDeclaration>();
+	for (const declaration of declarations) {
+		result.set(`${declaration.type}:${declaration.name}`, declaration);
+	}
+	return Array.from(result.values());
+}

--- a/packages/plugins/json/src/import-export/messageId.ts
+++ b/packages/plugins/json/src/import-export/messageId.ts
@@ -8,6 +8,10 @@ export function createMessageId(args: {
 	return `${MESSAGE_ID_PREFIX}${encodeURIComponent(JSON.stringify(args))}`;
 }
 
+export function createVariantId(messageId: string): string {
+	return `${MESSAGE_ID_PREFIX}variant:${encodeURIComponent(messageId)}`;
+}
+
 export function getMessagePath(messageId: string): string[] | undefined {
 	if (messageId.startsWith(MESSAGE_ID_PREFIX) === false) {
 		return undefined;

--- a/packages/plugins/json/src/import-export/messageId.ts
+++ b/packages/plugins/json/src/import-export/messageId.ts
@@ -1,0 +1,27 @@
+const MESSAGE_ID_PREFIX = "plugin.inlang.json:";
+
+export function createMessageId(args: {
+	locale: string;
+	bundleId: string;
+	path: string[];
+}): string {
+	return `${MESSAGE_ID_PREFIX}${encodeURIComponent(JSON.stringify(args))}`;
+}
+
+export function getMessagePath(messageId: string): string[] | undefined {
+	if (messageId.startsWith(MESSAGE_ID_PREFIX) === false) {
+		return undefined;
+	}
+
+	try {
+		const parsed = JSON.parse(
+			decodeURIComponent(messageId.slice(MESSAGE_ID_PREFIX.length))
+		);
+		return Array.isArray(parsed.path) &&
+			parsed.path.every((segment: unknown) => typeof segment === "string")
+			? parsed.path
+			: undefined;
+	} catch {
+		return undefined;
+	}
+}

--- a/packages/plugins/json/src/import-export/roundtrip.test.ts
+++ b/packages/plugins/json/src/import-export/roundtrip.test.ts
@@ -1,0 +1,245 @@
+import { expect, test } from "vitest";
+import { exportFiles } from "./exportFiles.js";
+import { importFiles } from "./importFiles.js";
+
+test("imports and exports generic JSON while preserving nested and dotted keys", async () => {
+	const imported = await importFiles({
+		settings: {} as any,
+		files: [
+			{
+				locale: "en",
+				content: new TextEncoder().encode(
+					JSON.stringify({
+						title: "Hello {name}",
+						nested: { body: "Welcome" },
+						"a.": { b: "Keep dotted path segments" },
+						"flat.dotted": "Stay flat",
+						empty: "",
+					})
+				),
+			},
+		],
+	});
+
+	expect(imported.bundles).toEqual([
+		{
+			id: "title",
+			declarations: [{ type: "input-variable", name: "name" }],
+		},
+		{ id: "nested.body", declarations: [] },
+		{ id: "a..b", declarations: [] },
+		{ id: "flat.dotted", declarations: [] },
+		{ id: "empty", declarations: [] },
+	]);
+	expect(imported.variants[0]?.pattern).toEqual([
+		{ type: "text", value: "Hello " },
+		{ type: "expression", arg: { type: "variable-reference", name: "name" } },
+	]);
+
+	const exported = await exportImported(imported);
+	expect(parseFile(exported[0]!)).toEqual({
+		title: "Hello {name}",
+		nested: { body: "Welcome" },
+		"a.": { b: "Keep dotted path segments" },
+		"flat.dotted": "Stay flat",
+		empty: "",
+	});
+});
+
+test("uses colon-delimited legacy bundle IDs for namespaces", async () => {
+	const settings = {
+		"plugin.inlang.json": {
+			pathPattern: {
+				common: "./messages/{languageTag}/common.json",
+				auth: "./messages/{languageTag}/auth.json",
+			},
+		},
+	};
+	const imported = await importFiles({
+		settings: settings as any,
+		files: [
+			{
+				locale: "en",
+				content: new TextEncoder().encode(
+					JSON.stringify({ header: { title: "Welcome" } })
+				),
+				toBeImportedFilesMetadata: { namespace: "common" },
+			},
+			{
+				locale: "en",
+				content: new TextEncoder().encode(
+					JSON.stringify({ signIn: "Sign in" })
+				),
+				toBeImportedFilesMetadata: { namespace: "auth" },
+			},
+		],
+	});
+
+	expect(imported.bundles.map((bundle) => bundle.id)).toEqual([
+		"common:header.title",
+		"auth:signIn",
+	]);
+
+	const exported = await exportImported(imported, settings);
+	const common = exported.find((file) => file.metadata?.namespace === "common");
+	const auth = exported.find((file) => file.metadata?.namespace === "auth");
+	expect(common?.metadata).toEqual({ namespace: "common" });
+	expect(parseFile(common!)).toEqual({ header: { title: "Welcome" } });
+	expect(auth?.metadata).toEqual({ namespace: "auth" });
+	expect(parseFile(auth!)).toEqual({ signIn: "Sign in" });
+});
+
+test("uses the first legacy namespace for newly-created unprefixed bundles", async () => {
+	const exported = await exportFiles({
+		settings: {
+			"plugin.inlang.json": {
+				pathPattern: {
+					common: "./messages/{locale}/common.json",
+					auth: "./messages/{locale}/auth.json",
+				},
+			},
+		} as any,
+		bundles: [{ id: "new.message", declarations: [] }] as any,
+		messages: [
+			{
+				id: "message-1",
+				bundleId: "new.message",
+				locale: "en",
+				selectors: [],
+			},
+		] as any,
+		variants: [
+			{
+				id: "variant-1",
+				messageId: "message-1",
+				matches: [],
+				pattern: [{ type: "text", value: "New message" }],
+			},
+		] as any,
+	});
+
+	expect(exported).toHaveLength(1);
+	expect(exported[0]?.metadata).toEqual({ namespace: "common" });
+	expect(parseFile(exported[0]!)).toEqual({ "new.message": "New message" });
+});
+
+test("supports one-sided variable-reference patterns", async () => {
+	const settings = {
+		"plugin.inlang.json": {
+			pathPattern: "./messages/{locale}.json",
+			variableReferencePattern: ["@"],
+		},
+	};
+	const imported = await importFiles({
+		settings: settings as any,
+		files: [
+			{
+				locale: "en",
+				content: new TextEncoder().encode(
+					JSON.stringify({ greeting: "Hello @name" })
+				),
+			},
+		],
+	});
+
+	expect(imported.variants[0]?.pattern).toEqual([
+		{ type: "text", value: "Hello " },
+		{ type: "expression", arg: { type: "variable-reference", name: "name" } },
+	]);
+	expect(parseFile((await exportImported(imported, settings))[0]!)).toEqual({
+		greeting: "Hello @name",
+	});
+});
+
+test("uses the import fallback for an empty variable-reference pattern", async () => {
+	const settings = {
+		"plugin.inlang.json": {
+			pathPattern: "./messages/{locale}.json",
+			variableReferencePattern: [],
+		},
+	};
+	const imported = await importFiles({
+		settings: settings as any,
+		files: [
+			{
+				locale: "en",
+				content: new TextEncoder().encode(
+					JSON.stringify({ greeting: "Hello {name" })
+				),
+			},
+		],
+	});
+
+	expect(parseFile((await exportImported(imported, settings))[0]!)).toEqual({
+		greeting: "Hello {name",
+	});
+});
+
+test("rejects constructs generic JSON cannot represent", async () => {
+	await expect(
+		exportFiles({
+			settings: {} as any,
+			bundles: [{ id: "message", declarations: [] }] as any,
+			messages: [
+				{
+					id: "message-1",
+					bundleId: "message",
+					locale: "en",
+					selectors: [{ type: "variable-reference", name: "count" }],
+				},
+			] as any,
+			variants: [] as any,
+		})
+	).rejects.toThrow(
+		"Selectors, matches, and multiple variants are not supported"
+	);
+
+	await expect(
+		exportFiles({
+			settings: {} as any,
+			bundles: [{ id: "message", declarations: [] }] as any,
+			messages: [
+				{
+					id: "message-1",
+					bundleId: "message",
+					locale: "en",
+					selectors: [],
+				},
+			] as any,
+			variants: [
+				{
+					id: "variant-1",
+					messageId: "message-1",
+					matches: [{ type: "literal-match", key: "count", value: "one" }],
+					pattern: [{ type: "text", value: "One message" }],
+				},
+			] as any,
+		})
+	).rejects.toThrow(
+		"Selectors, matches, and multiple variants are not supported"
+	);
+});
+
+async function exportImported(
+	imported: Awaited<ReturnType<typeof importFiles>>,
+	settings: Record<string, unknown> = {}
+) {
+	return exportFiles({
+		settings: settings as any,
+		bundles: imported.bundles as any,
+		messages: imported.messages as any,
+		variants: imported.variants.map((variant, index) => ({
+			...variant,
+			id: `variant-${index}`,
+			messageId: imported.messages.find(
+				(message) =>
+					message.bundleId === variant.messageBundleId &&
+					message.locale === variant.messageLocale
+			)?.id,
+		})) as any,
+	});
+}
+
+function parseFile(file: { content: Uint8Array }) {
+	return JSON.parse(new TextDecoder().decode(file.content));
+}

--- a/packages/plugins/json/src/import-export/roundtrip.test.ts
+++ b/packages/plugins/json/src/import-export/roundtrip.test.ts
@@ -1,4 +1,6 @@
 import { expect, test } from "vitest";
+import { loadProjectInMemory, newProject } from "@inlang/sdk";
+import { plugin } from "../plugin.js";
 import { exportFiles } from "./exportFiles.js";
 import { importFiles } from "./importFiles.js";
 
@@ -44,6 +46,59 @@ test("imports and exports generic JSON while preserving nested and dotted keys",
 		"flat.dotted": "Stay flat",
 		empty: "",
 	});
+});
+
+test("keeps literal dotted and nested keys distinct through SDK import", async () => {
+	const expected = {
+		"a.b": "Flat",
+		a: { b: "Nested" },
+	};
+	const project = await loadProjectInMemory({
+		blob: await newProject({
+			settings: {
+				baseLocale: "en",
+				locales: ["en"],
+				modules: [],
+				"plugin.inlang.json": {
+					pathPattern: "./{locale}.json",
+				},
+			},
+		}),
+		providePlugins: [plugin as any],
+	});
+
+	try {
+		const files = [
+			{
+				locale: "en",
+				content: new TextEncoder().encode(JSON.stringify(expected)),
+			},
+		];
+		await project.importFiles({
+			pluginKey: plugin.key,
+			files,
+		});
+		await project.importFiles({ pluginKey: plugin.key, files });
+
+		const messages = await project.db
+			.selectFrom("message")
+			.selectAll()
+			.execute();
+		const variants = await project.db
+			.selectFrom("variant")
+			.selectAll()
+			.execute();
+		expect(messages).toHaveLength(2);
+		expect(variants).toHaveLength(2);
+		expect(new Set(variants.map((variant) => variant.messageId))).toEqual(
+			new Set(messages.map((message) => message.id))
+		);
+
+		const [file] = await project.exportFiles({ pluginKey: plugin.key });
+		expect(parseFile(file!)).toEqual(expected);
+	} finally {
+		await project.close();
+	}
 });
 
 test("uses colon-delimited legacy bundle IDs for namespaces", async () => {
@@ -228,15 +283,7 @@ async function exportImported(
 		settings: settings as any,
 		bundles: imported.bundles as any,
 		messages: imported.messages as any,
-		variants: imported.variants.map((variant, index) => ({
-			...variant,
-			id: `variant-${index}`,
-			messageId: imported.messages.find(
-				(message) =>
-					message.bundleId === variant.messageBundleId &&
-					message.locale === variant.messageLocale
-			)?.id,
-		})) as any,
+		variants: imported.variants as any,
 	});
 }
 

--- a/packages/plugins/json/src/import-export/toBeImportedFiles.test.ts
+++ b/packages/plugins/json/src/import-export/toBeImportedFiles.test.ts
@@ -1,0 +1,85 @@
+import { expect, test } from "vitest";
+import { toBeImportedFiles } from "./toBeImportedFiles.js";
+import type { PluginSettings } from "../settings.js";
+
+test("discovers modern and legacy locale placeholders", async () => {
+	const files = await toBeImportedFiles({
+		settings: {
+			baseLocale: "en",
+			locales: ["en", "de"],
+			"plugin.inlang.json": {
+				pathPattern: "/messages/{locale}/{languageTag}.json",
+			} satisfies PluginSettings,
+		} as any,
+	});
+
+	expect(files).toEqual([
+		{ locale: "en", path: "/messages/en/en.json" },
+		{ locale: "de", path: "/messages/de/de.json" },
+	]);
+});
+
+test("uses legacy languageTags when locales are unavailable", async () => {
+	const files = await toBeImportedFiles({
+		settings: {
+			sourceLanguageTag: "en",
+			languageTags: ["en", "de"],
+			"plugin.inlang.json": {
+				pathPattern: "/messages/{languageTag}.json",
+			} satisfies PluginSettings,
+		} as any,
+	});
+
+	expect(files).toEqual([
+		{ locale: "en", path: "/messages/en.json" },
+		{ locale: "de", path: "/messages/de.json" },
+	]);
+});
+
+test("discovers every namespaced resource with namespace metadata", async () => {
+	const files = await toBeImportedFiles({
+		settings: {
+			locales: ["en", "de"],
+			"plugin.inlang.json": {
+				pathPattern: {
+					common: "/messages/{locale}/common.json",
+					auth: "/messages/{languageTag}/auth.json",
+				},
+			} satisfies PluginSettings,
+		} as any,
+	});
+
+	expect(files).toEqual([
+		{
+			locale: "en",
+			path: "/messages/en/common.json",
+			metadata: { namespace: "common" },
+		},
+		{
+			locale: "en",
+			path: "/messages/en/auth.json",
+			metadata: { namespace: "auth" },
+		},
+		{
+			locale: "de",
+			path: "/messages/de/common.json",
+			metadata: { namespace: "common" },
+		},
+		{
+			locale: "de",
+			path: "/messages/de/auth.json",
+			metadata: { namespace: "auth" },
+		},
+	]);
+});
+
+test("returns no files without a path pattern", async () => {
+	const files = await toBeImportedFiles({
+		settings: {
+			locales: ["en"],
+			"plugin.inlang.json": {},
+		} as any,
+	});
+
+	expect(files).toEqual([]);
+});

--- a/packages/plugins/json/src/import-export/toBeImportedFiles.ts
+++ b/packages/plugins/json/src/import-export/toBeImportedFiles.ts
@@ -1,0 +1,42 @@
+import type { InlangPlugin } from "@inlang/sdk";
+import type { PluginSettings } from "../settings.js";
+import { PLUGIN_KEY } from "../pluginKey.js";
+import { replaceLocale } from "../utilities.js";
+
+export const toBeImportedFiles: NonNullable<
+	InlangPlugin<{ [PLUGIN_KEY]: PluginSettings }>["toBeImportedFiles"]
+> = async ({ settings }) => {
+	const result: Array<{
+		locale: string;
+		path: string;
+		metadata?: Record<string, unknown>;
+	}> = [];
+	const pathPattern = settings[PLUGIN_KEY]?.pathPattern;
+	const locales = settings.locales ?? settings.languageTags ?? [];
+
+	if (pathPattern === undefined || pathPattern === null) {
+		return result;
+	}
+
+	if (typeof pathPattern === "string") {
+		for (const locale of locales) {
+			result.push({
+				locale,
+				path: replaceLocale(pathPattern, locale),
+			});
+		}
+		return result;
+	}
+
+	for (const locale of locales) {
+		for (const [namespace, pattern] of Object.entries(pathPattern)) {
+			result.push({
+				locale,
+				path: replaceLocale(pattern, locale),
+				metadata: { namespace },
+			});
+		}
+	}
+
+	return result;
+};

--- a/packages/plugins/json/src/modern-contract.test.ts
+++ b/packages/plugins/json/src/modern-contract.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from "vitest";
+import { plugin } from "./plugin.js";
+
+test("retains legacy callbacks alongside the modern resource-plugin contract", () => {
+	expect(plugin.id).toBe("plugin.inlang.json");
+	expect(plugin.key).toBe("plugin.inlang.json");
+	expect(plugin.loadMessages).toBeTypeOf("function");
+	expect(plugin.saveMessages).toBeTypeOf("function");
+	expect(plugin.toBeImportedFiles).toBeTypeOf("function");
+	expect(plugin.importFiles).toBeTypeOf("function");
+	expect(plugin.exportFiles).toBeTypeOf("function");
+});

--- a/packages/plugins/json/src/plugin.test.ts
+++ b/packages/plugins/json/src/plugin.test.ts
@@ -1,17 +1,49 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { expect, it, describe } from "vitest";
 import type { PluginSettings } from "./settings.js";
-import {
-  Message,
-  ProjectSettings,
-  Variant,
-  createVariant,
-  getVariant,
-} from "@inlang/sdk";
 import { plugin } from "./plugin.js";
 import { createNodeishMemoryFs } from "@lix-js/fs";
 
 const pluginId = "plugin.inlang.json";
+
+type LegacyPattern = Array<
+  { type: "Text"; value: string } | { type: "VariableReference"; name: string }
+>;
+type Variant = {
+  languageTag: string;
+  match: string[];
+  pattern: LegacyPattern;
+};
+type Message = {
+  id: string;
+  alias: Record<string, string>;
+  selectors: Array<{ type: "VariableReference"; name: string }>;
+  variants: Variant[];
+};
+type ProjectSettings = {
+  sourceLanguageTag: string;
+  languageTags: string[];
+  modules: string[];
+  [key: string]: unknown;
+};
+
+function getVariant(
+  message: Message,
+  args: { where: { languageTag: string } },
+): Variant | undefined {
+  return message.variants.find(
+    (variant) => variant.languageTag === args.where.languageTag,
+  );
+}
+
+function createVariant(message: Message, args: { data: Variant }): { data: Message } {
+  return {
+    data: {
+      ...message,
+      variants: [...message.variants, args.data],
+    },
+  };
+}
 
 describe("loadMessage", () => {
   it("should return messages if the path pattern is valid", async () => {
@@ -37,6 +69,28 @@ describe("loadMessage", () => {
     expect(variant?.pattern[0]?.type).toBe("Text");
   });
 
+  it("supports the locale placeholder through legacy callbacks", async () => {
+    const fs = createNodeishMemoryFs();
+    await fs.writeFile("./en.json", JSON.stringify({ title: "Hello" }));
+
+    const settings = {
+      sourceLanguageTag: "en",
+      languageTags: ["en"],
+      modules: [],
+      [pluginId]: {
+        pathPattern: "./{locale}.json",
+      } satisfies PluginSettings,
+    } satisfies ProjectSettings;
+
+    const messages = await plugin.loadMessages!({ settings, nodeishFs: fs });
+    expect(messages.map((message) => message.id)).toEqual(["title"]);
+
+    await plugin.saveMessages!({ messages, settings, nodeishFs: fs });
+    expect(JSON.parse(await fs.readFile("./en.json", { encoding: "utf-8" }))).toEqual({
+      title: "Hello",
+    });
+  });
+
   it("should work with empty json files", async () => {
     const fs = createNodeishMemoryFs();
     await fs.writeFile("./en.json", JSON.stringify({}));
@@ -52,7 +106,7 @@ describe("loadMessage", () => {
       } satisfies PluginSettings,
     } satisfies ProjectSettings;
 
-    expect(
+    await expect(
       plugin.loadMessages!({ settings, nodeishFs: fs }),
     ).resolves.toBeTruthy();
   });
@@ -72,7 +126,7 @@ describe("loadMessage", () => {
       } satisfies PluginSettings,
     } satisfies ProjectSettings;
 
-    expect(
+    await expect(
       plugin.loadMessages!({ settings, nodeishFs: fs }),
     ).resolves.toBeTruthy();
   });
@@ -149,7 +203,7 @@ describe("loadMessage", () => {
       } satisfies PluginSettings,
     } satisfies ProjectSettings;
 
-    expect(
+    await expect(
       plugin.loadMessages!({ settings, nodeishFs: fs }),
     ).resolves.toBeTruthy();
   });
@@ -173,7 +227,7 @@ describe("loadMessage", () => {
       } satisfies PluginSettings,
     } satisfies ProjectSettings;
 
-    expect(
+    await expect(
       plugin.loadMessages!({ settings, nodeishFs: fs }),
     ).resolves.toBeTruthy();
   });

--- a/packages/plugins/json/src/plugin.ts
+++ b/packages/plugins/json/src/plugin.ts
@@ -1,29 +1,75 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import type {
-  Message,
-  Variant,
-  LanguageTag,
-  Plugin,
-  NodeishFilesystemSubset,
-} from "@inlang/sdk";
+import type { InlangPlugin } from "@inlang/sdk";
 import { PluginSettings } from "./settings.js";
-import { replaceAll } from "./utilities.js";
+import { replaceAll, replaceLocale } from "./utilities.js";
 import { flatten, unflatten } from "flat";
 import { detectJsonFormatting } from "@inlang/detect-json-formatting";
+import { importFiles } from "./import-export/importFiles.js";
+import { exportFiles } from "./import-export/exportFiles.js";
+import { toBeImportedFiles } from "./import-export/toBeImportedFiles.js";
+import { PLUGIN_KEY } from "./pluginKey.js";
 
 // global variables to store the formatting of the file
 let serializeWithFormatting: ReturnType<typeof detectJsonFormatting>;
 let hasNestedKeys = false;
 
-const id = "plugin.inlang.json";
+const id = PLUGIN_KEY;
 
-export const plugin: Plugin<{
-  [id]: PluginSettings;
-}> = {
+type LanguageTag = string;
+type LegacyPattern = Array<
+  { type: "Text"; value: string } | { type: "VariableReference"; name: string }
+>;
+type Variant = {
+  languageTag: LanguageTag;
+  match: string[];
+  pattern: LegacyPattern;
+};
+type Message = {
+  id: string;
+  alias: Record<string, string>;
+  selectors: Array<{ type: "VariableReference"; name: string }>;
+  variants: Variant[];
+};
+type NodeishFilesystemSubset = {
+  readFile(path: string): Promise<Uint8Array | ArrayBuffer>;
+  readFile(path: string, options: { encoding: "utf-8" }): Promise<string>;
+  readdir: (path: string) => Promise<string[]>;
+  writeFile: (path: string, data: Uint8Array | string) => Promise<void>;
+  mkdir(path: string): Promise<unknown>;
+  mkdir(path: string, options: { recursive: true }): Promise<unknown>;
+};
+type LegacyProjectSettings = {
+  sourceLanguageTag: LanguageTag;
+  languageTags: LanguageTag[];
+  modules?: string[];
+};
+type JsonPlugin = Omit<
+  InlangPlugin<{ [id]: PluginSettings }>,
+  "loadMessages" | "saveMessages" | "addCustomApi"
+> & {
+  id: string;
+  displayName: string;
+  description: string;
+  loadMessages: (args: {
+    settings: LegacyProjectSettings & { [id]: PluginSettings };
+    nodeishFs: NodeishFilesystemSubset;
+  }) => Promise<Message[]>;
+  saveMessages: (args: {
+    messages: Message[];
+    settings: LegacyProjectSettings & { [id]: PluginSettings };
+    nodeishFs: NodeishFilesystemSubset;
+  }) => Promise<void>;
+};
+
+export const plugin: JsonPlugin = {
   id,
+  key: id,
   displayName: "JSON",
   description: "Plugin for JSON files",
   settingsSchema: PluginSettings,
+  toBeImportedFiles,
+  importFiles,
+  exportFiles,
   loadMessages: async ({ settings, nodeishFs }) => {
     settings[id].variableReferencePattern = settings[id]
       .variableReferencePattern || ["{", "}"];
@@ -120,7 +166,7 @@ async function getFileToParse(
   sourceLanguageTag: string,
   nodeishFs: NodeishFilesystemSubset
 ): Promise<Record<string, string>> {
-  const pathWithLanguage = path.replace("{languageTag}", languageTag);
+  const pathWithLanguage = replaceLocale(path, languageTag);
   // get file, make sure that is not braking when the namespace doesn't exist in every languageTag dir
   try {
     const file = await nodeishFs.readFile(pathWithLanguage, {
@@ -284,8 +330,7 @@ async function saveMessages(args: {
     for (const [languageTag, _value] of Object.entries(storage)) {
       for (const path of Object.values(args.pluginSettings.pathPattern)) {
         // check if directory exists
-        const directoryPath = path
-          .replace("{languageTag}", languageTag)
+        const directoryPath = replaceLocale(path, languageTag)
           .split("/")
           .slice(0, -1)
           .join("/");
@@ -296,9 +341,10 @@ async function saveMessages(args: {
         }
       }
       for (const [prefix, value] of Object.entries(_value)) {
-        const pathWithLanguage = (
-          args.pluginSettings.pathPattern[prefix] as string
-        ).replace("{languageTag}", languageTag);
+        const pathWithLanguage = replaceLocale(
+          args.pluginSettings.pathPattern[prefix] as string,
+          languageTag
+        );
         await args.nodeishFs.writeFile(
           pathWithLanguage,
           serializeFile(value, args.pluginSettings.variableReferencePattern)
@@ -317,8 +363,8 @@ async function saveMessages(args: {
       }
     }
     for (const [languageTag, value] of Object.entries(storage)) {
-      const pathWithLanguage = args.pluginSettings.pathPattern.replace(
-        "{languageTag}",
+      const pathWithLanguage = replaceLocale(
+        args.pluginSettings.pathPattern,
         languageTag
       );
       try {

--- a/packages/plugins/json/src/pluginKey.ts
+++ b/packages/plugins/json/src/pluginKey.ts
@@ -1,0 +1,3 @@
+// Kept in its own module so import/export modules can use the key without
+// importing plugin.ts, which would create a circular runtime import.
+export const PLUGIN_KEY = "plugin.inlang.json";

--- a/packages/plugins/json/src/settings.test.ts
+++ b/packages/plugins/json/src/settings.test.ts
@@ -14,6 +14,7 @@ test("valid path patterns", async () => {
     "../folder/{languageTag}/file.json",
     "./{languageTag}.json",
     "./{languageTag}/folder/file.json",
+    "./{locale}.json",
   ];
 
   for (const pathPattern of validPathPatterns) {

--- a/packages/plugins/json/src/settings.ts
+++ b/packages/plugins/json/src/settings.ts
@@ -1,14 +1,14 @@
 // pluginOptions for json plugin
 import { Type, type Static } from "@sinclair/typebox";
 const PathPattern = Type.String({
-  pattern: "^(\\./|\\../|/)[^*]*\\{languageTag\\}[^*]*\\.json",
+  pattern: "^(\\./|\\../|/)[^*]*\\{(languageTag|locale)\\}[^*]*\\.json",
   title: "Path to language files",
   description:
-    "Specify the pathPattern to locate language files in your repository. It must include `{languageTag}` and end with `.json`.",
+    "Specify the pathPattern to locate language files in your repository. It must include `{locale}` or legacy `{languageTag}` and end with `.json`.",
   examples: [
-    "./{languageTag}/file.json",
-    "../folder/{languageTag}/file.json",
-    "./{languageTag}.json",
+    "./{locale}/file.json",
+    "../folder/{locale}/file.json",
+    "./{locale}.json",
   ],
 });
 export type PluginSettings = Static<typeof PluginSettings>;

--- a/packages/plugins/json/src/utilities.ts
+++ b/packages/plugins/json/src/utilities.ts
@@ -8,6 +8,10 @@ export function replaceAll(str: string, find: string, replace: string) {
   return str.replace(new RegExp(escapeRegExp(find), "g"), replace);
 }
 
+export function replaceLocale(path: string, locale: string) {
+  return path.replace(/\{(locale|languageTag)\}/g, locale);
+}
+
 function escapeRegExp(string: string) {
   return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"); // $& means the whole matched string
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -611,8 +611,8 @@ importers:
         version: 0.31.28
     devDependencies:
       '@inlang/sdk':
-        specifier: 0.36.3
-        version: 0.36.3(babel-plugin-macros@3.1.0)
+        specifier: workspace:*
+        version: link:../../sdk
       '@inlang/tsconfig':
         specifier: workspace:*
         version: link:../../tsconfig


### PR DESCRIPTION
## Summary

- add the modern JSON resource-plugin contract: `toBeImportedFiles`, `importFiles`, and `exportFiles`
- retain the legacy `loadMessages` and `saveMessages` callbacks for existing consumers
- support namespace metadata and both `{locale}` and legacy `{languageTag}` path placeholders
- add a patch changeset and round-trip compatibility coverage

## Why

Implements the JSON-plugin modernization requested in [opral/sherlock#212](https://github.com/opral/sherlock/issues/212), while keeping this suitable for a non-breaking patch release.

## Validation

- `pnpm --filter @inlang/plugin-json test` (46 tests)
- `pnpm --filter @inlang/plugin-json build`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core i18n import/export and ID/nesting semantics; legacy API is preserved but new and old paths must stay consistent for the same projects.
> 
> **Overview**
> **@inlang/plugin-json** now implements the SDK resource-plugin surface (`toBeImportedFiles`, `importFiles`, `exportFiles`) so tooling can discover JSON paths, watch files, and sync bundles through the v2 project API—while **legacy** `loadMessages` / `saveMessages` stay on the same export.
> 
> `toBeImportedFiles` expands `pathPattern` (string or per-namespace map) for each locale, attaches **namespace metadata** for namespaced configs, and resolves tags from `locales` or fallback `languageTags`. Import/export map flat and nested JSON keys, variable placeholders, and `namespace:key` bundle IDs; export rejects pluralization/markup the format cannot represent. Stable message IDs are encoded in `messageId.ts` so nested shapes round-trip.
> 
> **Config/docs:** path patterns may use `{locale}` or legacy `{languageTag}` via shared `replaceLocale`; legacy FS paths use the same helper. Dev dependency switches to workspace `@inlang/sdk`. README and a patch changeset document the dual API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04c2e67f005fabf5fe350acd689b93f2443dcc4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->