### PR TITLE
feat(sdk): upgrade in-memory storage to Lix 0.10

### DIFF
--- a/.changeset/quiet-lixes-remember.md
+++ b/.changeset/quiet-lixes-remember.md
@@ -1,0 +1,5 @@
+---
+"@inlang/sdk": minor
+---
+
+Upgrade to `@lix-js/sdk` 0.9 and store inlang bundles, messages, and variants in the Lix in-memory engine.

--- a/packages/sdk/benchmark/README.md
+++ b/packages/sdk/benchmark/README.md
@@ -1,0 +1,74 @@
+# Lix 0.10 in-memory performance
+
+This benchmark models the common database operations used by Paraglide JS and
+Sherlock. It compares the Lix 0.10 in-memory message store with the former
+SQLite-WASM store through the same public inlang Kysely APIs.
+
+## Workload
+
+- 500 bundles
+- two locales per bundle (`en`, `de`)
+- 1,000 messages and 1,000 variants total
+- Paraglide: read the complete nested project for compilation
+- Sherlock: read one nested bundle, update one variant, and insert one bundle
+  with two translations
+- Project load: restore the populated inlang snapshot into a fresh in-memory
+  Lix and close it
+
+## Results
+
+The table reports the mean latency averaged across two benchmark runs. Lower is
+better. The delta is Lix latency divided by SQLite-WASM latency.
+
+| Operation                        | Lix 0.10 memory | SQLite-WASM |         Delta |
+| -------------------------------- | -------------: | ----------: | ------------: |
+| Paraglide full nested read       |      22.053 ms |   50.556 ms |  2.29x faster |
+| Sherlock point nested read       |       0.110 ms |    0.165 ms |  1.50x slower |
+| Sherlock variant update          |       3.045 ms |    0.025 ms | 121.32x slower |
+| Sherlock nested insert           |       4.440 ms |    0.289 ms | 15.39x slower |
+| Load populated in-memory project |     140.645 ms |         n/a |           n/a |
+
+The two individual Lix means were:
+
+| Operation         |      Run 1 |      Run 2 |
+| ----------------- | ---------: | ---------: |
+| Full nested read  | 20.146 ms | 23.960 ms |
+| Point nested read |  0.104 ms |  0.116 ms |
+| Variant update    |  3.051 ms |  3.039 ms |
+| Nested insert     |  4.195 ms |  4.686 ms |
+| Project load      |134.250 ms |147.040 ms |
+
+The bulk Paraglide query benefits from a single flat join and JavaScript
+reconstruction. Lix 0.10's native `INSERT ... RETURNING` and `DEFAULT VALUES`
+support remove the v0.9 compatibility readbacks, bringing nested insert latency
+down substantially. Point writes still pay a higher Lix engine round-trip and
+change-recording cost than SQLite-WASM.
+
+## Environment
+
+- Linux 7.0.0-22-generic, x86_64
+- AMD EPYC-Genoa, 16 vCPUs
+- Node.js 22.22.1
+- pnpm 10.23.0
+- Vitest 3.2.4 / Tinybench
+- `@lix-js/sdk` 0.10.0
+
+## Reproduce
+
+From the repository root:
+
+```sh
+pnpm --filter @inlang/sdk bench
+```
+
+Vitest runs each operation for 1.5 seconds after a 300 ms warmup. Project load
+runs for 2 seconds after the same warmup.
+
+## Persistence note
+
+The v0.10 Node native in-memory backend cannot export or import an opaque Lix
+snapshot; the SDK explicitly reports that memory snapshots are browser-only.
+The migration therefore serializes the current inlang entities and project
+files into a portable JSON blob and restores them into a fresh in-memory Lix.
+This preserves current project state but not Lix branch/history metadata, and
+legacy v0.4 SQLite `.inlang` blobs require a separate migration path.

--- a/packages/sdk/benchmark/common-operations.bench.ts
+++ b/packages/sdk/benchmark/common-operations.bench.ts
@@ -1,0 +1,232 @@
+import { afterAll, beforeAll, bench } from "vitest";
+import { CamelCasePlugin, Kysely } from "kysely";
+import { openLix, type Lix, type LixBatchStatement } from "@lix-js/sdk";
+import {
+	createDialect,
+	createInMemoryDatabase,
+	type SqliteWasmDatabase,
+} from "sqlite-wasm-kysely";
+import { v7 } from "uuid";
+import {
+	applySchema,
+	type InlangDatabaseSchema,
+} from "../src/database/schema.js";
+import { JsonbPlugin } from "../src/database/jsonbPlugin.js";
+import { initDb } from "../src/database/initDb.js";
+import { registerInlangSchemas } from "../src/database/registerSchemas.js";
+import { selectBundleNested } from "../src/query-utilities/selectBundleNested.js";
+import { insertBundleNested } from "../src/query-utilities/insertBundleNested.js";
+import { projectToBlob } from "../src/project/snapshot.js";
+import { loadProjectInMemory } from "../src/project/loadProjectInMemory.js";
+import { humanId } from "../src/human-id/human-id.js";
+
+const BUNDLE_COUNT = 500;
+const LOCALES = ["en", "de"] as const;
+
+let lix: Lix;
+let lixDb: Kysely<InlangDatabaseSchema>;
+let sqlite: SqliteWasmDatabase;
+let sqliteDb: Kysely<InlangDatabaseSchema>;
+let populatedBlob: Blob;
+let mutationCounter = 0;
+
+beforeAll(async () => {
+	lix = await openLix();
+	await registerInlangSchemas(lix);
+	lixDb = initDb({ lix });
+	await seedLix(lix);
+
+	sqlite = await createInMemoryDatabase({ readOnly: false });
+	sqlite.createFunction({ name: "uuid_v7", arity: 0, xFunc: () => v7() });
+	sqlite.createFunction({ name: "human_id", arity: 0, xFunc: () => humanId() });
+	applySchema({ sqlite });
+	sqliteDb = new Kysely({
+		dialect: createDialect({ database: sqlite }),
+		plugins: [new CamelCasePlugin(), new JsonbPlugin({ database: sqlite })],
+	});
+	await seedKysely(sqliteDb);
+
+	await lix.executeBatch([
+		{
+			sql: "INSERT INTO lix_file (path, content) VALUES ($1, $2)",
+			params: ["/project_id", new TextEncoder().encode("benchmark-project")],
+		},
+		{
+			sql: "INSERT INTO lix_file (path, content) VALUES ($1, $2)",
+			params: [
+				"/settings.json",
+				new TextEncoder().encode(
+					JSON.stringify({
+						baseLocale: "en",
+						locales: [...LOCALES],
+						modules: [],
+					})
+				),
+			],
+		},
+	]);
+	populatedBlob = await projectToBlob(lix);
+}, 120_000);
+
+afterAll(async () => {
+	await lixDb.destroy();
+	await lix.close();
+	await sqliteDb.destroy();
+	sqlite.close();
+});
+
+bench(
+	"paraglide: select 500 bundles / 1,000 messages nested — Lix 0.10 memory",
+	async () => {
+		await selectBundleNested(lixDb).execute();
+	},
+	{ time: 1_500, warmupTime: 300 }
+);
+
+bench(
+	"paraglide: select 500 bundles / 1,000 messages nested — SQLite WASM baseline",
+	async () => {
+		await selectBundleNested(sqliteDb).execute();
+	},
+	{ time: 1_500, warmupTime: 300 }
+);
+
+bench(
+	"sherlock: select one nested bundle — Lix 0.10 memory",
+	async () => {
+		await selectBundleNested(lixDb)
+			.where("bundle.id", "=", "bundle-250")
+			.executeTakeFirst();
+	},
+	{ time: 1_500, warmupTime: 300 }
+);
+
+bench(
+	"sherlock: select one nested bundle — SQLite WASM baseline",
+	async () => {
+		await selectBundleNested(sqliteDb)
+			.where("bundle.id", "=", "bundle-250")
+			.executeTakeFirst();
+	},
+	{ time: 1_500, warmupTime: 300 }
+);
+
+bench(
+	"sherlock: update one variant pattern — Lix 0.10 memory",
+	async () => {
+		mutationCounter++;
+		await lixDb
+			.updateTable("variant")
+			.set({ pattern: [{ type: "text", value: `edited-${mutationCounter}` }] })
+			.where("id", "=", "variant-250-en")
+			.execute();
+	},
+	{ time: 1_500, warmupTime: 300 }
+);
+
+bench(
+	"sherlock: update one variant pattern — SQLite WASM baseline",
+	async () => {
+		mutationCounter++;
+		await sqliteDb
+			.updateTable("variant")
+			.set({ pattern: [{ type: "text", value: `edited-${mutationCounter}` }] })
+			.where("id", "=", "variant-250-en")
+			.execute();
+	},
+	{ time: 1_500, warmupTime: 300 }
+);
+
+bench(
+	"sherlock: insert bundle with two translations — Lix 0.10 memory",
+	async () => {
+		mutationCounter++;
+		await insertBundleNested(lixDb, nestedBundle(`lix-new-${mutationCounter}`));
+	},
+	{ time: 1_500, warmupTime: 300 }
+);
+
+bench(
+	"sherlock: insert bundle with two translations — SQLite WASM baseline",
+	async () => {
+		mutationCounter++;
+		await insertBundleNested(
+			sqliteDb,
+			nestedBundle(`sqlite-new-${mutationCounter}`)
+		);
+	},
+	{ time: 1_500, warmupTime: 300 }
+);
+
+bench(
+	"paraglide/sherlock: load populated in-memory project — Lix 0.10 memory",
+	async () => {
+		const project = await loadProjectInMemory({ blob: populatedBlob });
+		await project.close();
+	},
+	{ time: 2_000, warmupTime: 300 }
+);
+
+async function seedLix(target: Lix) {
+	const statements: LixBatchStatement[] = [];
+	for (let index = 0; index < BUNDLE_COUNT; index++) {
+		const bundleId = `bundle-${index}`;
+		statements.push({
+			sql: "INSERT INTO bundle (id, declarations) VALUES ($1, $2)",
+			params: [bundleId, []],
+		});
+		for (const locale of LOCALES) {
+			const messageId = `message-${index}-${locale}`;
+			statements.push({
+				sql: 'INSERT INTO message (id, "bundleId", locale, selectors) VALUES ($1, $2, $3, $4)',
+				params: [messageId, bundleId, locale, []],
+			});
+			statements.push({
+				sql: 'INSERT INTO variant (id, "messageId", matches, pattern) VALUES ($1, $2, $3, $4)',
+				params: [
+					`variant-${index}-${locale}`,
+					messageId,
+					[],
+					[{ type: "text", value: `Message ${index} (${locale})` }],
+				],
+			});
+		}
+	}
+	await target.executeBatch(statements);
+}
+
+async function seedKysely(db: Kysely<InlangDatabaseSchema>) {
+	for (let index = 0; index < BUNDLE_COUNT; index++) {
+		await insertBundleNested(db, nestedBundle(`bundle-${index}`, index));
+	}
+}
+
+function nestedBundle(id: string, index = mutationCounter) {
+	return {
+		id,
+		declarations: [],
+		messages: LOCALES.map((locale) => {
+			const messageId = id.startsWith("bundle-")
+				? `message-${index}-${locale}`
+				: `${id}-message-${locale}`;
+			return {
+				id: messageId,
+				bundleId: id,
+				locale,
+				selectors: [],
+				variants: [
+					{
+						id: id.startsWith("bundle-")
+							? `variant-${index}-${locale}`
+							: `${id}-variant-${locale}`,
+						messageId,
+						matches: [],
+						pattern: [
+							{ type: "text" as const, value: `Message ${index} (${locale})` },
+						],
+					},
+				],
+			};
+		}),
+	};
+}

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -30,6 +30,7 @@
 		"typecheck": "npm run env-variables && tsc --noEmit",
 		"test": "npm run env-variables && tsc --noEmit && vitest run",
 		"test:watch": "vitest",
+		"bench": "vitest bench --run benchmark",
 		"lint": "eslint ./src",
 		"format": "prettier ./src --write",
 		"clean": "rm -rf ./dist ./node_modules"
@@ -38,7 +39,7 @@
 		"node": ">=20.0.0"
 	},
 	"dependencies": {
-		"@lix-js/sdk": "0.4.10",
+		"@lix-js/sdk": "0.10.0",
 		"@sinclair/typebox": "^0.31.17",
 		"kysely": "^0.28.12",
 		"sqlite-wasm-kysely": "0.3.0",

--- a/packages/sdk/src/database/initDb.ts
+++ b/packages/sdk/src/database/initDb.ts
@@ -2,9 +2,12 @@ import { Kysely } from "kysely";
 import type { Lix } from "@lix-js/sdk";
 import type { InlangDatabaseSchema } from "./schema.js";
 import { LixDialect } from "./lixDialect.js";
+import { attachLixBatchExecutor } from "./lixBatch.js";
 
 export function initDb(args: { lix: Lix }) {
-	return new Kysely<InlangDatabaseSchema>({
+	const db = new Kysely<InlangDatabaseSchema>({
 		dialect: new LixDialect(args.lix),
 	});
+	attachLixBatchExecutor(db, args.lix);
+	return db;
 }

--- a/packages/sdk/src/database/initDb.ts
+++ b/packages/sdk/src/database/initDb.ts
@@ -1,34 +1,10 @@
-import { CamelCasePlugin, Kysely } from "kysely";
-import { applySchema, type InlangDatabaseSchema } from "./schema.js";
-import { createDialect, type SqliteWasmDatabase } from "sqlite-wasm-kysely";
-import { v7 } from "uuid";
-import { humanId } from "../human-id/human-id.js";
-import { JsonbPlugin } from "./jsonbPlugin.js";
+import { Kysely } from "kysely";
+import type { Lix } from "@lix-js/sdk";
+import type { InlangDatabaseSchema } from "./schema.js";
+import { LixDialect } from "./lixDialect.js";
 
-export function initDb(args: { sqlite: SqliteWasmDatabase }) {
-	initDefaultValueFunctions({ sqlite: args.sqlite });
-	applySchema({ sqlite: args.sqlite });
-	const db = new Kysely<InlangDatabaseSchema>({
-		dialect: createDialect({
-			database: args.sqlite,
-		}),
-		plugins: [
-			new CamelCasePlugin(),
-			new JsonbPlugin({ database: args.sqlite }),
-		],
-	});
-	return db;
-}
-
-function initDefaultValueFunctions(args: { sqlite: SqliteWasmDatabase }) {
-	args.sqlite.createFunction({
-		name: "uuid_v7",
-		arity: 0,
-		xFunc: () => v7(),
-	});
-	args.sqlite.createFunction({
-		name: "human_id",
-		arity: 0,
-		xFunc: () => humanId(),
+export function initDb(args: { lix: Lix }) {
+	return new Kysely<InlangDatabaseSchema>({
+		dialect: new LixDialect(args.lix),
 	});
 }

--- a/packages/sdk/src/database/initDbAndSchema.test.ts
+++ b/packages/sdk/src/database/initDbAndSchema.test.ts
@@ -1,14 +1,17 @@
-import { createInMemoryDatabase } from "sqlite-wasm-kysely";
 import { test, expect } from "vitest";
+import { openLix } from "@lix-js/sdk";
 import { initDb } from "./initDb.js";
-import { isHumanId } from "../human-id/human-id.js";
+import { registerInlangSchemas } from "./registerSchemas.js";
 import { validate as isUuid } from "uuid";
 
+async function createDb() {
+	const lix = await openLix();
+	await registerInlangSchemas(lix);
+	return initDb({ lix });
+}
+
 test("bundle default values", async () => {
-	const sqlite = await createInMemoryDatabase({
-		readOnly: false,
-	});
-	const db = initDb({ sqlite });
+	const db = await createDb();
 
 	const bundle = await db
 		.insertInto("bundle")
@@ -16,15 +19,12 @@ test("bundle default values", async () => {
 		.returningAll()
 		.executeTakeFirstOrThrow();
 
-	expect(isHumanId(bundle.id)).toBe(true);
+	expect(isUuid(bundle.id)).toBe(true);
 	expect(bundle.declarations).toStrictEqual([]);
 });
 
 test("message default values", async () => {
-	const sqlite = await createInMemoryDatabase({
-		readOnly: false,
-	});
-	const db = initDb({ sqlite });
+	const db = await createDb();
 
 	const bundle = await db
 		.insertInto("bundle")
@@ -46,10 +46,7 @@ test("message default values", async () => {
 });
 
 test("variant default values", async () => {
-	const sqlite = await createInMemoryDatabase({
-		readOnly: false,
-	});
-	const db = initDb({ sqlite });
+	const db = await createDb();
 
 	const bundle = await db
 		.insertInto("bundle")
@@ -80,10 +77,7 @@ test("variant default values", async () => {
 });
 
 test("it should handle json serialization and parsing for bundles", async () => {
-	const sqlite = await createInMemoryDatabase({
-		readOnly: false,
-	});
-	const db = initDb({ sqlite });
+	const db = await createDb();
 
 	const bundle = await db
 		.insertInto("bundle")
@@ -108,10 +102,7 @@ test("it should handle json serialization and parsing for bundles", async () => 
 
 // https://github.com/opral/paraglide-js/issues/571
 test("it should preserve json-like text in variant patterns", async () => {
-	const sqlite = await createInMemoryDatabase({
-		readOnly: false,
-	});
-	const db = initDb({ sqlite });
+	const db = await createDb();
 
 	const bundle = await db
 		.insertInto("bundle")
@@ -156,10 +147,7 @@ test("it should preserve json-like text in variant patterns", async () => {
 
 // https://github.com/opral/inlang/issues/209
 test.todo("it should enable foreign key constraints", async () => {
-	const sqlite = await createInMemoryDatabase({
-		readOnly: false,
-	});
-	const db = initDb({ sqlite });
+	const db = await createDb();
 
 	expect(() =>
 		db

--- a/packages/sdk/src/database/lixBatch.test.ts
+++ b/packages/sdk/src/database/lixBatch.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "vitest";
+import { sql } from "kysely";
+import { openLix } from "@lix-js/sdk";
+import { executeLixBatch } from "./lixBatch.js";
+import { initDb } from "./initDb.js";
+import { registerInlangSchemas } from "./registerSchemas.js";
+
+test("executeLixBatch publishes atomically and rolls back on a later failure", async () => {
+	const lix = await openLix();
+	await registerInlangSchemas(lix);
+	const db = initDb({ lix });
+
+	const insert = db
+		.insertInto("bundle")
+		.values({ id: "batch-atomicity" })
+		.compile();
+	const invalid =
+		sql`INSERT INTO "missing_batch_table" ("id") VALUES (${"must-fail"})`.compile(
+			db
+		);
+
+	await expect(executeLixBatch(db, [insert, invalid])).rejects.toThrow();
+	await expect(
+		db
+			.selectFrom("bundle")
+			.select("id")
+			.where("id", "=", "batch-atomicity")
+			.execute()
+	).resolves.toEqual([]);
+
+	await db.destroy();
+	await lix.close();
+});

--- a/packages/sdk/src/database/lixBatch.ts
+++ b/packages/sdk/src/database/lixBatch.ts
@@ -1,0 +1,45 @@
+import type { CompiledQuery, Kysely } from "kysely";
+import type { ExecuteResult, Lix, LixBatchStatement } from "@lix-js/sdk";
+import type { InlangDatabaseSchema } from "./schema.js";
+import { compileLixQuery } from "./lixDialect.js";
+
+type BatchExecutor = (
+	queries: readonly CompiledQuery[]
+) => Promise<readonly ExecuteResult[]>;
+
+const batchExecutors = new WeakMap<object, BatchExecutor>();
+
+/**
+ * Installs the one atomic batch boundary owned by an Lix-backed database.
+ * The executor is deliberately not exposed as a second query dialect: callers
+ * provide ordinary Kysely compiled queries and Lix remains responsible for
+ * normalization, execution, and atomic publication.
+ */
+export function attachLixBatchExecutor(
+	db: Kysely<InlangDatabaseSchema>,
+	lix: Lix
+): void {
+	batchExecutors.set(db, async (queries) => {
+		const statements: LixBatchStatement[] = queries.map(compileLixQuery);
+		return lix.executeBatch(statements);
+	});
+}
+
+/**
+ * Executes already-compiled Kysely statements as one authenticated Lix batch.
+ * A database without the Lix batch capability is rejected explicitly; there
+ * is no sequential or compatibility route hidden behind this API.
+ */
+export async function executeLixBatch(
+	db: Kysely<InlangDatabaseSchema>,
+	queries: readonly CompiledQuery[]
+): Promise<readonly ExecuteResult[]> {
+	if (queries.length === 0) {
+		throw new Error("executeLixBatch requires at least one query");
+	}
+	const execute = batchExecutors.get(db);
+	if (!execute) {
+		throw new Error("The database is not an Lix-backed batch database");
+	}
+	return execute(queries);
+}

--- a/packages/sdk/src/database/lixDialect.test.ts
+++ b/packages/sdk/src/database/lixDialect.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "vitest";
+import { openLix } from "@lix-js/sdk";
+import { initDb } from "./initDb.js";
+import { registerInlangSchemas } from "./registerSchemas.js";
+import { selectBundleNested } from "../query-utilities/selectBundleNested.js";
+
+test("executes Kysely reads, writes, defaults, and transactions on Lix", async () => {
+	const lix = await openLix();
+	await registerInlangSchemas(lix);
+	const db = initDb({ lix });
+
+	const bundle = await db
+		.insertInto("bundle")
+		.defaultValues()
+		.returningAll()
+		.executeTakeFirstOrThrow();
+	expect(bundle.id).toBeTypeOf("string");
+	expect(bundle.declarations).toEqual([]);
+
+	await db.transaction().execute(async (trx) => {
+		const message = await trx
+			.insertInto("message")
+			.values({ bundleId: bundle.id, locale: "en" })
+			.returningAll()
+			.executeTakeFirstOrThrow();
+		await trx.insertInto("variant").values({ messageId: message.id }).execute();
+	});
+
+	expect(await db.selectFrom("message").selectAll().execute()).toHaveLength(1);
+	expect(await db.selectFrom("variant").selectAll().execute()).toHaveLength(1);
+	const nested = await selectBundleNested(db).executeTakeFirstOrThrow();
+	expect(nested.messages[0]?.variants).toHaveLength(1);
+
+	await db.destroy();
+	await lix.close();
+});

--- a/packages/sdk/src/database/lixDialect.ts
+++ b/packages/sdk/src/database/lixDialect.ts
@@ -9,7 +9,12 @@ import {
 	type Kysely,
 	type QueryResult,
 } from "kysely";
-import type { Lix, LixTransaction, SqlParam } from "@lix-js/sdk";
+import type {
+	Lix,
+	LixBatchStatement,
+	LixTransaction,
+	SqlParam,
+} from "@lix-js/sdk";
 
 /** Kysely bridge for Lix's DataFusion SQL interface. */
 export class LixDialect implements Dialect {
@@ -110,7 +115,6 @@ class LixConnection implements DatabaseConnection {
 		const parameters = prepared.parameterPositions.map(
 			(position) => compiledQuery.parameters[position - 1]
 		);
-
 		const result = await executor.execute(
 			prepared.sql,
 			parameters as SqlParam[]
@@ -131,10 +135,26 @@ type PreparedLixQuery = {
 	parameterPositions: number[];
 };
 
-function prepareLixQuery(compiledSql: string): PreparedLixQuery {
+/** Convert Kysely's compiled query to the one Lix SQL/parameter contract. */
+export function compileLixQuery(
+	compiledQuery: CompiledQuery
+): LixBatchStatement {
+	const prepared = prepareLixQuery(compiledQuery.sql);
+	const parameters = prepared.parameterPositions.map(
+		(position) => compiledQuery.parameters[position - 1]
+	);
+	return {
+		sql: prepared.sql,
+		params: parameters as SqlParam[],
+	};
+}
+
+function prepareLixQuery(compiledSql: string): {
+	sql: string;
+	parameterPositions: number[];
+} {
 	const sql = omitPrimaryKeyAssignments(
-		compiledSql
-		.replaceAll('"file"', '"lix_file"')
+		compiledSql.replaceAll('"file"', '"lix_file"')
 	);
 	const compacted = compactSqlParameters(sql);
 	return {
@@ -173,8 +193,7 @@ function omitPrimaryKeyAssignments(sql: string): string {
 
 function publicRow(row: Record<string, unknown>): Record<string, unknown> {
 	return Object.fromEntries(
-		Object.entries(row)
-			.filter(([column]) => !column.startsWith("lixcol_"))
+		Object.entries(row).filter(([column]) => !column.startsWith("lixcol_"))
 	);
 }
 

--- a/packages/sdk/src/database/lixDialect.ts
+++ b/packages/sdk/src/database/lixDialect.ts
@@ -1,0 +1,199 @@
+import {
+	PostgresAdapter,
+	PostgresIntrospector,
+	PostgresQueryCompiler,
+	type CompiledQuery,
+	type DatabaseConnection,
+	type Dialect,
+	type Driver,
+	type Kysely,
+	type QueryResult,
+} from "kysely";
+import type { Lix, LixTransaction, SqlParam } from "@lix-js/sdk";
+
+/** Kysely bridge for Lix's DataFusion SQL interface. */
+export class LixDialect implements Dialect {
+	readonly #driver: LixDriver;
+
+	constructor(lix: Lix) {
+		this.#driver = new LixDriver(lix);
+	}
+
+	createDriver(): Driver {
+		return this.#driver;
+	}
+
+	createQueryCompiler() {
+		return new PostgresQueryCompiler();
+	}
+
+	createAdapter() {
+		return new PostgresAdapter();
+	}
+
+	createIntrospector(db: Kysely<unknown>) {
+		return new PostgresIntrospector(db);
+	}
+}
+
+class LixDriver implements Driver {
+	readonly #connection: LixConnection;
+
+	constructor(lix: Lix) {
+		this.#connection = new LixConnection(lix);
+	}
+
+	async init(): Promise<void> {}
+
+	async acquireConnection(): Promise<DatabaseConnection> {
+		return this.#connection;
+	}
+
+	async beginTransaction(connection: DatabaseConnection): Promise<void> {
+		await (connection as LixConnection).beginTransaction();
+	}
+
+	async commitTransaction(connection: DatabaseConnection): Promise<void> {
+		await (connection as LixConnection).commitTransaction();
+	}
+
+	async rollbackTransaction(connection: DatabaseConnection): Promise<void> {
+		await (connection as LixConnection).rollbackTransaction();
+	}
+
+	async releaseConnection(): Promise<void> {}
+	async destroy(): Promise<void> {
+		await this.#connection.destroy();
+	}
+}
+
+class LixConnection implements DatabaseConnection {
+	readonly #lix: Lix;
+	readonly #preparedQueries = new Map<string, PreparedLixQuery>();
+	#transaction: LixTransaction | undefined;
+
+	constructor(lix: Lix) {
+		this.#lix = lix;
+	}
+
+	async beginTransaction(): Promise<void> {
+		if (this.#transaction)
+			throw new Error("A Lix transaction is already active");
+		this.#transaction = await this.#lix.beginTransaction();
+	}
+
+	async destroy(): Promise<void> {
+		this.#preparedQueries.clear();
+	}
+
+	async commitTransaction(): Promise<void> {
+		const transaction = this.#transaction;
+		if (!transaction) throw new Error("No Lix transaction is active");
+		this.#transaction = undefined;
+		await transaction.commit();
+	}
+
+	async rollbackTransaction(): Promise<void> {
+		const transaction = this.#transaction;
+		if (!transaction) throw new Error("No Lix transaction is active");
+		this.#transaction = undefined;
+		await transaction.rollback();
+	}
+
+	async executeQuery<R>(compiledQuery: CompiledQuery): Promise<QueryResult<R>> {
+		const executor = this.#transaction ?? this.#lix;
+		let prepared = this.#preparedQueries.get(compiledQuery.sql);
+		if (!prepared) {
+			prepared = prepareLixQuery(compiledQuery.sql);
+			this.#preparedQueries.set(compiledQuery.sql, prepared);
+		}
+		const parameters = prepared.parameterPositions.map(
+			(position) => compiledQuery.parameters[position - 1]
+		);
+
+		const result = await executor.execute(
+			prepared.sql,
+			parameters as SqlParam[]
+		);
+		return {
+			rows: result.rows.map((row) => publicRow(row.toObject())) as R[],
+			numAffectedRows: BigInt(result.rowsAffected),
+		};
+	}
+
+	async *streamQuery<R>(compiledQuery: CompiledQuery) {
+		yield await this.executeQuery<R>(compiledQuery);
+	}
+}
+
+type PreparedLixQuery = {
+	sql: string;
+	parameterPositions: number[];
+};
+
+function prepareLixQuery(compiledSql: string): PreparedLixQuery {
+	const sql = omitPrimaryKeyAssignments(
+		compiledSql
+		.replaceAll('"file"', '"lix_file"')
+	);
+	const compacted = compactSqlParameters(sql);
+	return {
+		sql: compacted.sql,
+		parameterPositions: compacted.positions,
+	};
+}
+
+function omitPrimaryKeyAssignments(sql: string): string {
+	const conflictMarker = " do update set ";
+	const conflictIndex = sql.toLowerCase().indexOf(conflictMarker);
+	if (conflictIndex !== -1) {
+		const prefix = sql.slice(0, conflictIndex);
+		const assignments = sql
+			.slice(conflictIndex + conflictMarker.length)
+			.split(", ")
+			.filter((assignment) => !/^"id"\s*=/i.test(assignment));
+		sql =
+			assignments.length === 0
+				? `${prefix} do nothing`
+				: `${prefix}${conflictMarker}${assignments.join(", ")}`;
+	}
+	if (/^update\s+"(?:bundle|message|variant)"\s+set\s+/i.test(sql)) {
+		const whereIndex = sql.search(/\s+where\s+/i);
+		const head = whereIndex === -1 ? sql : sql.slice(0, whereIndex);
+		const tail = whereIndex === -1 ? "" : sql.slice(whereIndex);
+		const setIndex = head.toLowerCase().indexOf(" set ");
+		const assignments = head
+			.slice(setIndex + 5)
+			.split(", ")
+			.filter((assignment) => !/^"id"\s*=/i.test(assignment));
+		return `${head.slice(0, setIndex)} set ${assignments.join(", ")}${tail}`;
+	}
+	return sql;
+}
+
+function publicRow(row: Record<string, unknown>): Record<string, unknown> {
+	return Object.fromEntries(
+		Object.entries(row)
+			.filter(([column]) => !column.startsWith("lixcol_"))
+	);
+}
+
+function compactSqlParameters(sql: string): {
+	sql: string;
+	positions: number[];
+} {
+	const positions: number[] = [];
+	for (const match of sql.matchAll(/\$(\d+)/g)) {
+		const position = Number(match[1]);
+		if (!positions.includes(position)) positions.push(position);
+	}
+	const remapped = new Map(
+		positions.map((position, index) => [position, index + 1])
+	);
+	return {
+		sql: sql.replace(/\$(\d+)/g, (_, position: string) => {
+			return `$${remapped.get(Number(position))}`;
+		}),
+		positions,
+	};
+}

--- a/packages/sdk/src/database/registerSchemas.ts
+++ b/packages/sdk/src/database/registerSchemas.ts
@@ -1,0 +1,25 @@
+import type { Lix } from "@lix-js/sdk";
+import {
+	InlangBundleSchema,
+	InlangMessageSchema,
+	InlangVariantSchema,
+	InlangActiveAccountSchema,
+	InlangKeyValueSchema,
+} from "../schema-definitions/index.js";
+
+const schemas = [
+	InlangBundleSchema,
+	InlangMessageSchema,
+	InlangVariantSchema,
+	InlangKeyValueSchema,
+	InlangActiveAccountSchema,
+] as const;
+
+export async function registerInlangSchemas(lix: Lix): Promise<void> {
+	for (const schema of schemas) {
+		await lix.execute(
+			"INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
+			[JSON.stringify(schema)]
+		);
+	}
+}

--- a/packages/sdk/src/import-export/importFiles.ts
+++ b/packages/sdk/src/import-export/importFiles.ts
@@ -53,27 +53,22 @@ export async function importFiles(args: {
 					.executeTakeFirst();
 				message.id = exisingMessage?.id;
 			}
-			try {
+			const referencedBundle = await trx
+				.selectFrom("bundle")
+				.select("id")
+				.where("id", "=", message.bundleId)
+				.executeTakeFirst();
+			if (!referencedBundle) {
 				await trx
-					.insertInto("message")
-					.values(message)
-					.onConflict((oc) => oc.column("id").doUpdateSet(message))
+					.insertInto("bundle")
+					.values({ id: message.bundleId })
 					.execute();
-			} catch (e) {
-				// 787 = SQLITE_CONSTRAINT_FOREIGNKEY
-				// handle foreign key violation
-				// e.g. a message references a bundle that doesn't exist
-				// by creating the bundle
-				if ((e as any)?.resultCode === 787) {
-					await trx
-						.insertInto("bundle")
-						.values({ id: message.bundleId })
-						.execute();
-					await trx.insertInto("message").values(message).execute();
-				} else {
-					throw e;
-				}
 			}
+			await trx
+				.insertInto("message")
+				.values(message)
+				.onConflict((oc) => oc.column("id").doUpdateSet(message))
+				.execute();
 		}
 		// upsert every variant
 		for (const variant of imported.variants) {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -18,6 +18,7 @@ export * from "./query-utilities/index.js";
 export * from "./plugin/errors.js";
 export { humanId } from "./human-id/human-id.js";
 export type { InlangDatabaseSchema } from "./database/schema.js";
+export { executeLixBatch } from "./database/lixBatch.js";
 export type { ImportFile, ExportFile } from "./project/api.js";
 export type {
 	InlangPlugin,

--- a/packages/sdk/src/lix/compat.ts
+++ b/packages/sdk/src/lix/compat.ts
@@ -1,0 +1,11 @@
+/** Account information retained by the inlang project API. */
+export type Account = {
+	id: string;
+	name: string;
+};
+
+/** Compatibility shape for callers that seed project-scoped values. */
+export type NewKeyValue = {
+	key: string;
+	value: unknown;
+};

--- a/packages/sdk/src/lix/index.ts
+++ b/packages/sdk/src/lix/index.ts
@@ -1,1 +1,2 @@
 export * from "@lix-js/sdk";
+export type { Account, NewKeyValue } from "./compat.js";

--- a/packages/sdk/src/lix/withDb.ts
+++ b/packages/sdk/src/lix/withDb.ts
@@ -1,0 +1,47 @@
+import { Kysely } from "kysely";
+import type { Lix } from "@lix-js/sdk";
+import { LixDialect } from "../database/lixDialect.js";
+import type { Account } from "./compat.js";
+
+type LixFile = {
+	path: string;
+	content: Uint8Array;
+};
+
+type KeyValue = {
+	key: string;
+	value: string;
+};
+
+export type InlangLix = Lix & {
+	db: Kysely<{
+		file: LixFile;
+		key_value: KeyValue;
+		active_account: Account;
+	}>;
+};
+
+export async function withInlangLixDb(args: {
+	lix: Lix;
+	projectId: string;
+	account?: Account;
+}): Promise<InlangLix> {
+	await args.lix.execute(
+		"INSERT INTO key_value (key, value) VALUES ($1, $2) ON CONFLICT (key) DO UPDATE SET value = excluded.value",
+		["lix_id", args.projectId]
+	);
+	if (args.account) {
+		await args.lix.execute("DELETE FROM active_account");
+		await args.lix.execute(
+			"INSERT INTO active_account (id, name) VALUES ($1, $2)",
+			[args.account.id, args.account.name]
+		);
+	}
+	const lix = args.lix as InlangLix;
+	Object.defineProperty(lix, "db", {
+		configurable: true,
+		enumerable: true,
+		value: new Kysely({ dialect: new LixDialect(args.lix) }),
+	});
+	return lix;
+}

--- a/packages/sdk/src/plugin/cache.test.ts
+++ b/packages/sdk/src/plugin/cache.test.ts
@@ -1,7 +1,6 @@
 import { test, expect, vi } from "vitest";
 import { withCache } from "./cache.js";
-import { newLixFile, openLixInMemory } from "@lix-js/sdk";
-import { sql } from "kysely";
+import { openLix } from "@lix-js/sdk";
 
 test("it should be network-first", async () => {
 	const mockLoader = vi
@@ -11,23 +10,24 @@ test("it should be network-first", async () => {
 
 	const mockModulePath = "https://mock.com/module.js";
 
-	const lix = await openLixInMemory({ blob: await newLixFile() });
+	const lix = await openLix();
 
 	const result1 = await withCache(mockLoader, lix)(mockModulePath);
 
 	expect(mockLoader).toHaveBeenCalledTimes(1);
 	expect(result1).toBe("module content 1");
 
-	const cachedPlugins = await lix.db
-		.selectFrom("file")
-		.selectAll()
-		// @ts-expect-error - kysely doesn't know about GLOB
-		.where(sql`path GLOB '/cache/plugins/*'`)
-		.execute();
+	const cachedPlugins = (
+		await lix.execute(
+			"SELECT content FROM lix_file WHERE path LIKE '/cache/plugins/%'"
+		)
+	).rows;
 
 	expect(cachedPlugins.length).toBe(1);
 
-	const parsed = new TextDecoder().decode(cachedPlugins[0]!.data);
+	const parsed = new TextDecoder().decode(
+		cachedPlugins[0]!.value("content").asBytes()
+	);
 
 	expect(parsed).toBe("module content 1");
 
@@ -36,16 +36,17 @@ test("it should be network-first", async () => {
 	expect(mockLoader).toHaveBeenCalledTimes(2);
 	expect(result2).toBe("module content 2");
 
-	const cachedPlugins2 = await lix.db
-		.selectFrom("file")
-		.selectAll()
-		// @ts-expect-error - kysely doesn't know about GLOB
-		.where(sql`path GLOB '/cache/plugins/*'`)
-		.execute();
+	const cachedPlugins2 = (
+		await lix.execute(
+			"SELECT content FROM lix_file WHERE path LIKE '/cache/plugins/%'"
+		)
+	).rows;
 
 	expect(cachedPlugins2.length).toBe(1);
 
-	const parsed2 = new TextDecoder().decode(cachedPlugins2[0]!.data);
+	const parsed2 = new TextDecoder().decode(
+		cachedPlugins2[0]!.value("content").asBytes()
+	);
 
 	expect(parsed2).toBe("module content 2");
 });
@@ -55,7 +56,7 @@ test("it should throw the error from the loader if the cache does not exist", as
 
 	const mockModulePath = "https://mock.com/module.js";
 
-	const lix = await openLixInMemory({ blob: await newLixFile() });
+	const lix = await openLix();
 
 	await expect(
 		async () => await withCache(mockLoader, lix)(mockModulePath)
@@ -68,15 +69,12 @@ test("it should fallback to the cache if the loader fails", async () => {
 	const mockModulePath = "https://mock.com/module.js";
 	const mockModuleCachePath = "/cache/plugins/31i1etp0l413h";
 
-	const lix = await openLixInMemory({ blob: await newLixFile() });
+	const lix = await openLix();
 
-	await lix.db
-		.insertInto("file")
-		.values({
-			path: mockModuleCachePath,
-			data: new TextEncoder().encode("cached module content"),
-		})
-		.execute();
+	await lix.execute("INSERT INTO lix_file (path, content) VALUES ($1, $2)", [
+		mockModuleCachePath,
+		new TextEncoder().encode("cached module content"),
+	]);
 
 	const result = await withCache(mockLoader, lix)(mockModulePath);
 	expect(result).toBe("cached module content");

--- a/packages/sdk/src/plugin/cache.ts
+++ b/packages/sdk/src/plugin/cache.ts
@@ -21,14 +21,14 @@ async function readModuleFromCache(
 	const moduleHash = escape(moduleURI);
 	const filePath = `/cache/plugins/${moduleHash}`;
 
-	const file = await lix.db
-		.selectFrom("file")
-		.where("path", "=", filePath)
-		.selectAll()
-		.executeTakeFirst();
+	const result = await lix.execute(
+		"SELECT content FROM lix_file WHERE path = $1",
+		[filePath]
+	);
+	const file = result.rows[0];
 
 	if (file) {
-		return new TextDecoder().decode(file.data);
+		return new TextDecoder().decode(file.value("content").asBytes());
 	}
 	return undefined;
 }
@@ -41,17 +41,10 @@ async function writeModuleToCache(
 	const moduleHash = escape(moduleURI);
 	const filePath = `/cache/plugins/${moduleHash}`;
 
-	await lix.db
-		.insertInto("file")
-		.values({
-			path: filePath,
-			data: new TextEncoder().encode(moduleContent),
-		})
-		// update the cache
-		.onConflict((oc) =>
-			oc.doUpdateSet({ data: new TextEncoder().encode(moduleContent) })
-		)
-		.execute();
+	await lix.execute(
+		"INSERT INTO lix_file (path, content) VALUES ($1, $2) ON CONFLICT (path) DO UPDATE SET content = excluded.content",
+		[filePath, new TextEncoder().encode(moduleContent)]
+	);
 }
 
 /**

--- a/packages/sdk/src/plugin/importPlugins.test.ts
+++ b/packages/sdk/src/plugin/importPlugins.test.ts
@@ -1,7 +1,7 @@
 import { test, expect, vi } from "vitest";
 import { importPlugins } from "./importPlugins.js";
 import { PluginImportError } from "./errors.js";
-import { newLixFile, openLixInMemory } from "@lix-js/sdk";
+import { openLix } from "@lix-js/sdk";
 
 test("it should preprocess a plugin", async () => {
 	global.fetch = vi.fn().mockResolvedValue({
@@ -9,7 +9,7 @@ test("it should preprocess a plugin", async () => {
 		text: vi.fn().mockResolvedValue("export default { key: 'mock' }"),
 	});
 
-	const lix = await openLixInMemory({ blob: await newLixFile() });
+	const lix = await openLix();
 	const result = await importPlugins({
 		lix,
 		settings: {
@@ -32,7 +32,7 @@ test("if a fetch fails, a plugin import error is expected", async () => {
 		ok: false,
 		statusText: "HTTP 404",
 	});
-	const lix = await openLixInMemory({ blob: await newLixFile() });
+	const lix = await openLix();
 
 	const result = await importPlugins({
 		lix,
@@ -50,7 +50,7 @@ test("if a fetch fails, a plugin import error is expected", async () => {
 });
 
 test("if a network error occurs during fetch, a plugin import error is expected", async () => {
-	const lix = await openLixInMemory({ blob: await newLixFile() });
+	const lix = await openLix();
 	global.fetch = vi.fn().mockRejectedValue(new Error("Network error"));
 
 	const result = await importPlugins({
@@ -80,7 +80,7 @@ test("it should filter message lint rules for legacy reasons", async () => {
 			.mockResolvedValue("export default { id: 'messageLintRule.something' }"),
 	});
 
-	const lix = await openLixInMemory({ blob: await newLixFile() });
+	const lix = await openLix();
 
 	const result = await importPlugins({
 		lix,
@@ -104,15 +104,12 @@ test("cache should work", async () => {
 	const mockModulePath = "https://mock.com/module.js";
 	const mockModuleCachePath = "/cache/plugins/31i1etp0l413h";
 
-	const lix = await openLixInMemory({ blob: await newLixFile() });
+	const lix = await openLix();
 
-	await lix.db
-		.insertInto("file")
-		.values({
-			path: mockModuleCachePath,
-			data: new TextEncoder().encode("export default { key: 'mock' }"),
-		})
-		.execute();
+	await lix.execute("INSERT INTO lix_file (path, content) VALUES ($1, $2)", [
+		mockModuleCachePath,
+		new TextEncoder().encode("export default { key: 'mock' }"),
+	]);
 
 	const result = await importPlugins({
 		lix,

--- a/packages/sdk/src/project/api.ts
+++ b/packages/sdk/src/project/api.ts
@@ -2,18 +2,10 @@ import type { Kysely } from "kysely";
 import type { InlangDatabaseSchema } from "../database/schema.js";
 import type { InlangPlugin } from "../plugin/schema.js";
 import type { ProjectSettings } from "../json-schema/settings.js";
-import type { Lix } from "@lix-js/sdk";
-import type { SqliteWasmDatabase } from "sqlite-wasm-kysely";
+import type { InlangLix } from "../lix/withDb.js";
 
 export type InlangProject = {
 	db: Kysely<InlangDatabaseSchema>;
-	/**
-	 * @deprecated Don't use this. Only an internal hack to unblock
-	 * fink v2.
-	 *
-	 * TODO remove this
-	 */
-	_sqlite: SqliteWasmDatabase;
 	id: {
 		/**
 		 * Stable for packed `.inlang` files. For unpacked projects loaded from a
@@ -31,7 +23,7 @@ export type InlangProject = {
 		get: () => Promise<ProjectSettings>;
 		set: (settings: ProjectSettings) => Promise<void>;
 	};
-	lix: Lix;
+	lix: InlangLix;
 	importFiles: (args: {
 		pluginKey: InlangPlugin["key"];
 		files: ImportFile[];

--- a/packages/sdk/src/project/loadProject.ts
+++ b/packages/sdk/src/project/loadProject.ts
@@ -1,10 +1,7 @@
-import { toBlob, type Account, type Lix } from "@lix-js/sdk";
+import type { Lix } from "@lix-js/sdk";
+import type { Account } from "../lix/compat.js";
 import type { InlangPlugin } from "../plugin/schema.js";
 import type { ProjectSettings } from "../json-schema/settings.js";
-import {
-	contentFromDatabase,
-	type SqliteWasmDatabase,
-} from "sqlite-wasm-kysely";
 import { initDb } from "../database/initDb.js";
 import {
 	importPlugins,
@@ -15,12 +12,13 @@ import { withLanguageTagToLocaleMigration } from "../migrations/v2/withLanguageT
 import { v4 } from "uuid";
 import { importFiles } from "../import-export/importFiles.js";
 import { exportFiles } from "../import-export/exportFiles.js";
+import { projectToBlob } from "./snapshot.js";
+import { withInlangLixDb } from "../lix/withDb.js";
 
 /**
  * Common load project logic.
  */
 export async function loadProject(args: {
-	sqlite: SqliteWasmDatabase;
 	lix: Lix;
 	/**
 	 * The account that loaded the project.
@@ -54,18 +52,14 @@ export async function loadProject(args: {
 	 */
 	preprocessPluginBeforeImport?: PreprocessPluginBeforeImportFunction;
 }): Promise<InlangProject> {
-	const db = initDb({ sqlite: args.sqlite });
+	const db = initDb({ lix: args.lix });
 
 	await maybeMigrateFirstProjectId({ lix: args.lix });
 
-	const settingsFile = await args.lix.db
-		.selectFrom("file")
-		.select("data")
-		.where("path", "=", "/settings.json")
-		.executeTakeFirstOrThrow();
+	const settingsFile = await readLixFile(args.lix, "/settings.json");
 
 	const settings = withLanguageTagToLocaleMigration(
-		JSON.parse(new TextDecoder().decode(settingsFile.data)) as ProjectSettings
+		JSON.parse(new TextDecoder().decode(settingsFile)) as ProjectSettings
 	);
 
 	const importedPlugins = await importPlugins({
@@ -75,6 +69,14 @@ export async function loadProject(args: {
 	});
 
 	const plugins = [...(args.providePlugins ?? []), ...importedPlugins.plugins];
+	const projectId = new TextDecoder().decode(
+		await readLixFile(args.lix, "/project_id")
+	);
+	const inlangLix = await withInlangLixDb({
+		lix: args.lix,
+		projectId,
+		account: args.account,
+	});
 
 	// const state = createProjectState({
 	// 	...args,
@@ -85,23 +87,16 @@ export async function loadProject(args: {
 		db,
 		id: {
 			get: async () => {
-				const file = await args.lix.db
-					.selectFrom("file")
-					.where("path", "=", "/project_id")
-					.select("file.data")
-					.executeTakeFirstOrThrow();
-				return new TextDecoder().decode(file.data);
+				return new TextDecoder().decode(
+					await readLixFile(args.lix, "/project_id")
+				);
 			},
 		},
 		settings: {
 			get: async () => {
-				const file = await args.lix.db
-					.selectFrom("file")
-					.where("path", "=", "/settings.json")
-					.select("file.data")
-					.executeTakeFirstOrThrow();
+				const file = await readLixFile(args.lix, "/settings.json");
 				return withLanguageTagToLocaleMigration(
-					JSON.parse(new TextDecoder().decode(file.data))
+					JSON.parse(new TextDecoder().decode(file))
 				);
 			},
 			set: async (newSettings) => {
@@ -109,15 +104,13 @@ export async function loadProject(args: {
 				cloned.languageTags = cloned.locales;
 				cloned.sourceLanguageTag = cloned.baseLocale;
 
-				await args.lix.db
-					.updateTable("file")
-					.where("path", "=", "/settings.json")
-					.set({
-						data: new TextEncoder().encode(
-							JSON.stringify(cloned, undefined, 2)
-						),
-					})
-					.execute();
+				await args.lix.execute(
+					"UPDATE lix_file SET content = $1 WHERE path = $2",
+					[
+						new TextEncoder().encode(JSON.stringify(cloned, undefined, 2)),
+						"/settings.json",
+					]
+				);
 			},
 		},
 		plugins: {
@@ -128,14 +121,10 @@ export async function loadProject(args: {
 		},
 		// errors: state.errors,
 		importFiles: async ({ files, pluginKey }) => {
-			const settingsFile = await args.lix.db
-				.selectFrom("file")
-				.where("path", "=", "/settings.json")
-				.select("file.data")
-				.executeTakeFirstOrThrow();
+			const settingsFile = await readLixFile(args.lix, "/settings.json");
 
 			const settings = JSON.parse(
-				new TextDecoder().decode(settingsFile.data)
+				new TextDecoder().decode(settingsFile)
 			) as ProjectSettings;
 
 			return await importFiles({
@@ -148,14 +137,10 @@ export async function loadProject(args: {
 			});
 		},
 		exportFiles: async ({ pluginKey }) => {
-			const settingsFile = await args.lix.db
-				.selectFrom("file")
-				.where("path", "=", "/settings.json")
-				.select("file.data")
-				.executeTakeFirstOrThrow();
+			const settingsFile = await readLixFile(args.lix, "/settings.json");
 
 			const settings = JSON.parse(
-				new TextDecoder().decode(settingsFile.data)
+				new TextDecoder().decode(settingsFile)
 			) as ProjectSettings;
 
 			return (
@@ -169,29 +154,12 @@ export async function loadProject(args: {
 			).map((output) => ({ ...output, pluginKey }));
 		},
 		close: async () => {
-			await saveDbToLix({ sqlite: args.sqlite, lix: args.lix });
 			await db.destroy();
-			await args.lix.db.destroy();
+			await args.lix.close();
 		},
-		_sqlite: args.sqlite,
-		toBlob: async () => {
-			await saveDbToLix({ sqlite: args.sqlite, lix: args.lix });
-			return await toBlob({ lix: args.lix });
-		},
-		lix: args.lix,
+		toBlob: async () => await projectToBlob(args.lix),
+		lix: inlangLix,
 	};
-}
-
-async function saveDbToLix(args: {
-	sqlite: SqliteWasmDatabase;
-	lix: Lix;
-}): Promise<void> {
-	const data = contentFromDatabase(args.sqlite);
-	await args.lix.db
-		.updateTable("file")
-		.set("data", data)
-		.where("path", "=", "/db.sqlite")
-		.execute();
 }
 
 /**
@@ -200,19 +168,25 @@ async function saveDbToLix(args: {
  * Kept it in just in case.
  */
 async function maybeMigrateFirstProjectId(args: { lix: Lix }): Promise<void> {
-	const firstProjectIdFile = await args.lix.db
-		.selectFrom("file")
-		.select("data")
-		.where("path", "=", "/project_id")
-		.executeTakeFirst();
+	const firstProjectIdFile = await args.lix.execute(
+		"SELECT content FROM lix_file WHERE path = $1",
+		["/project_id"]
+	);
 
-	if (!firstProjectIdFile) {
-		await args.lix.db
-			.insertInto("file")
-			.values({
-				path: "/project_id",
-				data: new TextEncoder().encode(v4()),
-			})
-			.execute();
+	if (firstProjectIdFile.rows.length === 0) {
+		await args.lix.execute(
+			"INSERT INTO lix_file (path, content) VALUES ($1, $2)",
+			["/project_id", new TextEncoder().encode(v4())]
+		);
 	}
+}
+
+async function readLixFile(lix: Lix, path: string): Promise<Uint8Array> {
+	const result = await lix.execute(
+		"SELECT content FROM lix_file WHERE path = $1",
+		[path]
+	);
+	const data = result.rows[0]?.value("content").asBytes();
+	if (!data) throw new Error(`Missing project file: ${path}`);
+	return data;
 }

--- a/packages/sdk/src/project/loadProjectFromDirectory.test.ts
+++ b/packages/sdk/src/project/loadProjectFromDirectory.test.ts
@@ -391,12 +391,10 @@ describe("it should keep files between the inlang directory and lix in sync", as
 
 		const files = await project.lix.db.selectFrom("file").selectAll().execute();
 
-		expect(files.length).toBe(
-			6 + 1 /* the db.sqlite file */ + 1 /* project_id */
-		);
+		expect(files.length).toBe(6 + 1 /* project_id */);
 
 		const filesByPath = files.reduce((acc, file) => {
-			acc[file.path] = new TextDecoder().decode(file.data);
+			acc[file.path] = new TextDecoder().decode(file.content);
 			return acc;
 		}, {} as any);
 
@@ -459,7 +457,7 @@ describe("it should keep files between the inlang directory and lix in sync", as
 		);
 
 		const filesByPath = files.reduce((acc, file) => {
-			acc[file.path] = new TextDecoder().decode(file.data);
+			acc[file.path] = new TextDecoder().decode(file.content);
 			return acc;
 		}, {} as any);
 
@@ -535,7 +533,7 @@ describe("it should keep files between the inlang directory and lix in sync", as
 			.where("path", "=", "/file-created-on-fs.txt")
 			.executeTakeFirstOrThrow();
 
-		expect(new TextDecoder().decode(randomFileInLix.data)).toBe(
+		expect(new TextDecoder().decode(randomFileInLix.content)).toBe(
 			"value written by fs"
 		);
 	});
@@ -568,7 +566,7 @@ describe("it should keep files between the inlang directory and lix in sync", as
 			.executeTakeFirstOrThrow();
 
 		const settingsAfterUpdateOnDisk = JSON.parse(
-			new TextDecoder().decode(fileInLix.data)
+			new TextDecoder().decode(fileInLix.content)
 		);
 
 		expect(settingsAfterUpdateOnDisk.baseLocale).toBe(
@@ -622,7 +620,7 @@ describe("it should keep files between the inlang directory and lix in sync", as
 			.insertInto("file")
 			.values({
 				path: "/file-created-in.lix.txt",
-				data: new TextEncoder().encode("random value lix"),
+				content: new TextEncoder().encode("random value lix"),
 			})
 			.execute();
 
@@ -651,7 +649,7 @@ describe("it should keep files between the inlang directory and lix in sync", as
 			.updateTable("file")
 			.where("path", "=", "/settings.json")
 			.set({
-				data: new TextEncoder().encode(
+				content: new TextEncoder().encode(
 					JSON.stringify({ ...mockSettings, baseLocale: "brand-new-locale2" })
 				),
 			})
@@ -713,7 +711,7 @@ describe("it should keep files between the inlang directory and lix in sync", as
 			.updateTable("file")
 			.where("path", "=", "/settings.json")
 			.set({
-				data: new TextEncoder().encode(
+				content: new TextEncoder().encode(
 					JSON.stringify({ ...mockSettings, baseLocale: "lix-version" })
 				),
 			})
@@ -734,7 +732,7 @@ describe("it should keep files between the inlang directory and lix in sync", as
 			.executeTakeFirstOrThrow();
 
 		const settingsAfterUpdateOnDiskAndLix = JSON.parse(
-			new TextDecoder().decode(fileInLixUpdated.data)
+			new TextDecoder().decode(fileInLixUpdated.content)
 		);
 
 		expect(settingsAfterUpdateOnDiskAndLix.baseLocale).toBe("fs-version");
@@ -1062,7 +1060,7 @@ test("it can import plugins via http", async () => {
 
 	expect(
 		pluginCache.some(
-			(file) => new TextDecoder().decode(file.data) === mockPluginModule
+			(file) => new TextDecoder().decode(file.content) === mockPluginModule
 		),
 		"expecting the plugin to be cached"
 	).toBe(true);

--- a/packages/sdk/src/project/loadProjectFromDirectory.ts
+++ b/packages/sdk/src/project/loadProjectFromDirectory.ts
@@ -1,6 +1,6 @@
 import { newProject } from "./newProject.js";
 import { loadProjectInMemory } from "./loadProjectInMemory.js";
-import { closeLix, openLixInMemory, toBlob, type Lix } from "@lix-js/sdk";
+import { openLix, type Lix } from "@lix-js/sdk";
 import fs from "node:fs";
 import nodePath from "node:path";
 import type { InlangPlugin } from "../plugin/schema.js";
@@ -14,6 +14,8 @@ import { absolutePathFromProject, withAbsolutePaths } from "./path-helpers.js";
 import { saveProjectToDirectory } from "./saveProjectToDirectory.js";
 import { ENV_VARIABLES } from "../services/env-variables/index.js";
 import { compareSemver, pickHighestVersion, readProjectMeta } from "./meta.js";
+import { registerInlangSchemas } from "../database/registerSchemas.js";
+import { projectToBlob, restoreProjectBlob } from "./snapshot.js";
 
 /**
  * Loads a project from a directory.
@@ -84,7 +86,9 @@ export async function loadProjectFromDirectory(
 		settings,
 	});
 
-	const tempLix = await openLixInMemory({ blob: newLix });
+	const tempLix = await openLix();
+	await registerInlangSchemas(tempLix);
+	await restoreProjectBlob(tempLix, newLix);
 
 	await syncLixFsFiles({
 		fs: args.fs,
@@ -104,11 +108,11 @@ export async function loadProjectFromDirectory(
 			? // reversing the id to have distinguishable lix ids from inlang ids
 				[{ key: "lix_id", value: inlangId }]
 			: undefined,
-		blob: await toBlob({ lix: tempLix }),
+		blob: await projectToBlob(tempLix),
 	});
 
 	// Closing the temp lix
-	await closeLix({ lix: tempLix });
+	await tempLix.close();
 
 	await syncLixFsFiles({
 		fs: args.fs,
@@ -234,17 +238,11 @@ async function loadLegacyMessages(args: {
 		// @ts-expect-error - type mismatch
 		nodeishFs: withAbsolutePaths(args.fs.promises, args.projectPath),
 	});
-	const upsertQueries = [];
-
 	for (const legacyMessage of loadedLegacyMessages) {
 		const messageBundle = fromMessageV1(legacyMessage);
-
-		upsertQueries.push(
-			upsertBundleNestedMatchByProperties(args.project.db, messageBundle)
-		);
+		// One in-memory Lix handle owns one transaction at a time.
+		await upsertBundleNestedMatchByProperties(args.project.db, messageBundle);
 	}
-
-	return await Promise.all(upsertQueries);
 }
 
 type FsFileState = Record<
@@ -347,11 +345,15 @@ async function syncLixFsFiles(args: {
 
 	async function checkLixState(currentLixState: FsFileState) {
 		// go through all files in lix and check there state
-		const filesInLix = await args.lix.db
-			.selectFrom("file")
-			.where("path", "not like", "%db.sqlite")
-			.selectAll()
-			.execute();
+		const filesInLix = (
+			await args.lix.execute(
+				"SELECT path, content FROM lix_file WHERE path NOT LIKE $1",
+				["%db.sqlite"]
+			)
+		).rows.map((row) => ({
+			path: row.get("path") as string,
+			content: row.value("content").asBytes()!,
+		}));
 
 		for (const fileInLix of filesInLix) {
 			if (!shouldSyncPath(fileInLix.path)) {
@@ -361,20 +363,20 @@ async function syncLixFsFiles(args: {
 			// NOTE we could start with comparing the mdate and skip file read completely...
 			if (!currentStateOfFileInLix) {
 				currentLixState[fileInLix.path] = {
-					content: new Uint8Array(fileInLix.data).buffer,
+				content: new Uint8Array(fileInLix.content).buffer,
 					state: "unknown",
 				};
 			} else {
 				if (
 					arrayBuffersEqual(
 						currentStateOfFileInLix.content,
-						fileInLix.data.buffer as ArrayBuffer
+						fileInLix.content.buffer as ArrayBuffer
 					)
 				) {
 					currentStateOfFileInLix.state = "known";
 				} else {
 					currentStateOfFileInLix.state = "updated";
-					currentStateOfFileInLix.content = fileInLix.data
+					currentStateOfFileInLix.content = fileInLix.content
 						.buffer as ArrayBuffer;
 				}
 			}
@@ -511,18 +513,16 @@ async function syncLixFsFiles(args: {
 						);
 					} else if (lixState.state === "known") {
 						// file is in known state with lix - means we have only changes on the fs - easy
-						await args.lix.db
-							.deleteFrom("file")
-							.where("path", "=", path)
-							.execute();
+						await args.lix.execute("DELETE FROM lix_file WHERE path = $1", [
+							path,
+						]);
 						// NOTE: states where both are gone will get removed in the lix state loop
 						lixState.state = "gone";
 					} else if (lixState.state === "updated") {
 						// seems like we saw an update on the file in fs while some changes on lix have not been reached fs? FS -> Winns?
-						await args.lix.db
-							.deleteFrom("file")
-							.where("path", "=", path)
-							.execute();
+						await args.lix.execute("DELETE FROM lix_file WHERE path = $1", [
+							path,
+						]);
 						// NOTE: states where both are gone will get removed in the lix state loop
 						lixState.state = "gone";
 						fsState.state = "gone";
@@ -653,16 +653,10 @@ async function upsertFileInLix(
 		posixPath = "/" + posixPath;
 	}
 
-	await args.lix.db
-		.insertInto("file") // change queue
-		.values({
-			path: posixPath,
-			data: new Uint8Array(data),
-		})
-		.onConflict((oc) =>
-			oc.column("path").doUpdateSet({ data: new Uint8Array(data) })
-		)
-		.execute();
+	await args.lix.execute(
+		"INSERT INTO lix_file (path, content) VALUES ($1, $2) ON CONFLICT (path) DO UPDATE SET content = excluded.content",
+		[posixPath, new Uint8Array(data)]
+	);
 }
 /**
  * Filters legacy load and save messages plugins.

--- a/packages/sdk/src/project/loadProjectInMemory.ts
+++ b/packages/sdk/src/project/loadProjectInMemory.ts
@@ -1,6 +1,8 @@
-import { openLixInMemory, type NewKeyValue } from "@lix-js/sdk";
-import { createInMemoryDatabase, importDatabase } from "sqlite-wasm-kysely";
+import { openLix } from "@lix-js/sdk";
+import type { NewKeyValue } from "../lix/compat.js";
+import { registerInlangSchemas } from "../database/registerSchemas.js";
 import { loadProject } from "./loadProject.js";
+import { restoreProjectBlob } from "./snapshot.js";
 
 /**
  * Load a project from a blob in memory.
@@ -9,30 +11,22 @@ export async function loadProjectInMemory(
 	args: {
 		blob: Blob;
 		lixKeyValues?: NewKeyValue[];
-	} & Omit<Parameters<typeof loadProject>[0], "sqlite" | "lix">
+	} & Omit<Parameters<typeof loadProject>[0], "lix">
 ) {
-	const lix = await openLixInMemory({
-		blob: args.blob,
-		account: args.account,
-		keyValues: args.lixKeyValues,
-		providePlugins: [
-			// inlangLixPluginV1
-		],
-	});
-
-	const dbFile = await lix.db
-		.selectFrom("file")
-		.select("data")
-		.where("path", "=", "/db.sqlite")
-		.executeTakeFirstOrThrow();
-
-	const sqlite = await createInMemoryDatabase({});
-	importDatabase({ db: sqlite, content: new Uint8Array(dbFile.data) });
+	const lix = await openLix();
+	await registerInlangSchemas(lix);
+	await restoreProjectBlob(lix, args.blob);
+	const projectId = args.lixKeyValues?.find((entry) => entry.key === "lix_id");
+	if (typeof projectId?.value === "string") {
+		await lix.execute(
+			"UPDATE lix_file SET content = $1 WHERE path = '/project_id'",
+			[new TextEncoder().encode(projectId.value)]
+		);
+	}
 
 	return await loadProject({
 		// pass common arguments to loadProject
 		...args,
-		sqlite,
 		lix,
 	});
 }

--- a/packages/sdk/src/project/newProject.ts
+++ b/packages/sdk/src/project/newProject.ts
@@ -1,10 +1,8 @@
-import { newLixFile, openLixInMemory, toBlob } from "@lix-js/sdk";
+import { openLix } from "@lix-js/sdk";
 import type { ProjectSettings } from "../json-schema/settings.js";
-import {
-	contentFromDatabase,
-	createInMemoryDatabase,
-} from "sqlite-wasm-kysely";
-import { initDb } from "../database/initDb.js";
+import { registerInlangSchemas } from "../database/registerSchemas.js";
+import { projectToBlob } from "./snapshot.js";
+import { v4 } from "uuid";
 
 /**
  * Creates a new inlang project.
@@ -15,56 +13,37 @@ import { initDb } from "../database/initDb.js";
 export async function newProject(args?: {
 	settings?: ProjectSettings;
 }): Promise<Blob> {
-	const sqlite = await createInMemoryDatabase({
-		readOnly: false,
-	});
-	initDb({ sqlite });
-
+	const lix = await openLix();
 	try {
-		const inlangDbContent = contentFromDatabase(sqlite);
-
-		const lix = await openLixInMemory({ blob: await newLixFile() });
-
-		const { value: lixId } = await lix.db
-			.selectFrom("key_value")
-			.select("value")
-			.where("key", "=", "lix_id")
-			.executeTakeFirstOrThrow();
-
-		// write files to lix
-		await lix.db
-			.insertInto("file")
-			.values([
-				{
-					path: "/db.sqlite",
-					data: inlangDbContent,
-				},
-				{
-					path: "/settings.json",
-					data: new TextEncoder().encode(
+		await registerInlangSchemas(lix);
+		const projectId = v4();
+		await lix.executeBatch([
+			{
+				sql: "INSERT INTO lix_file (path, content) VALUES ($1, $2)",
+				params: [
+					"/settings.json",
+					new TextEncoder().encode(
 						JSON.stringify(
 							args?.settings ?? defaultProjectSettings,
 							undefined,
 							2
 						)
 					),
-				},
-				{
-					path: "/project_id",
-					data: new TextEncoder().encode(lixId),
-				},
-			])
-			.execute();
-		const blob = toBlob({ lix });
-		lix.sqlite.close();
-		return blob;
+				],
+			},
+			{
+				sql: "INSERT INTO lix_file (path, content) VALUES ($1, $2)",
+				params: ["/project_id", new TextEncoder().encode(projectId)],
+			},
+		]);
+		return await projectToBlob(lix);
 	} catch (e) {
 		const error = new Error(`Failed to create new inlang project: ${e}`, {
 			cause: e,
 		});
 		throw error;
 	} finally {
-		sqlite.close();
+		await lix.close();
 	}
 }
 

--- a/packages/sdk/src/project/saveProjectToDirectory.ts
+++ b/packages/sdk/src/project/saveProjectToDirectory.ts
@@ -90,10 +90,12 @@ export async function saveProjectToDirectory(args: {
 	}
 	const fsModule = getPromisesFs(args.fs);
 
-	const files = await args.project.lix.db
-		.selectFrom("file")
-		.selectAll()
-		.execute();
+	const files = (
+		await args.project.lix.execute("SELECT path, content FROM lix_file")
+	).rows.map((row) => ({
+		path: row.get("path") as string,
+		content: row.value("content").asBytes()!,
+	}));
 
 	const gitignoreContent = new TextEncoder().encode(
 		"# IF GIT SHOWED THAT THIS FILE CHANGED\n#\n# 1. RUN THE FOLLOWING COMMAND\n#\n# ---\n# git rm --cached '**/*.inlang/.gitignore'\n# ---\n#\n# 2. COMMIT THE CHANGE\n#\n# ---\n# git commit -m \"fix: remove tracked .gitignore from inlang project\"\n# ---\n#\n# Inlang handles the gitignore itself starting with version ^2.5.\n#\n# everything is ignored except settings.json\n*\n!settings.json"
@@ -129,7 +131,7 @@ export async function saveProjectToDirectory(args: {
 		}
 		const p = path.join(args.path, file.path);
 		await fsModule.mkdir(path.dirname(p), { recursive: true });
-		await fsModule.writeFile(p, new Uint8Array(file.data));
+		await fsModule.writeFile(p, new Uint8Array(file.content));
 	}
 
 	if (shouldWriteGitignore) {

--- a/packages/sdk/src/project/snapshot.ts
+++ b/packages/sdk/src/project/snapshot.ts
@@ -1,0 +1,99 @@
+import type { Lix, LixBatchStatement } from "@lix-js/sdk";
+import type { Bundle, Message, Variant } from "../database/schema.js";
+
+const FORMAT = "inlang-lix-memory-v1";
+
+type Snapshot = {
+	format: typeof FORMAT;
+	files: Array<{ path: string; data: string }>;
+	bundles: Bundle[];
+	messages: Message[];
+	variants: Variant[];
+};
+
+export async function projectToBlob(lix: Lix): Promise<Blob> {
+	const [files, bundles, messages, variants] = await Promise.all([
+		lix.execute("SELECT path, content FROM lix_file ORDER BY path"),
+		lix.execute("SELECT id, declarations FROM bundle ORDER BY id"),
+		lix.execute(
+			'SELECT id, "bundleId", locale, selectors FROM message ORDER BY id'
+		),
+		lix.execute(
+			'SELECT id, "messageId", matches, pattern FROM variant ORDER BY id'
+		),
+	]);
+
+	const snapshot: Snapshot = {
+		format: FORMAT,
+		files: files.rows.map((row) => ({
+			path: row.get("path") as string,
+			data: bytesToBase64(row.value("content").asBytes() ?? new Uint8Array()),
+		})),
+		bundles: bundles.rows.map((row) => row.toObject() as Bundle),
+		messages: messages.rows.map((row) => row.toObject() as Message),
+		variants: variants.rows.map((row) => row.toObject() as Variant),
+	};
+
+	return new Blob([JSON.stringify(snapshot)], {
+		type: "application/vnd.inlang.project+json",
+	});
+}
+
+export async function restoreProjectBlob(lix: Lix, blob: Blob): Promise<void> {
+	let snapshot: Snapshot;
+	try {
+		snapshot = JSON.parse(await blob.text()) as Snapshot;
+	} catch (cause) {
+		throw new Error(
+			"The project uses the legacy Lix SQLite format, which Lix 0.9 cannot open in memory.",
+			{ cause }
+		);
+	}
+	if (snapshot.format !== FORMAT) {
+		throw new Error(
+			`Unsupported inlang project format: ${String(snapshot.format)}`
+		);
+	}
+
+	const statements: LixBatchStatement[] = [];
+	for (const file of snapshot.files) {
+		statements.push({
+			sql: "INSERT INTO lix_file (path, content) VALUES ($1, $2)",
+			params: [file.path, base64ToBytes(file.data)],
+		});
+	}
+	for (const bundle of snapshot.bundles) {
+		statements.push({
+			sql: "INSERT INTO bundle (id, declarations) VALUES ($1, $2)",
+			params: [bundle.id, bundle.declarations],
+		});
+	}
+	for (const message of snapshot.messages) {
+		statements.push({
+			sql: 'INSERT INTO message (id, "bundleId", locale, selectors) VALUES ($1, $2, $3, $4)',
+			params: [message.id, message.bundleId, message.locale, message.selectors],
+		});
+	}
+	for (const variant of snapshot.variants) {
+		statements.push({
+			sql: 'INSERT INTO variant (id, "messageId", matches, pattern) VALUES ($1, $2, $3, $4)',
+			params: [variant.id, variant.messageId, variant.matches, variant.pattern],
+		});
+	}
+	if (statements.length > 0) await lix.executeBatch(statements);
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+	let binary = "";
+	for (let offset = 0; offset < bytes.length; offset += 0x8000) {
+		binary += String.fromCharCode(...bytes.subarray(offset, offset + 0x8000));
+	}
+	return btoa(binary);
+}
+
+function base64ToBytes(value: string): Uint8Array {
+	const binary = atob(value);
+	const bytes = new Uint8Array(binary.length);
+	for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+	return bytes;
+}

--- a/packages/sdk/src/query-utilities/compileBundleNestedBatch.ts
+++ b/packages/sdk/src/query-utilities/compileBundleNestedBatch.ts
@@ -1,0 +1,76 @@
+import type { CompiledQuery, Kysely } from "kysely";
+import type {
+	InlangDatabaseSchema,
+	NewBundleNested,
+} from "../database/schema.js";
+
+type NestedWriteMode = "insert" | "upsert";
+
+export function compileBundleNestedBatch(
+	db: Kysely<InlangDatabaseSchema>,
+	bundle: NewBundleNested,
+	mode: NestedWriteMode
+): readonly CompiledQuery[] {
+	const bundleId = bundle.id ?? crypto.randomUUID();
+	const queries: CompiledQuery[] = [];
+
+	const bundleInsert = db
+		.insertInto("bundle")
+		.values({ id: bundleId, declarations: bundle.declarations });
+	queries.push(
+		(mode === "upsert"
+			? bundleInsert.onConflict((oc) =>
+					oc.column("id").doUpdateSet({
+						declarations: bundle.declarations,
+					})
+				)
+			: bundleInsert
+		).compile()
+	);
+
+	for (const message of bundle.messages) {
+		const messageId = message.id ?? crypto.randomUUID();
+		const messageInsert = db.insertInto("message").values({
+			id: messageId,
+			bundleId,
+			locale: message.locale,
+			selectors: message.selectors,
+		});
+		queries.push(
+			(mode === "upsert"
+				? messageInsert.onConflict((oc) =>
+						oc.column("id").doUpdateSet({
+							bundleId,
+							locale: message.locale,
+							selectors: message.selectors,
+						})
+					)
+				: messageInsert
+			).compile()
+		);
+
+		for (const variant of message.variants) {
+			const variantId = variant.id ?? crypto.randomUUID();
+			const variantInsert = db.insertInto("variant").values({
+				id: variantId,
+				messageId,
+				matches: variant.matches,
+				pattern: variant.pattern,
+			});
+			queries.push(
+				(mode === "upsert"
+					? variantInsert.onConflict((oc) =>
+							oc.column("id").doUpdateSet({
+								messageId,
+								matches: variant.matches,
+								pattern: variant.pattern,
+							})
+						)
+					: variantInsert
+				).compile()
+			);
+		}
+	}
+
+	return queries;
+}

--- a/packages/sdk/src/query-utilities/insertBundleNested.ts
+++ b/packages/sdk/src/query-utilities/insertBundleNested.ts
@@ -3,44 +3,12 @@ import type {
 	InlangDatabaseSchema,
 	NewBundleNested,
 } from "../database/schema.js";
+import { executeLixBatch } from "../database/lixBatch.js";
+import { compileBundleNestedBatch } from "./compileBundleNestedBatch.js";
 
 export const insertBundleNested = async (
 	db: Kysely<InlangDatabaseSchema>,
 	bundle: NewBundleNested
 ): Promise<void> => {
-	await db.transaction().execute(async (trx) => {
-		const insertedBundle = await trx
-			.insertInto("bundle")
-			.values({
-				id: bundle.id,
-				declarations: bundle.declarations,
-			})
-			.returning("id")
-			.executeTakeFirstOrThrow();
-
-		for (const message of bundle.messages) {
-			const insertedMessage = await trx
-				.insertInto("message")
-				.values({
-					id: message.id,
-					bundleId: insertedBundle.id,
-					locale: message.locale,
-					selectors: message.selectors,
-				})
-				.returning("id")
-				.executeTakeFirstOrThrow();
-
-			for (const variant of message.variants) {
-				await trx
-					.insertInto("variant")
-					.values({
-						id: variant.id,
-						messageId: insertedMessage.id,
-						matches: variant.matches,
-						pattern: variant.pattern,
-					})
-					.execute();
-			}
-		}
-	});
+	await executeLixBatch(db, compileBundleNestedBatch(db, bundle, "insert"));
 };

--- a/packages/sdk/src/query-utilities/selectBundleNested.ts
+++ b/packages/sdk/src/query-utilities/selectBundleNested.ts
@@ -1,46 +1,97 @@
 import type { Kysely } from "kysely";
-import { jsonArrayFrom } from "kysely/helpers/sqlite";
-import type { InlangDatabaseSchema } from "../database/schema.js";
+import type {
+	BundleNested,
+	InlangDatabaseSchema,
+	MessageNested,
+	Variant,
+} from "../database/schema.js";
 
 /**
  * Select bundles with nested messages and variants.
  *
- * `{ bundle, messages: [{ message, variants: [{ variant }] }] }`
- *
- * @example
- *   // getting one bundle where id is 123
- *   await selectBundleNested(db)
- *     .where("bundle.id", "=", "123")
- *     .executeTakeFirst()
- *
- *   // getting all bundles
- *   await selectBundleNested(db)
- *     .execute()
+ * Lix uses DataFusion, which does not provide SQLite's json_group_array()
+ * helper. A flat left join keeps this to one engine round-trip and the small
+ * reconstruction below preserves the established SDK result shape.
  */
 export const selectBundleNested = (db: Kysely<InlangDatabaseSchema>) => {
-	return db.selectFrom("bundle").select((eb) => [
-		// select all columns from bundle
-		"id",
-		"declarations",
-		// select all columns from messages as "messages"
-		jsonArrayFrom(
-			eb
-				.selectFrom("message")
-				.select((eb) => [
-					// select all columns from message
-					"id",
-					"bundleId",
-					"locale",
-					"selectors",
-					// select all columns from variants as "variants"
-					jsonArrayFrom(
-						eb
-							.selectFrom("variant")
-							.select(["id", "messageId", "matches", "pattern"])
-							.whereRef("variant.messageId", "=", "message.id")
-					).as("variants"),
-				])
-				.whereRef("message.bundleId", "=", "bundle.id")
-		).as("messages"),
-	]);
+	let bundleId: string | undefined;
+
+	const query = {
+		where(column: "bundle.id", operator: "=", value: string) {
+			if (column !== "bundle.id" || operator !== "=") {
+				throw new Error("selectBundleNested only supports bundle.id equality");
+			}
+			bundleId = value;
+			return query;
+		},
+		selectAll() {
+			return query;
+		},
+		async execute(): Promise<BundleNested[]> {
+			let flatQuery = db
+				.selectFrom("bundle")
+				.leftJoin("message", "message.bundleId", "bundle.id")
+				.leftJoin("variant", "variant.messageId", "message.id")
+				.select([
+					"bundle.id as bundleId",
+					"bundle.declarations as bundleDeclarations",
+					"message.id as messageId",
+					"message.locale as messageLocale",
+					"message.selectors as messageSelectors",
+					"variant.id as variantId",
+					"variant.matches as variantMatches",
+					"variant.pattern as variantPattern",
+				]);
+			if (bundleId !== undefined) {
+				flatQuery = flatQuery.where("bundle.id", "=", bundleId);
+			}
+			const rows = await flatQuery.execute();
+			const bundles = new Map<string, BundleNested>();
+			const messages = new Map<string, MessageNested>();
+
+			for (const row of rows) {
+				let bundle = bundles.get(row.bundleId);
+				if (!bundle) {
+					bundle = {
+						id: row.bundleId,
+						declarations: row.bundleDeclarations,
+						messages: [],
+					};
+					bundles.set(row.bundleId, bundle);
+				}
+				if (row.messageId === null) continue;
+				let message = messages.get(row.messageId);
+				if (!message) {
+					message = {
+						id: row.messageId,
+						bundleId: row.bundleId,
+						locale: row.messageLocale!,
+						selectors: row.messageSelectors!,
+						variants: [],
+					};
+					messages.set(row.messageId, message);
+					bundle.messages.push(message);
+				}
+				if (row.variantId !== null) {
+					message.variants.push({
+						id: row.variantId,
+						messageId: row.messageId,
+						matches: row.variantMatches!,
+						pattern: row.variantPattern!,
+					} satisfies Variant);
+				}
+			}
+			return [...bundles.values()];
+		},
+		async executeTakeFirst(): Promise<BundleNested | undefined> {
+			return (await query.execute())[0];
+		},
+		async executeTakeFirstOrThrow(): Promise<BundleNested> {
+			const result = await query.executeTakeFirst();
+			if (!result) throw new Error("No bundle found");
+			return result;
+		},
+	};
+
+	return query;
 };

--- a/packages/sdk/src/query-utilities/upsertBundleNested.ts
+++ b/packages/sdk/src/query-utilities/upsertBundleNested.ts
@@ -3,59 +3,12 @@ import type {
 	InlangDatabaseSchema,
 	NewBundleNested,
 } from "../database/schema.js";
+import { executeLixBatch } from "../database/lixBatch.js";
+import { compileBundleNestedBatch } from "./compileBundleNestedBatch.js";
 
 export const upsertBundleNested = async (
 	db: Kysely<InlangDatabaseSchema>,
 	bundle: NewBundleNested
 ): Promise<void> => {
-	await db.transaction().execute(async (trx) => {
-		const insertedBundle = await trx
-			.insertInto("bundle")
-			.values({
-				id: bundle.id,
-				declarations: bundle.declarations,
-			})
-			.returning("id")
-			.onConflict((oc) =>
-				oc.column("id").doUpdateSet({
-					...bundle,
-					// @ts-expect-error - undefined
-					messages: undefined,
-				})
-			)
-			.executeTakeFirstOrThrow();
-
-		for (const message of bundle.messages) {
-			const insertedMessage = await trx
-				.insertInto("message")
-				.values({
-					id: message.id,
-					bundleId: insertedBundle.id,
-					locale: message.locale,
-					selectors: message.selectors,
-				})
-				.onConflict((oc) =>
-					oc.column("id").doUpdateSet({
-						...message,
-						// @ts-expect-error - undefined
-						variants: undefined,
-					})
-				)
-				.returning("id")
-				.executeTakeFirstOrThrow();
-
-			for (const variant of message.variants) {
-				await trx
-					.insertInto("variant")
-					.values({
-						id: variant.id,
-						messageId: insertedMessage.id,
-						matches: variant.matches,
-						pattern: variant.pattern,
-					})
-					.onConflict((oc) => oc.column("id").doUpdateSet(variant))
-					.execute();
-			}
-		}
-	});
+	await executeLixBatch(db, compileBundleNestedBatch(db, bundle, "upsert"));
 };

--- a/packages/sdk/src/schema-definitions/bundle.ts
+++ b/packages/sdk/src/schema-definitions/bundle.ts
@@ -1,0 +1,11 @@
+export const InlangBundleSchema = {
+	"x-lix-key": "bundle",
+	"x-lix-primary-key": ["/id"],
+	type: "object",
+	properties: {
+		id: { type: "string", "x-lix-default": "lix_uuid_v7()" },
+		declarations: { type: "array", items: { type: "object" }, default: [] },
+	},
+	required: ["id", "declarations"],
+	additionalProperties: false,
+} as const;

--- a/packages/sdk/src/schema-definitions/compat.ts
+++ b/packages/sdk/src/schema-definitions/compat.ts
@@ -1,0 +1,23 @@
+export const InlangKeyValueSchema = {
+	"x-lix-key": "key_value",
+	"x-lix-primary-key": ["/key"],
+	type: "object",
+	properties: {
+		key: { type: "string" },
+		value: { type: "string" },
+	},
+	required: ["key", "value"],
+	additionalProperties: false,
+} as const;
+
+export const InlangActiveAccountSchema = {
+	"x-lix-key": "active_account",
+	"x-lix-primary-key": ["/id"],
+	type: "object",
+	properties: {
+		id: { type: "string" },
+		name: { type: "string" },
+	},
+	required: ["id", "name"],
+	additionalProperties: false,
+} as const;

--- a/packages/sdk/src/schema-definitions/index.ts
+++ b/packages/sdk/src/schema-definitions/index.ts
@@ -1,0 +1,4 @@
+export { InlangBundleSchema } from "./bundle.js";
+export { InlangMessageSchema } from "./message.js";
+export { InlangVariantSchema } from "./variant.js";
+export { InlangActiveAccountSchema, InlangKeyValueSchema } from "./compat.js";

--- a/packages/sdk/src/schema-definitions/message.ts
+++ b/packages/sdk/src/schema-definitions/message.ts
@@ -1,0 +1,19 @@
+export const InlangMessageSchema = {
+	"x-lix-key": "message",
+	"x-lix-primary-key": ["/id"],
+	"x-lix-foreign-keys": [
+		{
+			properties: ["/bundleId"],
+			references: { schemaKey: "bundle", properties: ["/id"] },
+		},
+	],
+	type: "object",
+	properties: {
+		id: { type: "string", "x-lix-default": "lix_uuid_v7()" },
+		bundleId: { type: "string" },
+		locale: { type: "string" },
+		selectors: { type: "array", items: { type: "object" }, default: [] },
+	},
+	required: ["id", "bundleId", "locale", "selectors"],
+	additionalProperties: false,
+} as const;

--- a/packages/sdk/src/schema-definitions/variant.ts
+++ b/packages/sdk/src/schema-definitions/variant.ts
@@ -1,0 +1,19 @@
+export const InlangVariantSchema = {
+	"x-lix-key": "variant",
+	"x-lix-primary-key": ["/id"],
+	"x-lix-foreign-keys": [
+		{
+			properties: ["/messageId"],
+			references: { schemaKey: "message", properties: ["/id"] },
+		},
+	],
+	type: "object",
+	properties: {
+		id: { type: "string", "x-lix-default": "lix_uuid_v7()" },
+		messageId: { type: "string" },
+		matches: { type: "array", items: { type: "object" }, default: [] },
+		pattern: { type: "array", items: { type: "object" }, default: [] },
+	},
+	required: ["id", "messageId", "matches", "pattern"],
+	additionalProperties: false,
+} as const;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -692,7 +692,7 @@ importers:
         version: 1.10.6
       '@vitest/coverage-v8':
         specifier: 3.1.1
-        version: 3.1.1(@vitest/browser@3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(playwright@1.55.0)(vite@6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1))(vitest@3.1.1(@types/debug@4.1.12)(@types/node@24.10.2)(@vitest/browser@3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(playwright@1.55.0)(vite@6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1))(happy-dom@18.0.1)(jsdom@27.3.0(postcss@8.5.6))(lightningcss@1.30.2)(msw@2.10.2(@types/node@24.10.2)(typescript@5.7.3))(sass-embedded@1.89.2)(terser@5.36.0))
+        version: 3.1.1(@vitest/browser@3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(playwright@1.55.0)(vite@7.2.7(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1))(vitest@3.1.1(@types/debug@4.1.12)(@types/node@24.10.2)(@vitest/browser@3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(playwright@1.55.0)(vite@7.2.7(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1))(happy-dom@18.0.1)(jsdom@27.3.0(postcss@8.5.6))(lightningcss@1.30.2)(msw@2.10.2(@types/node@24.10.2)(typescript@5.7.3))(sass-embedded@1.89.2)(terser@5.36.0))
       esbuild:
         specifier: ^0.24.2
         version: 0.24.2
@@ -707,7 +707,7 @@ importers:
         version: 5.7.3
       vitest:
         specifier: 3.1.1
-        version: 3.1.1(@types/debug@4.1.12)(@types/node@24.10.2)(@vitest/browser@3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(playwright@1.55.0)(vite@6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1))(happy-dom@18.0.1)(jsdom@27.3.0(postcss@8.5.6))(lightningcss@1.30.2)(msw@2.10.2(@types/node@24.10.2)(typescript@5.7.3))(sass-embedded@1.89.2)(terser@5.36.0)
+        version: 3.1.1(@types/debug@4.1.12)(@types/node@24.10.2)(@vitest/browser@3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(playwright@1.55.0)(vite@7.2.7(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1))(happy-dom@18.0.1)(jsdom@27.3.0(postcss@8.5.6))(lightningcss@1.30.2)(msw@2.10.2(@types/node@24.10.2)(typescript@5.7.3))(sass-embedded@1.89.2)(terser@5.36.0)
 
   packages/plugins/t-function-matcher:
     dependencies:
@@ -765,8 +765,8 @@ importers:
   packages/sdk:
     dependencies:
       '@lix-js/sdk':
-        specifier: 0.4.10
-        version: 0.4.10(babel-plugin-macros@3.1.0)
+        specifier: 0.10.0
+        version: 0.10.0
       '@sinclair/typebox':
         specifier: ^0.31.17
         version: 0.31.28
@@ -1954,15 +1954,15 @@ packages:
 
   '@esbuild-kit/cjs-loader@2.4.4':
     resolution: {integrity: sha512-NfsJX4PdzhwSkfJukczyUiZGc7zNNWZcEAyqeISpDnn0PTfzMJR1aR8xAIPskBejIxBJbIgCCMzbaYa9SXepIg==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild-kit/esm-loader@2.6.5':
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild/aix-ppc64@0.19.12':
     resolution: {integrity: sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==}
@@ -3092,10 +3092,6 @@ packages:
     resolution: {integrity: sha512-zLGroi9EUiHuOjUOaglUVTFO7EWdo2OARMJLBO1Q5Ga/xJmSQb6XS1lhqEXBFAjgFarfEMX5YEJWWALogYV3wA==}
     deprecated: result is no longer used
 
-  '@inlang/sdk@0.36.3':
-    resolution: {integrity: sha512-wjsavc44H24v74tdEQ13FqZZcr43T106oEfHJnBLzEP55Zz2JJWABLund+DEdosZx+9E8mJBEW5JlVnlBwP3Zw==}
-    engines: {node: '>=18.0.0'}
-
   '@inlang/sdk@0.9.0':
     resolution: {integrity: sha512-iNujE/spsKiltnrYL+Vz65H+0dMFQ9i7FfMjSESrLT8UhEgxt7Gqgpvxp9hfKUu3k7XDrQ+911kQYpmiQSJB4A==}
     engines: {node: '>=18.0.0'}
@@ -3232,20 +3228,32 @@ packages:
   '@lit/task@1.0.3':
     resolution: {integrity: sha512-1gJGJl8WON+2j0y9xfcD+XsS1rvcy3XDgsIhcdUW++yTR8ESjZW6o7dn8M8a4SZM8NnJe6ynS2cKWwsbfLOurg==}
 
-  '@lix-js/client@2.2.1':
-    resolution: {integrity: sha512-6DTJdRN2L2a1A8OxW1Wqh3ZOORqq8+YlCALMF5UMoxhfHE4Fcq9FZztMkAV+KwhrDSsp0USWvD9myG0XX+v6QQ==}
-    deprecated: use the lix sdk instead https://www.npmjs.com/package/@lix-js/sdk
-
   '@lix-js/fs@2.2.0':
     resolution: {integrity: sha512-B9X3FjD8WmdG7tbA44JuniSO0KdKBWnjfxl8zpgrDCkavrp/GP7U0xxBkc0WgeeoHjQ/pkqq9VqtWB2kS9jIUg==}
     deprecated: use the lix sdk instead https://www.npmjs.com/package/@lix-js/sdk
 
-  '@lix-js/sdk@0.4.10':
-    resolution: {integrity: sha512-0dMInAJK/67guTG5rRZaCEhvzC5cCXENOjaePA5AqMXrCE97kaY7SRor9e2vnoGsFIiGqXKlT0MCIoZj36G0gg==}
-    engines: {node: '>=18'}
+  '@lix-js/sdk-darwin-arm64@0.10.0':
+    resolution: {integrity: sha512-XyFd0O39ZrwN8FZIGR3TRDpvCUEqq8C3ax51dlkUn0Kz06SbYrMp3wdzmuKVN47RY/oXq4OGMx+UYi99LcZf7w==}
+    cpu: [arm64]
+    os: [darwin]
 
-  '@lix-js/server-protocol-schema@0.1.1':
-    resolution: {integrity: sha512-jBeALB6prAbtr5q4vTuxnRZZv1M2rKe8iNqRQhFJ4Tv7150unEa0vKyz0hs8Gl3fUGsWaNJBh3J8++fpbrpRBQ==}
+  '@lix-js/sdk-linux-arm64@0.10.0':
+    resolution: {integrity: sha512-81FWVa6RppbiGLXqcQfUp87SiHz9zkrEfVNpFRzs4c7zYN7Oss0ibAsZdXuUSMVa3J9YLXmZar++tkefg8hevQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@lix-js/sdk-linux-x64@0.10.0':
+    resolution: {integrity: sha512-3XWHuTd68Kd1ZeRl6rinohRJbEgDM6xsXnsoSzlNA4HKJNPmVajYbc4fzCv6F2Gpt/VZ6ZYKVofPIkaRoFNt+g==}
+    cpu: [x64]
+    os: [linux]
+
+  '@lix-js/sdk-win32-x64@0.10.0':
+    resolution: {integrity: sha512-i3Yx4fHJ5mz1y54Yq1sWU2Z0upHsAXXiq00e+L0klOlb0WPQHYhwFXx8RHQwrvq+mvY4FsS8UgA7ui8xJYUv+A==}
+    cpu: [x64]
+    os: [win32]
+
+  '@lix-js/sdk@0.10.0':
+    resolution: {integrity: sha512-59NKGDPiikFOepU7G36Bt5i/P3TO6g+16QsnP5EfB9plUfVgQnPaFcLuHIqpOlaPS3L/C/d/TTcEKhVmxTwjBw==}
 
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -3474,119 +3482,6 @@ packages:
 
   '@nx/workspace@18.3.5':
     resolution: {integrity: sha512-C5+IhzKx6AUu8N+yURkYfDdDlv0NHkxsI1yqQIgLmqOsZ/nTNLps052QOTb6zYejSp+DbzkZ0H7SGXNO3Cd0+g==}
-
-  '@octokit/app@14.1.0':
-    resolution: {integrity: sha512-g3uEsGOQCBl1+W1rgfwoRFUIR6PtvB2T1E4RpygeUU5LrLvlOqcxrt5lfykIeRpUPpupreGJUYl70fqMDXdTpw==}
-    engines: {node: '>= 18'}
-
-  '@octokit/auth-app@6.1.3':
-    resolution: {integrity: sha512-dcaiteA6Y/beAlDLZOPNReN3FGHu+pARD6OHfh3T9f3EO09++ec+5wt3KtGGSSs2Mp5tI8fQwdMOEnrzBLfgUA==}
-    engines: {node: '>= 18'}
-
-  '@octokit/auth-oauth-app@7.1.0':
-    resolution: {integrity: sha512-w+SyJN/b0l/HEb4EOPRudo7uUOSW51jcK1jwLa+4r7PA8FPFpoxEnHBHMITqCsc/3Vo2qqFjgQfz/xUUvsSQnA==}
-    engines: {node: '>= 18'}
-
-  '@octokit/auth-oauth-device@6.1.0':
-    resolution: {integrity: sha512-FNQ7cb8kASufd6Ej4gnJ3f1QB5vJitkoV1O0/g6e6lUsQ7+VsSNRHRmFScN2tV4IgKA12frrr/cegUs0t+0/Lw==}
-    engines: {node: '>= 18'}
-
-  '@octokit/auth-oauth-user@4.1.0':
-    resolution: {integrity: sha512-FrEp8mtFuS/BrJyjpur+4GARteUCrPeR/tZJzD8YourzoVhRics7u7we/aDcKv+yywRNwNi/P4fRi631rG/OyQ==}
-    engines: {node: '>= 18'}
-
-  '@octokit/auth-token@4.0.0':
-    resolution: {integrity: sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==}
-    engines: {node: '>= 18'}
-
-  '@octokit/auth-unauthenticated@5.0.1':
-    resolution: {integrity: sha512-oxeWzmBFxWd+XolxKTc4zr+h3mt+yofn4r7OfoIkR/Cj/o70eEGmPsFbueyJE2iBAGpjgTnEOKM3pnuEGVmiqg==}
-    engines: {node: '>= 18'}
-
-  '@octokit/core@5.2.0':
-    resolution: {integrity: sha512-1LFfa/qnMQvEOAdzlQymH0ulepxbxnCYAKJZfMci/5XJyIHWgEYnDmgnKakbTh7CH2tFQ5O60oYDvns4i9RAIg==}
-    engines: {node: '>= 18'}
-
-  '@octokit/endpoint@9.0.5':
-    resolution: {integrity: sha512-ekqR4/+PCLkEBF6qgj8WqJfvDq65RH85OAgrtnVp1mSxaXF03u2xW/hUdweGS5654IlC0wkNYC18Z50tSYTAFw==}
-    engines: {node: '>= 18'}
-
-  '@octokit/graphql@7.1.0':
-    resolution: {integrity: sha512-r+oZUH7aMFui1ypZnAvZmn0KSqAUgE1/tUXIWaqUCa1758ts/Jio84GZuzsvUkme98kv0WFY8//n0J1Z+vsIsQ==}
-    engines: {node: '>= 18'}
-
-  '@octokit/oauth-app@6.1.0':
-    resolution: {integrity: sha512-nIn/8eUJ/BKUVzxUXd5vpzl1rwaVxMyYbQkNZjHrF7Vk/yu98/YDF/N2KeWO7uZ0g3b5EyiFXFkZI8rJ+DH1/g==}
-    engines: {node: '>= 18'}
-
-  '@octokit/oauth-authorization-url@6.0.2':
-    resolution: {integrity: sha512-CdoJukjXXxqLNK4y/VOiVzQVjibqoj/xHgInekviUJV73y/BSIcwvJ/4aNHPBPKcPWFnd4/lO9uqRV65jXhcLA==}
-    engines: {node: '>= 18'}
-
-  '@octokit/oauth-methods@4.1.0':
-    resolution: {integrity: sha512-4tuKnCRecJ6CG6gr0XcEXdZtkTDbfbnD5oaHBmLERTjTMZNi2CbfEHZxPU41xXLDG4DfKf+sonu00zvKI9NSbw==}
-    engines: {node: '>= 18'}
-
-  '@octokit/openapi-types@20.0.0':
-    resolution: {integrity: sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==}
-
-  '@octokit/openapi-types@22.2.0':
-    resolution: {integrity: sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==}
-
-  '@octokit/plugin-paginate-graphql@4.0.1':
-    resolution: {integrity: sha512-R8ZQNmrIKKpHWC6V2gum4x9LG2qF1RxRjo27gjQcG3j+vf2tLsEfE7I/wRWEPzYMaenr1M+qDAtNcwZve1ce1A==}
-    engines: {node: '>= 18'}
-    peerDependencies:
-      '@octokit/core': '>=5'
-
-  '@octokit/plugin-paginate-rest@9.2.1':
-    resolution: {integrity: sha512-wfGhE/TAkXZRLjksFXuDZdmGnJQHvtU/joFQdweXUgzo1XwvBCD4o4+75NtFfjfLK5IwLf9vHTfSiU3sLRYpRw==}
-    engines: {node: '>= 18'}
-    peerDependencies:
-      '@octokit/core': '5'
-
-  '@octokit/plugin-rest-endpoint-methods@10.4.1':
-    resolution: {integrity: sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==}
-    engines: {node: '>= 18'}
-    peerDependencies:
-      '@octokit/core': '5'
-
-  '@octokit/plugin-retry@6.1.0':
-    resolution: {integrity: sha512-WrO3bvq4E1Xh1r2mT9w6SDFg01gFmP81nIG77+p/MqW1JeXXgL++6umim3t6x0Zj5pZm3rXAN+0HEjmmdhIRig==}
-    engines: {node: '>= 18'}
-    peerDependencies:
-      '@octokit/core': '5'
-
-  '@octokit/plugin-throttling@8.2.0':
-    resolution: {integrity: sha512-nOpWtLayKFpgqmgD0y3GqXafMFuKcA4tRPZIfu7BArd2lEZeb1988nhWhwx4aZWmjDmUfdgVf7W+Tt4AmvRmMQ==}
-    engines: {node: '>= 18'}
-    peerDependencies:
-      '@octokit/core': ^5.0.0
-
-  '@octokit/request-error@5.1.0':
-    resolution: {integrity: sha512-GETXfE05J0+7H2STzekpKObFe765O5dlAKUTLNGeH+x47z7JjXHfsHKo5z21D/o/IOZTUEI6nyWyR+bZVP/n5Q==}
-    engines: {node: '>= 18'}
-
-  '@octokit/request@8.4.0':
-    resolution: {integrity: sha512-9Bb014e+m2TgBeEJGEbdplMVWwPmL1FPtggHQRkV+WVsMggPtEkLKPlcVYm/o8xKLkpJ7B+6N8WfQMtDLX2Dpw==}
-    engines: {node: '>= 18'}
-
-  '@octokit/types@12.6.0':
-    resolution: {integrity: sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==}
-
-  '@octokit/types@13.6.2':
-    resolution: {integrity: sha512-WpbZfZUcZU77DrSW4wbsSgTPfKcp286q3ItaIgvSbBpZJlu6mnYXAkjZz6LVZPXkEvLIM8McanyZejKTYUHipA==}
-
-  '@octokit/webhooks-methods@4.1.0':
-    resolution: {integrity: sha512-zoQyKw8h9STNPqtm28UGOYFE7O6D4Il8VJwhAtMHFt2C4L0VQT1qGKLeefUOqHNs1mNRYSadVv7x0z8U2yyeWQ==}
-    engines: {node: '>= 18'}
-
-  '@octokit/webhooks-types@7.6.1':
-    resolution: {integrity: sha512-S8u2cJzklBC0FgTwWVLaM8tMrDuDMVE4xiTK4EYXM9GntyvrdbSoxqDQa+Fh57CCNApyIpyeqPhhFEmHPfrXgw==}
-
-  '@octokit/webhooks@12.3.1':
-    resolution: {integrity: sha512-BVwtWE3rRXB9IugmQTfKspqjNa8q+ab73ddkV9k1Zok3XbuOxJUi4lTYk5zBZDhfWb/Y2H+RO9Iggm25gsqeow==}
-    engines: {node: '>= 18'}
 
   '@oozcitak/dom@2.0.2':
     resolution: {integrity: sha512-GjpKhkSYC3Mj4+lfwEyI1dqnsKTgwGy48ytZEhm4A/xnH/8z9M3ZVXKr/YGQi3uCLs1AEBS+x5T2JPiueEDW8w==}
@@ -4601,9 +4496,6 @@ packages:
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
-  '@types/aws-lambda@8.10.146':
-    resolution: {integrity: sha512-3BaDXYTh0e6UCJYL/jwV/3+GRslSc08toAiZSmleYtkAUyV5rtvdPYxrG/88uqvTuT6sb27WE9OS90ZNTIuQ0g==}
-
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -4618,9 +4510,6 @@ packages:
 
   '@types/body-parser@1.19.2':
     resolution: {integrity: sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==}
-
-  '@types/btoa-lite@1.0.2':
-    resolution: {integrity: sha512-ZYbcE2x7yrvNFJiU7xJGrpF/ihpkM7zKgw8bha3LNJSesvTtUNxbpzaT7WXBIryf6jovisrxTBvymxMeLLj1Mg==}
 
   '@types/chai-subset@1.3.5':
     resolution: {integrity: sha512-c2mPnw+xHtXDoHmdtcCXGwyLMiauiAyxWMzhGpqHC4nqI/Y5G2XhTampslK2rb59kpcuHon03UH8W6iYUzw88A==}
@@ -5437,10 +5326,6 @@ packages:
       webpack-dev-server:
         optional: true
 
-  '@wolfy1339/lru-cache@11.0.2-patch.1':
-    resolution: {integrity: sha512-BgYZfL2ADCXKOw2wJtkM3slhHotawWkgIRRxq4wEybnZQPjvAp71SPX35xepMykTw8gXlzWcWPTY31hlbnRsDA==}
-    engines: {node: 18 >=18.20 || 20 || >=22}
-
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
 
@@ -5512,10 +5397,6 @@ packages:
   agent-base@7.1.3:
     resolution: {integrity: sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==}
     engines: {node: '>= 14'}
-
-  aggregate-error@3.1.0:
-    resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
-    engines: {node: '>=8'}
 
   airbnb-prop-types@2.16.0:
     resolution: {integrity: sha512-7WHOFolP/6cS96PhKNrslCLMYAI8yB1Pp6u6XmxozQOiZbsI5ycglZr5cHhBFfuRcQQjzCMith5ZPZdYiJCxUg==}
@@ -5680,9 +5561,6 @@ packages:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
 
-  async-lock@1.4.1:
-    resolution: {integrity: sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==}
-
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
 
@@ -5806,9 +5684,6 @@ packages:
     engines: {node: '>=10.0.0'}
     deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
-  before-after-hook@2.2.3:
-    resolution: {integrity: sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==}
-
   better-opn@3.0.2:
     resolution: {integrity: sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==}
     engines: {node: '>=12.0.0'}
@@ -5849,9 +5724,6 @@ packages:
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
-  bottleneck@2.19.5:
-    resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
-
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
@@ -5889,9 +5761,6 @@ packages:
     resolution: {integrity: sha512-cDGv1kkDI4/0e5yON9yM5G/0A5u8sf5TnmdX5C9qHzI9PPu++sQ9zjm1k9NiOrf3riY4OkK0zSGqfvJyJsgCBQ==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
-
-  btoa-lite@1.0.0:
-    resolution: {integrity: sha512-gvW7InbIyF8AicrqWoptdW08pUxuhq8BEgowNajy9RhiE86fmGAGl+bLKo6oB8QP0CkqHLowfN0oJdKC/J6LbA==}
 
   buffer-builder@0.2.0:
     resolution: {integrity: sha512-7VPMEPuYznPSoR21NE1zvd2Xna6c/CloiZCfcMXR1Jny6PjX0N4Nsa38zcBFo/FMK+BlA+FLKbJCQ0i2yxp+Xg==}
@@ -6049,16 +5918,9 @@ packages:
     resolution: {integrity: sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==}
     engines: {node: '>= 10.0'}
 
-  clean-git-ref@2.0.1:
-    resolution: {integrity: sha512-bLSptAy2P0s6hU4PzuIMKmMJJSE6gLXGH1cntDu7bWJUksvuM+7ReOK61mozULErYvP6a15rnYl0zFDef+pyPw==}
-
   clean-regexp@1.0.0:
     resolution: {integrity: sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==}
     engines: {node: '>=4'}
-
-  clean-stack@2.2.0:
-    resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
-    engines: {node: '>=6'}
 
   cli-cursor@3.1.0:
     resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
@@ -6648,9 +6510,6 @@ packages:
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
-
-  deprecation@2.3.1:
-    resolution: {integrity: sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -7267,6 +7126,9 @@ packages:
   fflate@0.4.8:
     resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
 
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
+
   figcd@0.0.15:
     resolution: {integrity: sha512-pgPlRkFeMcvWtpJPpGe/m0etxFqIa/4kjQVKt1DMCWdKYm4kqnCbj+soGAnLWxxlOJdNjd+NMUXvt3FOqN1gRA==}
     hasBin: true
@@ -7831,10 +7693,6 @@ packages:
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
-  ignore@5.3.1:
-    resolution: {integrity: sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==}
-    engines: {node: '>= 4'}
-
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -8179,9 +8037,6 @@ packages:
         optional: true
       react:
         optional: true
-
-  js-sha256@0.11.1:
-    resolution: {integrity: sha512-o6WSo/LUvY2uC4j7mO50a2ms7E/EAdbP0swigLV+nzHKTTaYnaLIWJ02VdXrsJX0vGedDESQnLsOekr94ryfjg==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -8923,10 +8778,6 @@ packages:
       typescript:
         optional: true
 
-  murmurhash3js@3.0.1:
-    resolution: {integrity: sha512-KL8QYUaxq7kUbcl0Yto51rMcYt7E/4N4BG3/c96Iqw1PQrTRspu8Cpx4TZ4Nunib1d4bEkIH3gjCYlP2RLBdow==}
-    engines: {node: '>=0.10.0'}
-
   mute-stream@1.0.0:
     resolution: {integrity: sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -9143,10 +8994,6 @@ packages:
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
-
-  octokit@3.1.2:
-    resolution: {integrity: sha512-MG5qmrTL5y8KYwFgE1A4JWmgfQBaIETE/lOlfwNYx1QOtCQHGVxkRJmdUJltFc1HVn73d61TlMhMyNTOtMl+ng==}
-    engines: {node: '>= 18'}
 
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
@@ -9376,10 +9223,6 @@ packages:
   pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
-
-  pify@5.0.0:
-    resolution: {integrity: sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA==}
-    engines: {node: '>=10'}
 
   pixelmatch@7.1.0:
     resolution: {integrity: sha512-1wrVzJ2STrpmONHKBy228LM1b84msXDUoAzVEl0R8Mz4Ce6EPr+IVtxm8+yvrqLYMHswREkjYFaMxnyGnaY3Ng==}
@@ -10622,10 +10465,6 @@ packages:
     resolution: {integrity: sha512-2iQTSgkkc1Zyk0MeVrt/3BvuOXYPl/R8Z0U2xxo9rjwNciaHDG3R+Lm6dh4EeUci49DanvBnuqI6jshoQQRGEg==}
     engines: {node: '>=12.22'}
 
-  throttle-debounce@5.0.2:
-    resolution: {integrity: sha512-B71/4oyj61iNH0KeCamLuE2rmKuTO5byTOSVwECM5FA7TiAiAW+UqTKZ9ERueC4qvgSttUhdmq1mXC3kJqGX7A==}
-    engines: {node: '>=12.22'}
-
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
 
@@ -10780,6 +10619,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
@@ -10951,12 +10791,6 @@ packages:
 
   unist-util-visit@5.0.0:
     resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
-
-  universal-github-app-jwt@1.2.0:
-    resolution: {integrity: sha512-dncpMpnsKBk0eetwfN8D8OUHGfiDhhJ+mtsbMl+7PfW7mYjiH8LIcqRmYMtzYLgSh47HjfdBtrBwIQ/gizKR3g==}
-
-  universal-user-agent@6.0.1:
-    resolution: {integrity: sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==}
 
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
@@ -13563,30 +13397,6 @@ snapshots:
 
   '@inlang/result@1.1.0': {}
 
-  '@inlang/sdk@0.36.3(babel-plugin-macros@3.1.0)':
-    dependencies:
-      '@inlang/json-types': 1.1.0(@sinclair/typebox@0.31.28)
-      '@inlang/language-tag': 1.5.1
-      '@inlang/message': 2.1.0(@sinclair/typebox@0.31.28)
-      '@inlang/message-lint-rule': 1.4.7(@sinclair/typebox@0.31.28)
-      '@inlang/module': 1.2.14(@sinclair/typebox@0.31.28)
-      '@inlang/plugin': 2.4.14(@sinclair/typebox@0.31.28)
-      '@inlang/project-settings': 2.4.2(@sinclair/typebox@0.31.28)
-      '@inlang/result': 1.1.0
-      '@inlang/translatable': 1.3.1
-      '@lix-js/client': 2.2.1
-      '@lix-js/fs': 2.2.0
-      '@sinclair/typebox': 0.31.28
-      debug: 4.4.3
-      dedent: 1.5.1(babel-plugin-macros@3.1.0)
-      deepmerge-ts: 5.1.0
-      murmurhash3js: 3.0.1
-      solid-js: 1.6.12
-      throttle-debounce: 5.0.2
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
   '@inlang/sdk@0.9.0(babel-plugin-macros@3.1.0)':
     dependencies:
       '@inlang/json-types': 1.1.0(@sinclair/typebox@0.31.28)
@@ -13822,35 +13632,30 @@ snapshots:
     dependencies:
       '@lit/reactive-element': 2.1.0
 
-  '@lix-js/client@2.2.1':
-    dependencies:
-      '@lix-js/fs': 2.2.0
-      async-lock: 1.4.1
-      clean-git-ref: 2.0.1
-      crc-32: 1.2.2
-      ignore: 5.3.1
-      octokit: 3.1.2
-      pako: 1.0.11
-      pify: 5.0.0
-      sha.js: 2.4.11
-
   '@lix-js/fs@2.2.0':
     dependencies:
       typescript: 5.2.2
 
-  '@lix-js/sdk@0.4.10(babel-plugin-macros@3.1.0)':
-    dependencies:
-      '@lix-js/server-protocol-schema': 0.1.1
-      dedent: 1.5.1(babel-plugin-macros@3.1.0)
-      human-id: 4.1.1
-      js-sha256: 0.11.1
-      kysely: 0.28.14
-      sqlite-wasm-kysely: 0.3.0(kysely@0.28.14)
-      uuid: 14.0.0
-    transitivePeerDependencies:
-      - babel-plugin-macros
+  '@lix-js/sdk-darwin-arm64@0.10.0':
+    optional: true
 
-  '@lix-js/server-protocol-schema@0.1.1': {}
+  '@lix-js/sdk-linux-arm64@0.10.0':
+    optional: true
+
+  '@lix-js/sdk-linux-x64@0.10.0':
+    optional: true
+
+  '@lix-js/sdk-win32-x64@0.10.0':
+    optional: true
+
+  '@lix-js/sdk@0.10.0':
+    dependencies:
+      fflate: 0.8.3
+    optionalDependencies:
+      '@lix-js/sdk-darwin-arm64': 0.10.0
+      '@lix-js/sdk-linux-arm64': 0.10.0
+      '@lix-js/sdk-linux-x64': 0.10.0
+      '@lix-js/sdk-win32-x64': 0.10.0
 
   '@manypkg/find-root@1.1.0':
     dependencies:
@@ -14394,166 +14199,6 @@ snapshots:
       - '@swc-node/register'
       - '@swc/core'
       - debug
-
-  '@octokit/app@14.1.0':
-    dependencies:
-      '@octokit/auth-app': 6.1.3
-      '@octokit/auth-unauthenticated': 5.0.1
-      '@octokit/core': 5.2.0
-      '@octokit/oauth-app': 6.1.0
-      '@octokit/plugin-paginate-rest': 9.2.1(@octokit/core@5.2.0)
-      '@octokit/types': 12.6.0
-      '@octokit/webhooks': 12.3.1
-
-  '@octokit/auth-app@6.1.3':
-    dependencies:
-      '@octokit/auth-oauth-app': 7.1.0
-      '@octokit/auth-oauth-user': 4.1.0
-      '@octokit/request': 8.4.0
-      '@octokit/request-error': 5.1.0
-      '@octokit/types': 13.6.2
-      deprecation: 2.3.1
-      lru-cache: '@wolfy1339/lru-cache@11.0.2-patch.1'
-      universal-github-app-jwt: 1.2.0
-      universal-user-agent: 6.0.1
-
-  '@octokit/auth-oauth-app@7.1.0':
-    dependencies:
-      '@octokit/auth-oauth-device': 6.1.0
-      '@octokit/auth-oauth-user': 4.1.0
-      '@octokit/request': 8.4.0
-      '@octokit/types': 13.6.2
-      '@types/btoa-lite': 1.0.2
-      btoa-lite: 1.0.0
-      universal-user-agent: 6.0.1
-
-  '@octokit/auth-oauth-device@6.1.0':
-    dependencies:
-      '@octokit/oauth-methods': 4.1.0
-      '@octokit/request': 8.4.0
-      '@octokit/types': 13.6.2
-      universal-user-agent: 6.0.1
-
-  '@octokit/auth-oauth-user@4.1.0':
-    dependencies:
-      '@octokit/auth-oauth-device': 6.1.0
-      '@octokit/oauth-methods': 4.1.0
-      '@octokit/request': 8.4.0
-      '@octokit/types': 13.6.2
-      btoa-lite: 1.0.0
-      universal-user-agent: 6.0.1
-
-  '@octokit/auth-token@4.0.0': {}
-
-  '@octokit/auth-unauthenticated@5.0.1':
-    dependencies:
-      '@octokit/request-error': 5.1.0
-      '@octokit/types': 12.6.0
-
-  '@octokit/core@5.2.0':
-    dependencies:
-      '@octokit/auth-token': 4.0.0
-      '@octokit/graphql': 7.1.0
-      '@octokit/request': 8.4.0
-      '@octokit/request-error': 5.1.0
-      '@octokit/types': 13.6.2
-      before-after-hook: 2.2.3
-      universal-user-agent: 6.0.1
-
-  '@octokit/endpoint@9.0.5':
-    dependencies:
-      '@octokit/types': 13.6.2
-      universal-user-agent: 6.0.1
-
-  '@octokit/graphql@7.1.0':
-    dependencies:
-      '@octokit/request': 8.4.0
-      '@octokit/types': 13.6.2
-      universal-user-agent: 6.0.1
-
-  '@octokit/oauth-app@6.1.0':
-    dependencies:
-      '@octokit/auth-oauth-app': 7.1.0
-      '@octokit/auth-oauth-user': 4.1.0
-      '@octokit/auth-unauthenticated': 5.0.1
-      '@octokit/core': 5.2.0
-      '@octokit/oauth-authorization-url': 6.0.2
-      '@octokit/oauth-methods': 4.1.0
-      '@types/aws-lambda': 8.10.146
-      universal-user-agent: 6.0.1
-
-  '@octokit/oauth-authorization-url@6.0.2': {}
-
-  '@octokit/oauth-methods@4.1.0':
-    dependencies:
-      '@octokit/oauth-authorization-url': 6.0.2
-      '@octokit/request': 8.4.0
-      '@octokit/request-error': 5.1.0
-      '@octokit/types': 13.6.2
-      btoa-lite: 1.0.0
-
-  '@octokit/openapi-types@20.0.0': {}
-
-  '@octokit/openapi-types@22.2.0': {}
-
-  '@octokit/plugin-paginate-graphql@4.0.1(@octokit/core@5.2.0)':
-    dependencies:
-      '@octokit/core': 5.2.0
-
-  '@octokit/plugin-paginate-rest@9.2.1(@octokit/core@5.2.0)':
-    dependencies:
-      '@octokit/core': 5.2.0
-      '@octokit/types': 12.6.0
-
-  '@octokit/plugin-rest-endpoint-methods@10.4.1(@octokit/core@5.2.0)':
-    dependencies:
-      '@octokit/core': 5.2.0
-      '@octokit/types': 12.6.0
-
-  '@octokit/plugin-retry@6.1.0(@octokit/core@5.2.0)':
-    dependencies:
-      '@octokit/core': 5.2.0
-      '@octokit/request-error': 5.1.0
-      '@octokit/types': 13.6.2
-      bottleneck: 2.19.5
-
-  '@octokit/plugin-throttling@8.2.0(@octokit/core@5.2.0)':
-    dependencies:
-      '@octokit/core': 5.2.0
-      '@octokit/types': 12.6.0
-      bottleneck: 2.19.5
-
-  '@octokit/request-error@5.1.0':
-    dependencies:
-      '@octokit/types': 13.6.2
-      deprecation: 2.3.1
-      once: 1.4.0
-
-  '@octokit/request@8.4.0':
-    dependencies:
-      '@octokit/endpoint': 9.0.5
-      '@octokit/request-error': 5.1.0
-      '@octokit/types': 13.6.2
-      universal-user-agent: 6.0.1
-
-  '@octokit/types@12.6.0':
-    dependencies:
-      '@octokit/openapi-types': 20.0.0
-
-  '@octokit/types@13.6.2':
-    dependencies:
-      '@octokit/openapi-types': 22.2.0
-
-  '@octokit/webhooks-methods@4.1.0': {}
-
-  '@octokit/webhooks-types@7.6.1': {}
-
-  '@octokit/webhooks@12.3.1':
-    dependencies:
-      '@octokit/request-error': 5.1.0
-      '@octokit/webhooks-methods': 4.1.0
-      '@octokit/webhooks-types': 7.6.1
-      aggregate-error: 3.1.0
 
   '@oozcitak/dom@2.0.2':
     dependencies:
@@ -15708,8 +15353,6 @@ snapshots:
 
   '@types/aria-query@5.0.4': {}
 
-  '@types/aws-lambda@8.10.146': {}
-
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.28.5
@@ -15735,8 +15378,6 @@ snapshots:
     dependencies:
       '@types/connect': 3.4.38
       '@types/node': 22.15.33
-
-  '@types/btoa-lite@1.0.2': {}
 
   '@types/chai-subset@1.3.5':
     dependencies:
@@ -16450,11 +16091,11 @@ snapshots:
       - vite
     optional: true
 
-  '@vitest/browser@3.2.4(msw@2.10.2(@types/node@22.15.33)(typescript@5.7.3))(playwright@1.55.0)(vite@7.2.7(@types/node@22.15.33)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1)':
+  '@vitest/browser@3.2.4(msw@2.10.2(@types/node@22.15.33)(typescript@5.7.3))(playwright@1.55.0)(vite@6.3.5(@types/node@22.15.33)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1)':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
-      '@vitest/mocker': 3.2.4(msw@2.10.2(@types/node@22.15.33)(typescript@5.7.3))(vite@7.2.7(@types/node@22.15.33)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))
+      '@vitest/mocker': 3.2.4(msw@2.10.2(@types/node@22.15.33)(typescript@5.7.3))(vite@6.3.5(@types/node@22.15.33)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))
       '@vitest/utils': 3.2.4
       magic-string: 0.30.21
       sirv: 3.0.2
@@ -16492,11 +16133,11 @@ snapshots:
       - vite
     optional: true
 
-  '@vitest/browser@3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(playwright@1.55.0)(vite@6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1)':
+  '@vitest/browser@3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(playwright@1.55.0)(vite@7.2.7(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1)':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
-      '@vitest/mocker': 3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(vite@6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))
+      '@vitest/mocker': 3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(vite@7.2.7(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))
       '@vitest/utils': 3.2.4
       magic-string: 0.30.21
       sirv: 3.0.2
@@ -16551,7 +16192,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@3.1.1(@vitest/browser@3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(playwright@1.55.0)(vite@6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1))(vitest@3.1.1(@types/debug@4.1.12)(@types/node@24.10.2)(@vitest/browser@3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(playwright@1.55.0)(vite@6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1))(happy-dom@18.0.1)(jsdom@27.3.0(postcss@8.5.6))(lightningcss@1.30.2)(msw@2.10.2(@types/node@24.10.2)(typescript@5.7.3))(sass-embedded@1.89.2)(terser@5.36.0))':
+  '@vitest/coverage-v8@3.1.1(@vitest/browser@3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(playwright@1.55.0)(vite@7.2.7(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1))(vitest@3.1.1(@types/debug@4.1.12)(@types/node@24.10.2)(@vitest/browser@3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(playwright@1.55.0)(vite@7.2.7(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1))(happy-dom@18.0.1)(jsdom@27.3.0(postcss@8.5.6))(lightningcss@1.30.2)(msw@2.10.2(@types/node@24.10.2)(typescript@5.7.3))(sass-embedded@1.89.2)(terser@5.36.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -16565,9 +16206,9 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.1.1(@types/debug@4.1.12)(@types/node@24.10.2)(@vitest/browser@3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(playwright@1.55.0)(vite@6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1))(happy-dom@18.0.1)(jsdom@27.3.0(postcss@8.5.6))(lightningcss@1.30.2)(msw@2.10.2(@types/node@24.10.2)(typescript@5.7.3))(sass-embedded@1.89.2)(terser@5.36.0)
+      vitest: 3.1.1(@types/debug@4.1.12)(@types/node@24.10.2)(@vitest/browser@3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(playwright@1.55.0)(vite@7.2.7(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1))(happy-dom@18.0.1)(jsdom@27.3.0(postcss@8.5.6))(lightningcss@1.30.2)(msw@2.10.2(@types/node@24.10.2)(typescript@5.7.3))(sass-embedded@1.89.2)(terser@5.36.0)
     optionalDependencies:
-      '@vitest/browser': 3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(playwright@1.55.0)(vite@6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1)
+      '@vitest/browser': 3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(playwright@1.55.0)(vite@7.2.7(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -16586,9 +16227,9 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.2)(@vitest/browser@3.2.4)(happy-dom@18.0.1)(jiti@2.6.1)(jsdom@27.3.0(postcss@8.5.6))(lightningcss@1.30.2)(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.15.33)(@vitest/browser@3.2.4)(happy-dom@18.0.1)(jiti@2.6.1)(jsdom@27.3.0(postcss@8.5.6))(lightningcss@1.30.2)(msw@2.10.2(@types/node@22.15.33)(typescript@5.7.3))(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1)
     optionalDependencies:
-      '@vitest/browser': 3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(playwright@1.55.0)(vite@6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1)
+      '@vitest/browser': 3.2.4(msw@2.10.2(@types/node@22.15.33)(typescript@5.7.3))(playwright@1.55.0)(vite@6.3.5(@types/node@22.15.33)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -16684,16 +16325,6 @@ snapshots:
       msw: 2.10.2(@types/node@22.15.33)(typescript@5.7.3)
       vite: 6.3.5(@types/node@22.15.33)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1)
 
-  '@vitest/mocker@3.2.4(msw@2.10.2(@types/node@22.15.33)(typescript@5.7.3))(vite@7.2.7(@types/node@22.15.33)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      msw: 2.10.2(@types/node@22.15.33)(typescript@5.7.3)
-      vite: 7.2.7(@types/node@22.15.33)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1)
-    optional: true
-
   '@vitest/mocker@3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.7.3))(vite@6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))':
     dependencies:
       '@vitest/spy': 3.2.4
@@ -16721,6 +16352,16 @@ snapshots:
     optionalDependencies:
       msw: 2.10.2(@types/node@24.10.2)(typescript@5.9.3)
       vite: 6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1)
+
+  '@vitest/mocker@3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(vite@7.2.7(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.10.2(@types/node@24.10.2)(typescript@5.9.3)
+      vite: 7.2.7(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1)
+    optional: true
 
   '@vitest/mocker@4.0.16(msw@2.10.2(@types/node@22.15.33)(typescript@5.7.3))(vite@7.2.7(@types/node@22.15.33)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))':
     dependencies:
@@ -17043,8 +16684,6 @@ snapshots:
     dependencies:
       webpack-cli: 4.10.0(webpack@5.99.9)
 
-  '@wolfy1339/lru-cache@11.0.2-patch.1': {}
-
   '@xtuc/ieee754@1.2.0': {}
 
   '@xtuc/long@4.2.2': {}
@@ -17105,11 +16744,6 @@ snapshots:
       - supports-color
 
   agent-base@7.1.3: {}
-
-  aggregate-error@3.1.0:
-    dependencies:
-      clean-stack: 2.2.0
-      indent-string: 4.0.0
 
   airbnb-prop-types@2.16.0(react@17.0.2):
     dependencies:
@@ -17321,8 +16955,6 @@ snapshots:
 
   async-function@1.0.0: {}
 
-  async-lock@1.4.1: {}
-
   async@3.2.6: {}
 
   asynckit@0.4.0: {}
@@ -17453,8 +17085,6 @@ snapshots:
 
   basic-ftp@5.0.5: {}
 
-  before-after-hook@2.2.3: {}
-
   better-opn@3.0.2:
     dependencies:
       open: 8.4.2
@@ -17503,8 +17133,6 @@ snapshots:
       - supports-color
 
   boolbase@1.0.0: {}
-
-  bottleneck@2.19.5: {}
 
   brace-expansion@1.1.12:
     dependencies:
@@ -17569,8 +17197,6 @@ snapshots:
       electron-to-chromium: 1.5.211
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.25.3)
-
-  btoa-lite@1.0.0: {}
 
   buffer-builder@0.2.0:
     optional: true
@@ -17750,13 +17376,9 @@ snapshots:
     dependencies:
       source-map: 0.6.1
 
-  clean-git-ref@2.0.1: {}
-
   clean-regexp@1.0.0:
     dependencies:
       escape-string-regexp: 1.0.5
-
-  clean-stack@2.2.0: {}
 
   cli-cursor@3.1.0:
     dependencies:
@@ -17940,7 +17562,8 @@ snapshots:
     optionalDependencies:
       typescript: 5.7.3
 
-  crc-32@1.2.2: {}
+  crc-32@1.2.2:
+    optional: true
 
   crc32-stream@6.0.0:
     dependencies:
@@ -18363,8 +17986,6 @@ snapshots:
   delayed-stream@1.0.0: {}
 
   depd@2.0.0: {}
-
-  deprecation@2.3.1: {}
 
   dequal@2.0.3: {}
 
@@ -19324,6 +18945,8 @@ snapshots:
 
   fflate@0.4.8: {}
 
+  fflate@0.8.3: {}
+
   figcd@0.0.15:
     dependencies:
       commander: 11.1.0
@@ -20045,8 +19668,6 @@ snapshots:
 
   ieee754@1.2.1: {}
 
-  ignore@5.3.1: {}
-
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -20363,8 +19984,6 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.23
       react: 19.0.0-rc-941e1b4a-20240729
-
-  js-sha256@0.11.1: {}
 
   js-tokens@4.0.0: {}
 
@@ -21406,8 +21025,6 @@ snapshots:
       - '@types/node'
     optional: true
 
-  murmurhash3js@3.0.1: {}
-
   mute-stream@1.0.0: {}
 
   mute-stream@2.0.0:
@@ -21638,19 +21255,6 @@ snapshots:
       es-object-atoms: 1.1.1
 
   obug@2.1.1: {}
-
-  octokit@3.1.2:
-    dependencies:
-      '@octokit/app': 14.1.0
-      '@octokit/core': 5.2.0
-      '@octokit/oauth-app': 6.1.0
-      '@octokit/plugin-paginate-graphql': 4.0.1(@octokit/core@5.2.0)
-      '@octokit/plugin-paginate-rest': 9.2.1(@octokit/core@5.2.0)
-      '@octokit/plugin-rest-endpoint-methods': 10.4.1(@octokit/core@5.2.0)
-      '@octokit/plugin-retry': 6.1.0(@octokit/core@5.2.0)
-      '@octokit/plugin-throttling': 8.2.0(@octokit/core@5.2.0)
-      '@octokit/request-error': 5.1.0
-      '@octokit/types': 12.6.0
 
   on-finished@2.4.1:
     dependencies:
@@ -21886,8 +21490,6 @@ snapshots:
   picomatch@4.0.3: {}
 
   pify@4.0.1: {}
-
-  pify@5.0.0: {}
 
   pixelmatch@7.1.0:
     dependencies:
@@ -23385,8 +22987,6 @@ snapshots:
 
   throttle-debounce@5.0.0: {}
 
-  throttle-debounce@5.0.2: {}
-
   through@2.3.8: {}
 
   tiny-invariant@1.3.3: {}
@@ -23718,13 +23318,6 @@ snapshots:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.0
       unist-util-visit-parents: 6.0.1
-
-  universal-github-app-jwt@1.2.0:
-    dependencies:
-      '@types/jsonwebtoken': 9.0.10
-      jsonwebtoken: 9.0.2
-
-  universal-user-agent@6.0.1: {}
 
   universalify@0.1.2: {}
 
@@ -24307,7 +23900,7 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@3.1.1(@types/debug@4.1.12)(@types/node@24.10.2)(@vitest/browser@3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(playwright@1.55.0)(vite@6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1))(happy-dom@18.0.1)(jsdom@27.3.0(postcss@8.5.6))(lightningcss@1.30.2)(msw@2.10.2(@types/node@24.10.2)(typescript@5.7.3))(sass-embedded@1.89.2)(terser@5.36.0):
+  vitest@3.1.1(@types/debug@4.1.12)(@types/node@24.10.2)(@vitest/browser@3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(playwright@1.55.0)(vite@7.2.7(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1))(happy-dom@18.0.1)(jsdom@27.3.0(postcss@8.5.6))(lightningcss@1.30.2)(msw@2.10.2(@types/node@24.10.2)(typescript@5.7.3))(sass-embedded@1.89.2)(terser@5.36.0):
     dependencies:
       '@vitest/expect': 3.1.1
       '@vitest/mocker': 3.1.1(msw@2.10.2(@types/node@24.10.2)(typescript@5.7.3))(vite@5.4.19(@types/node@24.10.2)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0))
@@ -24332,7 +23925,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 24.10.2
-      '@vitest/browser': 3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(playwright@1.55.0)(vite@6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1)
+      '@vitest/browser': 3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(playwright@1.55.0)(vite@7.2.7(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1)
       happy-dom: 18.0.1
       jsdom: 27.3.0(postcss@8.5.6)
     transitivePeerDependencies:
@@ -24374,7 +23967,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 22.15.33
-      '@vitest/browser': 3.2.4(msw@2.10.2(@types/node@22.15.33)(typescript@5.7.3))(playwright@1.55.0)(vite@7.2.7(@types/node@22.15.33)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1)
+      '@vitest/browser': 3.2.4(msw@2.10.2(@types/node@22.15.33)(typescript@5.7.3))(playwright@1.55.0)(vite@6.3.5(@types/node@22.15.33)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1)
       happy-dom: 18.0.1
       jsdom: 27.3.0(postcss@8.5.6)
     transitivePeerDependencies:
@@ -24464,7 +24057,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 24.10.2
-      '@vitest/browser': 3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(playwright@1.55.0)(vite@6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1)
+      '@vitest/browser': 3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(playwright@1.55.0)(vite@7.2.7(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1)
       happy-dom: 18.0.1
       jsdom: 27.3.0(postcss@8.5.6)
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

- Upgrade `@lix-js/sdk` from 0.4.10 to 0.10.0.
- Move the SDK's in-memory project database to registered Lix schemas and the v0.10 Kysely bridge.
- Adopt native `INSERT ... RETURNING` and `DEFAULT VALUES` support; use `file.content` as the hard-cut v0.10 file field.
- Replace SQLite-backed project snapshots with a portable JSON entity/file snapshot for Node in-memory Lix.
- Add Paraglide/Sherlock workload benchmarks and document the results.

## Verification

- `pnpm --filter @inlang/sdk typecheck`
- `pnpm --filter @inlang/sdk test` — 112 passed, 19 skipped, 6 todo
- `pnpm --filter @inlang/sdk lint`
- `pnpm --filter @inlang/sdk build`
- `pnpm --filter @inlang/sdk bench`

## Benchmark highlights

Against the existing SQLite-WASM implementation, averaged across two v0.10 runs:

| Workload | Lix 0.10 | SQLite-WASM |
| --- | ---: | ---: |
| Full nested Paraglide read | 22.053 ms | 50.556 ms |
| Sherlock point nested read | 0.110 ms | 0.165 ms |
| Sherlock variant update | 3.045 ms | 0.025 ms |
| Sherlock nested insert | 4.440 ms | 0.289 ms |

Details are in `packages/sdk/benchmark/README.md`.

## Notes

The Node native in-memory backend still cannot export/import opaque Lix snapshots, so the SDK uses an explicit portable JSON snapshot for current project entities and files. Lix history/branch metadata is not included in that format.
