### PR TITLE
Update social proof metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@
 <p align="center">
   <a href="https://github.com/opral/inlang"><strong>1.9k+</strong> GitHub stars</a>
   &nbsp;·&nbsp;
-  <a href="https://www.npmjs.com/package/@inlang/sdk"><strong>395k+</strong> weekly npm downloads</a>
+  <a href="https://www.npmjs.com/package/@inlang/sdk"><strong>500k+</strong> weekly npm downloads</a>
   &nbsp;·&nbsp;
-  <a href="https://github.com/opral/inlang/graphs/contributors"><strong>110+</strong> contributors</a>
+  <a href="https://github.com/opral/inlang/graphs/contributors"><strong>115+</strong> contributors</a>
 </p>
 
 <p align="center">

--- a/packages/website-v2/src/routes/index.tsx
+++ b/packages/website-v2/src/routes/index.tsx
@@ -100,7 +100,7 @@ function App() {
                 href="https://www.npmjs.com/package/@inlang/sdk"
                 target="_blank"
                 rel="noopener noreferrer"
-                aria-label="250k+ weekly npm downloads - view package"
+                aria-label="500k+ weekly npm downloads - view package"
                 className="group"
               >
                 <div className="flex items-center gap-2 text-2xl font-semibold text-slate-900 group-hover:text-slate-700">
@@ -111,7 +111,7 @@ function App() {
                   >
                     <path d="M1.763 0C.786 0 0 .786 0 1.763v20.474C0 23.214.786 24 1.763 24h20.474c.977 0 1.763-.786 1.763-1.763V1.763C24 .786 23.214 0 22.237 0zM5.13 5.323l13.837.019-.009 13.836h-3.464l.01-10.382h-3.456L12.04 19.17H5.113z" />
                   </svg>
-                  250k+
+                  500k+
                 </div>
                 <div className="text-sm text-slate-500">weekly downloads</div>
               </a>
@@ -119,7 +119,7 @@ function App() {
                 href="https://github.com/opral/inlang/graphs/contributors"
                 target="_blank"
                 rel="noopener noreferrer"
-                aria-label="110+ contributors - view all contributors"
+                aria-label="115+ contributors - view all contributors"
                 className="group"
               >
                 <div className="flex items-center gap-2 text-2xl font-semibold text-slate-900 group-hover:text-slate-700">
@@ -130,7 +130,7 @@ function App() {
                   >
                     <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
                   </svg>
-                  110+
+                  115+
                 </div>
                 <div className="text-sm text-slate-500">contributors</div>
               </a>


### PR DESCRIPTION
## What changed

- update weekly npm downloads to `500k+` in the root README and website landing page
- update the contributor count to `115+`
- keep visible values and accessibility labels in sync

## Why

The existing social-proof figures were stale. The npm downloads API reports 506,332 downloads for `@inlang/sdk` for July 27–August 2, 2026, and GitHub currently reports 116 contributors.

## Impact

Visitors now see current, consistently rounded adoption metrics across the repository and landing page.

## Validation

- `git diff --check`
- `pnpm exec oxlint src/routes/index.tsx` (from `packages/website-v2`)
- full website lint attempted after locked dependency install; it remains blocked by pre-existing missing generated modules (`routeTree.gen`, marketplace packages) and cascading unrelated TypeScript errors
- Prettier accepts the touched TSX file; the root README has pre-existing formatting differences