### PR TITLE
fix inferred inputs in message-format declarations

### DIFF
--- a/.changeset/infer-message-format-inputs.md
+++ b/.changeset/infer-message-format-inputs.md
@@ -1,0 +1,5 @@
+---
+"@inlang/plugin-message-format": patch
+---
+
+Infer input declarations referenced by local message-format declarations.

--- a/packages/plugins/inlang-message-format/src/import-export/importFiles.ts
+++ b/packages/plugins/inlang-message-format/src/import-export/importFiles.ts
@@ -65,6 +65,7 @@ function parseBundle(
 } {
 	const parsed = parseVariants(key, locale, value);
 	const declarations = unique(parsed.declarations);
+	addInputDeclarationsForLocalReferences(declarations);
 	const selectors = unique(parsed.selectors);
 
 	const undeclaredSelectors = selectors.filter(
@@ -91,6 +92,43 @@ function parseBundle(
 		},
 		variants: parsed.variants,
 	};
+}
+
+/**
+ * Local declarations may reference inputs without repeating them as explicit
+ * `input` declarations. Keep the SDK bundle declarations complete so
+ * consumers can generate the correct message function signature.
+ */
+function addInputDeclarationsForLocalReferences(
+	declarations: Declaration[]
+): void {
+	const declaredNames = new Set(
+		declarations.map((declaration) => declaration.name)
+	);
+
+	for (const declaration of declarations) {
+		if (declaration.type !== "local-variable") {
+			continue;
+		}
+
+		const references: string[] = [];
+		if (declaration.value.arg.type === "variable-reference") {
+			references.push(declaration.value.arg.name);
+		}
+		for (const option of declaration.value.annotation?.options ?? []) {
+			if (option.value.type === "variable-reference") {
+				references.push(option.value.name);
+			}
+		}
+
+		for (const name of references) {
+			if (declaredNames.has(name)) {
+				continue;
+			}
+			declarations.push({ type: "input-variable", name });
+			declaredNames.add(name);
+		}
+	}
 }
 
 function parseVariants(

--- a/packages/plugins/inlang-message-format/src/import-export/roundtrip.test.ts
+++ b/packages/plugins/inlang-message-format/src/import-export/roundtrip.test.ts
@@ -562,6 +562,72 @@ test("local variables with function declarations and options", async () => {
 	});
 });
 
+test("adds undeclared inputs referenced by local declarations", async () => {
+	const imported = await runImportFiles({
+		with_number: [
+			{
+				declarations: [
+					"local formatted = count: number style=unit unit=minute unitDisplay=long",
+				],
+				selectors: [],
+				match: { "*": "{formatted}" },
+			},
+		],
+	});
+
+	expect(imported.bundles[0]?.declarations).toContainEqual({
+		type: "input-variable",
+		name: "count",
+	});
+});
+
+test("infers inputs referenced by formatter options", async () => {
+	const imported = await runImportFiles({
+		relative_time: [
+			{
+				declarations: ["local formatted = duration: relativetime unit=$unit"],
+				selectors: [],
+				match: { "*": "{formatted}" },
+			},
+		],
+	});
+
+	const declarations = imported.bundles[0]?.declarations ?? [];
+	expect(declarations).toContainEqual({
+		type: "input-variable",
+		name: "duration",
+	});
+	expect(declarations).toContainEqual({
+		type: "input-variable",
+		name: "unit",
+	});
+});
+
+test("infers free inputs from local declarations without shadowing locals", async () => {
+	const imported = await runImportFiles({
+		formatted: [
+			{
+				declarations: [
+					"local base = count: number",
+					"local formatted = base: number",
+				],
+				selectors: [],
+				match: { "*": "{formatted}" },
+			},
+		],
+	});
+
+	const declarations = imported.bundles[0]?.declarations ?? [];
+	expect(declarations).toContainEqual({
+		type: "input-variable",
+		name: "count",
+	});
+	expect(declarations).not.toContainEqual({
+		type: "input-variable",
+		name: "base",
+	});
+});
+
 test("local variables support whitespace around literal formatter options", async () => {
 	const imported = await runImportFiles({
 		some_happy_cat: [


### PR DESCRIPTION
## Summary

`@inlang/plugin-message-format` could parse a local declaration such as `local formatted = count: number ...` without emitting the corresponding `input count` declaration. Consumers then received incomplete bundle declarations and generated message functions without the required runtime input.

This change infers input declarations for free references in local arguments and formatter options, while preserving references to declared local variables as locals. It adds regression coverage for undeclared local arguments, dynamic formatter options, and local-to-local references.

Fixes [opral/paraglide-js#731](https://github.com/opral/paraglide-js/issues/731)

## Validation

- `pnpm --filter @inlang/plugin-message-format test` — 58 passed, 1 skipped