### PR TITLE
Refresh inlang landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,7 @@
 
 <br>
 
-<p align="center">
-  <a href="https://github.com/opral/inlang"><strong>1.9k+</strong> GitHub stars</a>
-  &nbsp;·&nbsp;
-  <a href="https://www.npmjs.com/package/@inlang/sdk"><strong>395k+</strong> weekly npm downloads</a>
-  &nbsp;·&nbsp;
-  <a href="https://github.com/opral/inlang/graphs/contributors"><strong>110+</strong> contributors</a>
-</p>
+[**1.9k+**](https://github.com/opral/inlang) [**GitHub stars**](https://github.com/opral/inlang) · [**395k+**](https://www.npmjs.com/package/@inlang/sdk) [**weekly npm downloads**](https://www.npmjs.com/package/@inlang/sdk) · [**110+**](https://github.com/opral/inlang/graphs/contributors) [**contributors**](https://github.com/opral/inlang/graphs/contributors)
 
 <p align="center">
   <sub>Used across the inlang ecosystem by teams at</sub><br/><br/>

--- a/packages/website-v2/src/components/Footer.tsx
+++ b/packages/website-v2/src/components/Footer.tsx
@@ -89,7 +89,7 @@ export default function Footer() {
             </span>
           </Link>
           <p className="pt-0.5 text-sm text-slate-600">
-            The open-format TMS for software teams.
+            The open format TMS for software products.
           </p>
           <div className="flex flex-wrap gap-6 pt-1">
             {socialMediaLinks.map((link) => (
@@ -189,7 +189,7 @@ export default function Footer() {
           rel="noreferrer"
           className="text-sm text-slate-500 hover:text-slate-700 transition-colors"
         >
-          Copyright 2025 Opral
+          Copyright 2026 Opral
         </a>
       </div>
     </footer>

--- a/packages/website-v2/src/components/Header.tsx
+++ b/packages/website-v2/src/components/Header.tsx
@@ -2,415 +2,215 @@ import { useState } from "react";
 import { Link, useLocation } from "@tanstack/react-router";
 import { getGithubStars } from "../github-stars-cache";
 
-const builtOnInlangLinks = [
+const ecosystemLinks = [
+  { label: "Tools", to: "/c/tools" },
+  { label: "Plugins", to: "/c/plugins" },
   {
-    label: "Tools",
-    to: "/c/tools",
-    icon: (
-      <svg
-        className="h-4 w-4"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      >
-        <path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z" />
-        <path d="m3.3 7 8.7 5 8.7-5" />
-        <path d="M12 22V12" />
-      </svg>
-    ),
-  },
-  {
-    label: "Plugins",
-    to: "/c/plugins",
-    icon: (
-      <svg
-        className="h-4 w-4"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      >
-        <rect width="7" height="7" x="14" y="3" rx="1" />
-        <path d="M10 21V8a1 1 0 0 0-1-1H4a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-5a1 1 0 0 0-1-1H3" />
-      </svg>
-    ),
-  },
-  {
-    label: "Validation Rules",
+    label: "Validation rules",
     to: "https://github.com/opral/lix/issues/239",
     external: true,
-    icon: (
-      <span
-        className="text-sm"
-        style={{
-          textDecoration: "underline",
-          textDecorationStyle: "wavy",
-          textUnderlineOffset: "2px",
-        }}
-      >
-        Aa
-      </span>
-    ),
   },
 ];
+
+const formatStars = (count: number) => {
+  if (count >= 1000) {
+    return `${(count / 1000).toFixed(1).replace(/\.0$/, "")}k`;
+  }
+  return count.toString();
+};
+
+function GithubStars({ count }: { count: number | null }) {
+  return (
+    <a
+      href="https://github.com/opral/inlang"
+      target="_blank"
+      rel="noreferrer"
+      className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 px-3 py-1.5 text-[13px] font-semibold text-slate-700 transition-colors hover:border-slate-300 hover:bg-slate-50 hover:text-slate-900"
+      aria-label={`${count ? formatStars(count) : "2k+"} GitHub stars`}
+    >
+      <span className="text-yellow-500" aria-hidden="true">
+        ★
+      </span>
+      {count ? formatStars(count) : "2k+"}
+      <span className="font-medium text-slate-400">GitHub</span>
+    </a>
+  );
+}
 
 export default function Header() {
   const location = useLocation();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const githubStars = getGithubStars("opral/inlang");
 
-  const formatStars = (count: number) => {
-    if (count >= 1000) {
-      return `${(count / 1000).toFixed(1).replace(/\.0$/, "")}k`;
-    }
-    return count.toString();
-  };
-
   return (
-    <header className="sticky top-0 z-50 w-full">
-      {/* Top header: Site-level navigation */}
-      <div className="bg-white border-b border-slate-200">
-        <div className="mx-auto flex max-w-7xl items-center justify-between gap-4 px-4 py-3 sm:px-6 sm:py-4">
-          {/* Left side: Logo */}
-          <Link to="/" className="flex items-center gap-2 hover:opacity-80">
-            <img
-              src="/favicon/safari-pinned-tab.svg"
-              alt="inlang"
-              className="h-8 w-8"
-            />
-            <span className="text-lg font-semibold text-slate-900">inlang</span>
-          </Link>
-
-          {/* Right side: Blog + Documentation | X Discord | GitHub Stars */}
-          <nav className="hidden items-center gap-4 text-sm font-medium text-slate-600 sm:flex">
-            <Link
-              to="/docs"
-              className={`hover:text-[color:var(--vp-c-brand-2)] ${
-                location.pathname.startsWith("/docs")
-                  ? "text-[color:var(--vp-c-brand-2)]"
-                  : ""
-              }`}
-            >
-              Documentation
-            </Link>
-            <Link
-              to="/blog"
-              className={`hover:text-[color:var(--vp-c-brand-2)] ${
-                location.pathname.startsWith("/blog")
-                  ? "text-[color:var(--vp-c-brand-2)]"
-                  : ""
-              }`}
-            >
-              Blog
-            </Link>
-
-            {/* Divider */}
-            <div className="h-4 w-px bg-slate-300" />
-
-            {/* Social icons: X and Discord */}
-            <div className="flex items-center gap-3">
-              {/* X (Twitter) */}
-              <a
-                href="https://x.com/inlangHQ"
-                target="_blank"
-                rel="noreferrer"
-                className="text-slate-900 hover:text-slate-600 transition-colors"
-                aria-label="Follow on X"
-              >
-                <svg
-                  className="h-4 w-4"
-                  viewBox="0 0 24 24"
-                  fill="currentColor"
-                >
-                  <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
-                </svg>
-              </a>
-
-              {/* Discord */}
-              <a
-                href="https://discord.gg/Dcs6MMJUzF"
-                target="_blank"
-                rel="noreferrer"
-                className="text-slate-900 hover:text-slate-600 transition-colors"
-                aria-label="Join Discord"
-              >
-                <svg
-                  className="h-5 w-5"
-                  viewBox="0 0 24 24"
-                  fill="currentColor"
-                >
-                  <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z" />
-                </svg>
-              </a>
-            </div>
-
-            {/* Divider */}
-            <div className="h-4 w-px bg-slate-300" />
-
-            {/* GitHub with stars */}
-            <a
-              href="https://github.com/opral/inlang"
-              target="_blank"
-              rel="noreferrer"
-              className="group inline-flex items-center gap-1.5 text-sm font-medium text-slate-900 hover:text-slate-600 transition-colors"
-            >
-              <svg className="h-4 w-4" viewBox="0 0 16 16" fill="currentColor">
-                <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
-              </svg>
-              GitHub
-              {githubStars !== null && (
-                <span
-                  className="inline-flex items-center gap-1"
-                  title={`${githubStars.toLocaleString()} GitHub stars`}
-                >
-                  <span className="relative h-3.5 w-3.5" aria-hidden="true">
-                    {/* Outlined star - visible by default, hidden on hover */}
-                    <svg
-                      className="absolute inset-0 h-3.5 w-3.5 text-slate-400 group-hover:opacity-0 transition-opacity"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="2"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    >
-                      <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
-                    </svg>
-                    {/* Filled star - hidden by default, visible on hover */}
-                    <svg
-                      className="absolute inset-0 h-3.5 w-3.5 text-yellow-500 opacity-0 group-hover:opacity-100 transition-opacity"
-                      viewBox="0 0 16 16"
-                      fill="currentColor"
-                    >
-                      <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25z" />
-                    </svg>
-                  </span>
-                  <span
-                    aria-label={`${githubStars.toLocaleString()} GitHub stars`}
-                  >
-                    {formatStars(githubStars)}
-                  </span>
-                </span>
-              )}
-            </a>
-          </nav>
-
-          {/* Mobile hamburger button */}
-          <button
-            type="button"
-            onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
-            className="flex h-9 w-9 items-center justify-center rounded-md text-slate-600 hover:bg-slate-100 sm:hidden"
-            aria-label="Toggle menu"
-          >
-            {mobileMenuOpen ? (
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-                strokeWidth={2}
-                stroke="currentColor"
-                className="h-5 w-5"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M6 18L18 6M6 6l12 12"
-                />
-              </svg>
-            ) : (
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-                strokeWidth={2}
-                stroke="currentColor"
-                className="h-5 w-5"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"
-                />
-              </svg>
-            )}
-          </button>
-        </div>
-      </div>
-
-      {/* Subheader: format categories */}
-      <div className="bg-slate-50 border-b border-slate-200">
-        <div className="mx-auto hidden max-w-7xl items-center gap-1 px-4 py-2 sm:flex sm:px-6">
-          <span className="mr-3 text-xs font-semibold uppercase tracking-wide text-slate-400">
-            Built on .inlang
+    <header className="sticky top-0 z-50 w-full border-b border-slate-200 bg-white">
+      <div className="mx-auto flex h-[60px] max-w-[1200px] items-center gap-6 px-4 sm:px-6 lg:px-8">
+        <Link
+          to="/"
+          className="flex shrink-0 items-center gap-2.5 text-slate-900 transition-opacity hover:opacity-75"
+          onClick={() => setMobileMenuOpen(false)}
+        >
+          <img
+            src="/favicon/safari-pinned-tab.svg"
+            alt=""
+            className="h-[26px] w-[26px]"
+          />
+          <span className="text-[16.5px] font-semibold tracking-tight">
+            inlang
           </span>
-          <nav className="flex items-center gap-5 text-sm font-medium text-slate-600">
-            {builtOnInlangLinks.map((link) => {
-              const isCurrentCategory =
-                !link.external && location.pathname === link.to;
+        </Link>
 
-              return link.external ? (
+        <nav className="hidden items-center gap-[22px] text-sm font-medium md:flex">
+          <Link
+            to="/docs"
+            className={
+              location.pathname.startsWith("/docs")
+                ? "text-cyan-700"
+                : "text-slate-700 hover:text-cyan-700"
+            }
+          >
+            Docs
+          </Link>
+          <Link
+            to="/blog"
+            className={
+              location.pathname.startsWith("/blog")
+                ? "text-cyan-700"
+                : "text-slate-700 hover:text-cyan-700"
+            }
+          >
+            Blog
+          </Link>
+        </nav>
+
+        <div className="ml-auto hidden items-center gap-3 md:flex">
+          <GithubStars count={githubStars} />
+          <Link
+            to="/c/tools"
+            className="rounded-lg bg-cyan-700 px-[15px] py-2 text-[13.5px] font-semibold text-white transition-colors hover:bg-cyan-800"
+          >
+            Explore tools
+          </Link>
+        </div>
+
+        <button
+          type="button"
+          onClick={() => setMobileMenuOpen((open) => !open)}
+          className="ml-auto flex h-9 w-9 items-center justify-center rounded-md text-slate-600 hover:bg-slate-100 md:hidden"
+          aria-label="Toggle navigation"
+          aria-expanded={mobileMenuOpen}
+        >
+          {mobileMenuOpen ? (
+            <svg
+              className="h-5 w-5"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+            >
+              <path d="m6 6 12 12M18 6 6 18" />
+            </svg>
+          ) : (
+            <svg
+              className="h-5 w-5"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+            >
+              <path d="M4 7h16M4 12h16M4 17h16" />
+            </svg>
+          )}
+        </button>
+      </div>
+
+      <div className="border-t border-slate-200 bg-slate-50">
+        <div className="mx-auto hidden max-w-[1200px] items-center gap-5 px-4 py-2 sm:px-6 md:flex lg:px-8">
+          <span className="shrink-0 font-mono text-[10.5px] font-semibold tracking-[0.12em] text-slate-400">
+            BUILT ON INLANG
+          </span>
+          <nav className="flex items-center gap-5 text-[13.5px] font-medium">
+            {ecosystemLinks.map((link) =>
+              link.external ? (
                 <a
                   key={link.label}
                   href={link.to}
                   target="_blank"
                   rel="noreferrer"
-                  className="flex items-center gap-1.5 hover:text-slate-900"
+                  className="text-slate-600 hover:text-slate-900"
                 >
-                  {link.icon}
                   {link.label}
                 </a>
               ) : (
                 <Link
                   key={link.label}
                   to={link.to}
-                  className={`flex items-center gap-1.5 transition-colors ${
-                    isCurrentCategory
-                      ? "text-cyan-600 font-semibold"
+                  className={
+                    location.pathname === link.to
+                      ? "font-semibold text-cyan-700"
                       : "text-slate-600 hover:text-slate-900"
-                  }`}
+                  }
                 >
-                  {link.icon}
                   {link.label}
                 </Link>
-              );
-            })}
+              ),
+            )}
           </nav>
         </div>
       </div>
 
-      {/* Mobile menu dropdown */}
       {mobileMenuOpen && (
-        <div className="bg-slate-50 border-b border-slate-200 px-4 pb-4 sm:hidden">
-          <nav className="flex flex-col">
-            <span className="pb-2 pt-4 text-xs font-semibold uppercase tracking-wide text-slate-400">
-              Built on .inlang
+        <div className="border-t border-slate-200 bg-white px-4 py-4 md:hidden">
+          <nav className="mx-auto flex max-w-[1200px] flex-col gap-1 text-sm font-medium">
+            <Link
+              to="/docs"
+              className="rounded-md px-3 py-2 text-slate-700 hover:bg-slate-50"
+              onClick={() => setMobileMenuOpen(false)}
+            >
+              Docs
+            </Link>
+            <Link
+              to="/blog"
+              className="rounded-md px-3 py-2 text-slate-700 hover:bg-slate-50"
+              onClick={() => setMobileMenuOpen(false)}
+            >
+              Blog
+            </Link>
+            <div className="my-2 border-t border-slate-200" />
+            <span className="px-3 pb-1 font-mono text-[10.5px] font-semibold tracking-[0.12em] text-slate-400">
+              BUILT ON INLANG
             </span>
-            {builtOnInlangLinks.map((link) => {
-              const isActive = !link.external && location.pathname === link.to;
-
-              return link.external ? (
+            {ecosystemLinks.map((link) =>
+              link.external ? (
                 <a
                   key={link.label}
                   href={link.to}
                   target="_blank"
                   rel="noreferrer"
-                  className="flex items-center gap-1.5 py-2.5 text-sm font-medium text-slate-600 hover:text-slate-900"
-                  onClick={() => setMobileMenuOpen(false)}
+                  className="rounded-md px-3 py-2 text-slate-700 hover:bg-slate-50"
                 >
-                  {link.icon}
                   {link.label}
                 </a>
               ) : (
                 <Link
                   key={link.label}
                   to={link.to}
-                  className={`flex items-center gap-1.5 py-2.5 text-sm font-medium ${
-                    isActive
-                      ? "text-cyan-600"
-                      : "text-slate-600 hover:text-slate-900"
-                  }`}
+                  className="rounded-md px-3 py-2 text-slate-700 hover:bg-slate-50"
                   onClick={() => setMobileMenuOpen(false)}
                 >
-                  {link.icon}
                   {link.label}
                 </Link>
-              );
-            })}
-
-            <div className="my-2 h-px bg-slate-200" />
-
-            <Link
-              to="/docs"
-              className="py-2.5 text-sm font-medium text-slate-600 hover:text-slate-900"
-              onClick={() => setMobileMenuOpen(false)}
-            >
-              Documentation
-            </Link>
-            <Link
-              to="/blog"
-              className="py-2.5 text-sm font-medium text-slate-600 hover:text-slate-900"
-              onClick={() => setMobileMenuOpen(false)}
-            >
-              Blog
-            </Link>
-
-            <div className="my-2 h-px bg-slate-200" />
-
-            {/* Social links */}
-            <div className="flex items-center gap-4 py-2.5">
-              <a
-                href="https://github.com/opral/inlang"
-                target="_blank"
-                rel="noreferrer"
-                className="inline-flex items-center gap-1.5 text-sm font-medium text-slate-600 hover:text-slate-900"
+              ),
+            )}
+            <div className="mt-3 flex flex-wrap items-center gap-3 px-3">
+              <GithubStars count={githubStars} />
+              <Link
+                to="/c/tools"
+                className="rounded-lg bg-cyan-700 px-4 py-2 text-[13.5px] font-semibold text-white"
                 onClick={() => setMobileMenuOpen(false)}
               >
-                <svg
-                  className="h-4 w-4"
-                  viewBox="0 0 16 16"
-                  fill="currentColor"
-                >
-                  <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
-                </svg>
-                GitHub
-                {githubStars !== null && (
-                  <span
-                    className="inline-flex items-center gap-0.5 pr-1 text-slate-500"
-                    title={`${githubStars.toLocaleString()} GitHub stars`}
-                  >
-                    <svg
-                      className="h-3 w-3 text-yellow-500"
-                      viewBox="0 0 16 16"
-                      fill="currentColor"
-                      aria-hidden="true"
-                    >
-                      <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25z" />
-                    </svg>
-                    <span
-                      aria-label={`${githubStars.toLocaleString()} GitHub stars`}
-                    >
-                      {formatStars(githubStars)}
-                    </span>
-                  </span>
-                )}
-              </a>
-              <a
-                href="https://x.com/inlangHQ"
-                target="_blank"
-                rel="noreferrer"
-                className="text-slate-900 hover:text-slate-600"
-                onClick={() => setMobileMenuOpen(false)}
-                aria-label="Follow on X"
-              >
-                <svg
-                  className="h-4 w-4"
-                  viewBox="0 0 24 24"
-                  fill="currentColor"
-                >
-                  <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
-                </svg>
-              </a>
-              <a
-                href="https://discord.gg/Dcs6MMJUzF"
-                target="_blank"
-                rel="noreferrer"
-                className="text-slate-900 hover:text-slate-600"
-                onClick={() => setMobileMenuOpen(false)}
-                aria-label="Join Discord"
-              >
-                <svg
-                  className="h-5 w-5"
-                  viewBox="0 0 24 24"
-                  fill="currentColor"
-                >
-                  <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z" />
-                </svg>
-              </a>
+                Explore tools
+              </Link>
             </div>
           </nav>
         </div>

--- a/packages/website-v2/src/routes/index.tsx
+++ b/packages/website-v2/src/routes/index.tsx
@@ -1,11 +1,18 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { createServerFn } from "@tanstack/react-start";
 import { parse } from "@opral/markdown-wc";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { initMarkdownInteractive } from "../components/markdown-interactive";
 import { getGithubStars } from "../github-stars-cache";
 import markdownCss from "../markdown.css?url";
 import landingMarkdown from "../../../../README.md?raw";
+import kraftHeinzLogo from "../../../../assets/used-by/kraft-heinz.png";
+import boseLogo from "../../../../assets/used-by/bose.svg";
+import disneyLogo from "../../../../assets/used-by/disney.svg";
+import ethZurichLogo from "../../../../assets/used-by/eth-zurich.svg";
+import braveLogo from "../../../../assets/used-by/brave.svg";
+import michelinLogo from "../../../../assets/used-by/michelin.svg";
+import idealistaLogo from "../../../../assets/used-by/idealista.svg";
 
 const ogImage =
   "https://cdn.jsdelivr.net/gh/opral/inlang@latest/packages/website/public/opengraph/inlang-social-image.jpg";
@@ -21,31 +28,23 @@ const loadLandingContent = createServerFn({ method: "GET" }).handler(
 );
 
 export const Route = createFileRoute("/")({
-  loader: async () => {
-    return await loadLandingContent();
-  },
+  loader: async () => await loadLandingContent(),
   head: () => ({
     meta: [
       { title: "inlang" },
-      {
-        name: "description",
-        content: siteDescription,
-      },
+      { name: "description", content: siteDescription },
       { name: "og:image", content: ogImage },
       { name: "twitter:card", content: "summary_large_image" },
       { name: "twitter:image", content: ogImage },
       { name: "twitter:image:alt", content: "inlang" },
       { name: "twitter:title", content: "inlang" },
-      {
-        name: "twitter:description",
-        content: siteDescription,
-      },
+      { name: "twitter:description", content: siteDescription },
       { name: "twitter:site", content: "@inlanghq" },
       { name: "twitter:creator", content: "@inlanghq" },
     ],
     links: [{ rel: "stylesheet", href: markdownCss }],
   }),
-  component: App,
+  component: LandingPage,
 });
 
 const formatStars = (count: number) => {
@@ -55,212 +54,212 @@ const formatStars = (count: number) => {
   return count.toString();
 };
 
-function App() {
+function ProjectDiagram() {
+  const inputs = ["i18n library", "IDE extension", "CI automation", "your own"];
+
+  return (
+    <div className="flex w-full max-w-[520px] flex-col items-center py-3">
+      <div className="grid w-full grid-cols-2 gap-2 sm:grid-cols-4">
+        {inputs.map((input, index) => (
+          <div className="flex justify-center" key={input}>
+            <span
+              className={`whitespace-nowrap rounded-[9px] px-2.5 py-1.5 text-xs font-semibold sm:px-2 ${
+                index === inputs.length - 1
+                  ? "border border-dashed border-slate-300 text-slate-400"
+                  : "border border-slate-200 bg-white text-slate-800 shadow-sm"
+              }`}
+            >
+              {input}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      <svg
+        viewBox="0 0 500 64"
+        className="hidden h-16 w-full sm:block"
+        aria-hidden="true"
+      >
+        <path
+          d="M62 0V18Q62 26 70 26H180"
+          fill="none"
+          stroke="#94a3b8"
+          strokeWidth="1.5"
+        />
+        <path d="M188 0V26" fill="none" stroke="#94a3b8" strokeWidth="1.5" />
+        <path
+          d="M313 0V18Q313 26 305 26H188"
+          fill="none"
+          stroke="#94a3b8"
+          strokeWidth="1.5"
+        />
+        <path
+          d="M438 0V18Q438 26 430 26H313"
+          fill="none"
+          stroke="#94a3b8"
+          strokeWidth="1.5"
+        />
+        <path d="M250 26V54" fill="none" stroke="#94a3b8" strokeWidth="1.5" />
+        <path d="M70 26H430" fill="none" stroke="#94a3b8" strokeWidth="1.5" />
+        <polygon points="244,54 256,54 250,63" fill="#94a3b8" />
+      </svg>
+      <div className="my-5 h-9 w-px bg-slate-300 sm:hidden" />
+
+      <div className="relative w-[280px] max-w-[85vw]">
+        <div className="absolute inset-0 translate-x-2 translate-y-2 rounded-xl border border-slate-200 bg-slate-50" />
+        <div className="project-file-card relative overflow-hidden rounded-xl border-[1.5px] border-slate-300 bg-white">
+          <div className="absolute right-0 top-0 h-7 w-7 rounded-bl-[10px] bg-slate-200" />
+          <div className="border-b border-slate-100 px-5 py-3.5 font-mono text-sm font-semibold text-slate-900">
+            project.inlang
+          </div>
+          <div className="flex flex-col gap-2 px-5 pb-[18px] pt-[13px] font-mono text-xs font-medium">
+            {[
+              ["en", "Hello world"],
+              ["de", "Hallo Welt"],
+              ["ja", "こんにちは世界"],
+            ].map(([locale, message]) => (
+              <div className="flex gap-3.5" key={locale}>
+                <span className="w-[17px] text-cyan-700">{locale}</span>
+                <span className="text-slate-600">{message}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const customerLogos = [
+  { src: kraftHeinzLogo, alt: "Kraft Heinz", className: "h-5" },
+  { src: boseLogo, alt: "Bose", className: "h-4" },
+  { src: disneyLogo, alt: "Disney", className: "h-6" },
+  { src: ethZurichLogo, alt: "ETH Zurich", className: "h-4" },
+  { src: braveLogo, alt: "Brave", className: "h-[22px]" },
+  { src: michelinLogo, alt: "Michelin", className: "h-[22px]" },
+  { src: idealistaLogo, alt: "idealista", className: "h-[18px]" },
+];
+
+function LandingPage() {
   const { html } = Route.useLoaderData();
   const githubStars = getGithubStars("opral/inlang");
+  const [copied, setCopied] = useState(false);
 
   useEffect(() => {
     initMarkdownInteractive();
   }, []);
 
+  const copyInstallCommand = async () => {
+    await navigator.clipboard?.writeText("npm i @inlang/sdk");
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1500);
+  };
+
   return (
-    <main className="bg-white text-slate-900">
-      <section className="pt-10 pb-16">
-        <div className="mx-auto max-w-7xl px-4 sm:px-6 grid grid-cols-1 lg:grid-cols-12 gap-10 items-center">
-          <div className="lg:col-span-6 flex flex-col gap-6">
-            <h1 className="max-w-2xl text-4xl font-semibold tracking-tight md:text-5xl">
-              The open-format TMS for software teams.
-            </h1>
-            <p className="max-w-xl text-lg leading-8 text-slate-600">
-              Store translations in your repo as a vendor-neutral file format,
-              so developers, translators, CI, translation tools, and AI agents
-              can read and update the same localization source of truth.
-            </p>
-            <div className="flex gap-12 pt-2">
-              <a
-                href="https://github.com/opral/inlang"
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label={`${githubStars ? formatStars(githubStars) : "2k+"} GitHub stars - view repository`}
-                className="group"
-              >
-                <div className="flex items-center gap-2 text-2xl font-semibold text-slate-900 group-hover:text-slate-700">
-                  <svg
-                    className="h-5 w-5 text-yellow-500"
-                    viewBox="0 0 16 16"
-                    fill="currentColor"
-                  >
-                    <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25z" />
-                  </svg>
-                  {githubStars ? formatStars(githubStars) : "2k+"}
-                </div>
-                <div className="text-sm text-slate-500">GitHub stars</div>
-              </a>
-              <a
-                href="https://www.npmjs.com/package/@inlang/sdk"
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label="250k+ weekly npm downloads - view package"
-                className="group"
-              >
-                <div className="flex items-center gap-2 text-2xl font-semibold text-slate-900 group-hover:text-slate-700">
-                  <svg
-                    className="h-5 w-5 text-[#CB3837]"
-                    viewBox="0 0 24 24"
-                    fill="currentColor"
-                  >
-                    <path d="M1.763 0C.786 0 0 .786 0 1.763v20.474C0 23.214.786 24 1.763 24h20.474c.977 0 1.763-.786 1.763-1.763V1.763C24 .786 23.214 0 22.237 0zM5.13 5.323l13.837.019-.009 13.836h-3.464l.01-10.382h-3.456L12.04 19.17H5.113z" />
-                  </svg>
-                  250k+
-                </div>
-                <div className="text-sm text-slate-500">weekly downloads</div>
-              </a>
-              <a
-                href="https://github.com/opral/inlang/graphs/contributors"
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label="110+ contributors - view all contributors"
-                className="group"
-              >
-                <div className="flex items-center gap-2 text-2xl font-semibold text-slate-900 group-hover:text-slate-700">
-                  <svg
-                    className="h-5 w-5"
-                    viewBox="0 0 16 16"
-                    fill="currentColor"
-                  >
-                    <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
-                  </svg>
-                  110+
-                </div>
-                <div className="text-sm text-slate-500">contributors</div>
-              </a>
-            </div>
-            <div className="flex flex-wrap gap-3 pt-2">
-              <Link
-                to="/c/tools"
-                className="rounded-lg bg-slate-900 text-white px-4 py-2 text-sm font-semibold hover:bg-slate-800 transition-colors"
-              >
-                Explore tools
-              </Link>
-              <Link
-                to="/docs"
-                className="rounded-lg bg-slate-200 text-slate-900 px-4 py-2 text-sm font-semibold hover:bg-slate-300 transition-colors"
-              >
-                Documentation
-              </Link>
-            </div>
+    <div className="bg-white text-slate-900">
+      <section className="mx-auto grid max-w-[1200px] grid-cols-1 items-center gap-12 px-4 py-14 sm:px-6 md:py-[68px] lg:grid-cols-[1fr_520px] lg:gap-14 lg:px-8">
+        <div className="flex flex-col gap-5">
+          <h1 className="max-w-2xl text-[40px] font-semibold leading-[1.14] tracking-[-0.025em] text-balance sm:text-5xl">
+            The open format TMS for software products.
+          </h1>
+          <p className="max-w-xl text-[17px] leading-[1.7] text-slate-600 text-pretty">
+            Store translations in your repo as a vendor-neutral file format, so
+            developers, translators, CI, translation tools, and AI agents can
+            read and update the same localization source of truth.
+          </p>
+          <div className="flex flex-wrap gap-3 pt-1">
+            <Link
+              to="/c/tools"
+              className="whitespace-nowrap rounded-[9px] bg-cyan-700 px-[22px] py-3 text-[14.5px] font-semibold text-white transition-colors hover:bg-cyan-800"
+            >
+              Explore tools
+            </Link>
+            <Link
+              to="/docs"
+              className="whitespace-nowrap rounded-[9px] border border-slate-300 bg-white px-[22px] py-3 text-[14.5px] font-semibold text-slate-900 transition-colors hover:border-slate-400"
+            >
+              Documentation
+            </Link>
           </div>
-          <div className="lg:col-span-6 flex justify-center lg:justify-end">
-            <pre className="text-xs sm:text-sm font-mono text-slate-700 bg-slate-50 border border-slate-200 rounded-xl p-6 overflow-x-auto">
-              {`┌──────────┐      ┌───────────┐      ┌────────────┐
-│ i18n lib │      │Translation│      │    CI/CD   │
-│          │      │   Tool    │      │ Automation │
-└────┬─────┘      └─────┬─────┘      └─────┬──────┘
-     │                  │                  │
-     └────────┐         │         ┌────────┘
-              ▼         ▼         ▼
-        ┌────────────────────────────────┐
-        │         .inlang file           │
-        └────────────────────────────────┘`}
-            </pre>
+          <div className="flex w-fit max-w-full items-center gap-3 rounded-[9px] border border-slate-200 bg-slate-50 px-4 py-[11px] font-mono text-[13px] font-medium text-slate-600">
+            <span className="text-slate-400">$</span>
+            <code className="overflow-x-auto whitespace-nowrap">
+              npm i @inlang/sdk
+            </code>
+            <button
+              type="button"
+              onClick={copyInstallCommand}
+              className="border-l border-slate-200 pl-3 text-slate-400 transition-colors hover:text-slate-700"
+            >
+              {copied ? "copied!" : "copy"}
+            </button>
+          </div>
+        </div>
+
+        <ProjectDiagram />
+      </section>
+
+      <section className="border-y border-slate-200 bg-slate-50">
+        <div className="mx-auto flex max-w-[1200px] flex-col items-start gap-5 px-4 py-[22px] sm:px-6 md:flex-row md:items-center md:gap-9 lg:px-8">
+          <span className="shrink-0 font-mono text-[10.5px] font-semibold tracking-[0.12em] text-slate-400">
+            USED BY TEAMS AT
+          </span>
+          <div className="flex flex-wrap items-center gap-x-6 gap-y-4 opacity-[0.58] grayscale">
+            {customerLogos.map((logo) => (
+              <img
+                key={logo.alt}
+                src={logo.src}
+                alt={logo.alt}
+                className={`${logo.className} max-w-[112px] object-contain`}
+              />
+            ))}
           </div>
         </div>
       </section>
 
-      {/* Tools that read/write the inlang file format section commented out
-      <section className="pb-14">
-        <div className="mx-auto max-w-7xl px-4 sm:px-6">
-          <div className="border-t border-slate-200 pt-10">
-          <SectionHeading title="Tools that read/write the inlang file format" className="max-w-2xl" />
-          <p>These are independent tools that read and write .inlang; they are not inlang itself.</p>
-          ...
+      <section className="mx-auto max-w-[880px] px-4 pb-6 pt-12 sm:px-6 lg:px-8">
+        <div className="flex items-center justify-between gap-4 px-1 pb-3">
+          <div className="flex flex-wrap items-center gap-x-2.5 text-[13.5px]">
+            <span className="font-semibold">README.md</span>
+            <span className="text-slate-500">from opral/inlang</span>
           </div>
-        </div>
-      </section>
-      */}
-
-      <section className="pt-6">
-        <div className="mx-auto max-w-4xl px-4 sm:px-6">
           <a
             href="https://github.com/opral/inlang"
             target="_blank"
             rel="noopener noreferrer"
-            className="flex items-center justify-between mb-10 px-4 py-3 rounded-lg border border-slate-200 bg-slate-50 hover:bg-slate-100 transition-colors group"
+            className="shrink-0 text-[13px] font-medium text-slate-600 hover:text-cyan-800"
           >
-            <div className="flex items-center gap-3">
-              <svg
-                className="w-5 h-5 text-slate-700"
-                viewBox="0 0 24 24"
-                fill="currentColor"
-              >
-                <path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.166 6.839 9.489.5.092.682-.217.682-.48 0-.237-.008-.866-.013-1.7-2.782.603-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.464-1.11-1.464-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.645.35-1.087.636-1.337-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.268 2.75 1.026A9.578 9.578 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.026 2.747-1.026.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.161 22 16.416 22 12c0-5.523-4.477-10-10-10z" />
-              </svg>
-              <div>
-                <span className="text-sm font-medium text-slate-900">
-                  README.md
-                </span>
-                <span className="text-sm text-slate-500 ml-2">
-                  from opral/inlang
-                </span>
-              </div>
-            </div>
-            <div className="flex items-center gap-1.5 text-sm text-slate-600 group-hover:text-slate-900">
-              View on GitHub
-              <svg
-                className="w-4 h-4"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                strokeWidth={2}
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M14 5l7 7m0 0l-7 7m7-7H3"
-                />
-              </svg>
-            </div>
+            View on GitHub →
           </a>
-          <article
-            className="marketplace-markdown"
-            dangerouslySetInnerHTML={{ __html: html }}
-          />
         </div>
+        <article
+          className="marketplace-markdown rounded-xl border border-slate-200 bg-white px-5 py-8 sm:px-12 sm:py-11"
+          dangerouslySetInnerHTML={{ __html: html }}
+        />
       </section>
 
-      <section className="py-16">
-        <div className="mx-auto max-w-4xl px-4 sm:px-6">
-          <hr className="border-slate-200 mb-16" />
-          <div className="text-center">
-            <h2 className="text-2xl font-semibold tracking-tight mb-6">
-              Ready to get started?
-            </h2>
-            <div className="flex flex-wrap justify-center gap-3">
-              <Link
-                to="/c/tools"
-                className="rounded-lg bg-slate-900 text-white px-6 py-3 text-sm font-semibold hover:bg-slate-800 transition-colors"
-              >
-                Explore tools
-              </Link>
-              <a
-                href="https://github.com/opral/inlang"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="rounded-lg border border-slate-300 text-slate-900 px-6 py-3 text-sm font-semibold hover:border-slate-400 hover:bg-slate-50 transition-colors flex items-center gap-2"
-              >
-                <svg
-                  className="h-5 w-5"
-                  viewBox="0 0 16 16"
-                  fill="currentColor"
-                >
-                  <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
-                </svg>
-                {githubStars ? formatStars(githubStars) : "2k+"} stars
-              </a>
-            </div>
-          </div>
+      <section className="mx-auto max-w-[880px] px-4 pb-[72px] pt-12 text-center sm:px-6 lg:px-8">
+        <hr className="mb-12 border-slate-200" />
+        <h2 className="mb-[18px] text-[22px] font-semibold tracking-tight">
+          Ready to get started?
+        </h2>
+        <div className="flex flex-wrap justify-center gap-3">
+          <Link
+            to="/c/tools"
+            className="rounded-[9px] bg-cyan-700 px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-cyan-800"
+          >
+            Explore tools
+          </Link>
+          <a
+            href="https://github.com/opral/inlang"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="rounded-[9px] border border-slate-300 px-6 py-3 text-sm font-semibold text-slate-900 transition-colors hover:border-slate-400"
+          >
+            ★ {githubStars ? formatStars(githubStars) : "2k+"} stars
+          </a>
         </div>
       </section>
-    </main>
+    </div>
   );
 }

--- a/packages/website-v2/src/styles.css
+++ b/packages/website-v2/src/styles.css
@@ -15,3 +15,7 @@ code {
     ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono",
     monospace;
 }
+
+.project-file-card {
+  clip-path: polygon(0 0, calc(100% - 28px) 0, 100% 28px, 100% 100%, 0 100%);
+}

--- a/packages/website-v2/vite.config.ts
+++ b/packages/website-v2/vite.config.ts
@@ -34,7 +34,7 @@ const config = defineConfig(({ mode, command }) => {
           targets: [
             {
               src: "../../blog/**",
-              dest: "../client/blog",
+              dest: command === "serve" ? "blog" : "../client/blog",
             },
           ],
           watch: command === "serve" ? { reloadPageOnChange: true } : undefined,


### PR DESCRIPTION
## What changed

- refresh the site header, landing hero, project diagram, customer strip, README frame, CTA, and footer to match the updated design
- keep rendering the complete repository README and update its metrics presentation
- update the landing tagline to focus on software products
- serve local blog assets from the `/blog` path during development while preserving the production copy destination

## Why

The landing page needed to match the supplied updated design, and the blog preview used a build-only static-copy destination that caused local image requests to return 404s.

## Impact

The landing page now has the updated navigation and visual hierarchy, retains the full README, and blog thumbnails render in local development.

## Validation

- `pnpm --filter @inlang/website-v2 lint`
- `pnpm --filter @inlang/website-v2 build`
- verified representative local blog SVG and PNG URLs return HTTP 200 with the correct content types