### PR TITLE
perf(sdk): batch nested Lix mutations atomically

### DIFF
--- a/packages/sdk/src/database/initDb.ts
+++ b/packages/sdk/src/database/initDb.ts
@@ -2,9 +2,12 @@ import { Kysely } from "kysely";
 import type { Lix } from "@lix-js/sdk";
 import type { InlangDatabaseSchema } from "./schema.js";
 import { LixDialect } from "./lixDialect.js";
+import { attachLixBatchExecutor } from "./lixBatch.js";
 
 export function initDb(args: { lix: Lix }) {
-	return new Kysely<InlangDatabaseSchema>({
+	const db = new Kysely<InlangDatabaseSchema>({
 		dialect: new LixDialect(args.lix),
 	});
+	attachLixBatchExecutor(db, args.lix);
+	return db;
 }

--- a/packages/sdk/src/database/lixBatch.test.ts
+++ b/packages/sdk/src/database/lixBatch.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "vitest";
+import { sql } from "kysely";
+import { openLix } from "@lix-js/sdk";
+import { executeLixBatch } from "./lixBatch.js";
+import { initDb } from "./initDb.js";
+import { registerInlangSchemas } from "./registerSchemas.js";
+
+test("executeLixBatch publishes atomically and rolls back on a later failure", async () => {
+	const lix = await openLix();
+	await registerInlangSchemas(lix);
+	const db = initDb({ lix });
+
+	const insert = db
+		.insertInto("bundle")
+		.values({ id: "batch-atomicity" })
+		.compile();
+	const invalid =
+		sql`INSERT INTO "missing_batch_table" ("id") VALUES (${"must-fail"})`.compile(
+			db
+		);
+
+	await expect(executeLixBatch(db, [insert, invalid])).rejects.toThrow();
+	await expect(
+		db
+			.selectFrom("bundle")
+			.select("id")
+			.where("id", "=", "batch-atomicity")
+			.execute()
+	).resolves.toEqual([]);
+
+	await db.destroy();
+	await lix.close();
+});

--- a/packages/sdk/src/database/lixBatch.ts
+++ b/packages/sdk/src/database/lixBatch.ts
@@ -1,0 +1,45 @@
+import type { CompiledQuery, Kysely } from "kysely";
+import type { ExecuteResult, Lix, LixBatchStatement } from "@lix-js/sdk";
+import type { InlangDatabaseSchema } from "./schema.js";
+import { compileLixQuery } from "./lixDialect.js";
+
+type BatchExecutor = (
+	queries: readonly CompiledQuery[]
+) => Promise<readonly ExecuteResult[]>;
+
+const batchExecutors = new WeakMap<object, BatchExecutor>();
+
+/**
+ * Installs the one atomic batch boundary owned by an Lix-backed database.
+ * The executor is deliberately not exposed as a second query dialect: callers
+ * provide ordinary Kysely compiled queries and Lix remains responsible for
+ * normalization, execution, and atomic publication.
+ */
+export function attachLixBatchExecutor(
+	db: Kysely<InlangDatabaseSchema>,
+	lix: Lix
+): void {
+	batchExecutors.set(db, async (queries) => {
+		const statements: LixBatchStatement[] = queries.map(compileLixQuery);
+		return lix.executeBatch(statements);
+	});
+}
+
+/**
+ * Executes already-compiled Kysely statements as one authenticated Lix batch.
+ * A database without the Lix batch capability is rejected explicitly; there
+ * is no sequential or compatibility route hidden behind this API.
+ */
+export async function executeLixBatch(
+	db: Kysely<InlangDatabaseSchema>,
+	queries: readonly CompiledQuery[]
+): Promise<readonly ExecuteResult[]> {
+	if (queries.length === 0) {
+		throw new Error("executeLixBatch requires at least one query");
+	}
+	const execute = batchExecutors.get(db);
+	if (!execute) {
+		throw new Error("The database is not an Lix-backed batch database");
+	}
+	return execute(queries);
+}

--- a/packages/sdk/src/database/lixDialect.ts
+++ b/packages/sdk/src/database/lixDialect.ts
@@ -9,7 +9,12 @@ import {
 	type Kysely,
 	type QueryResult,
 } from "kysely";
-import type { Lix, LixTransaction, SqlParam } from "@lix-js/sdk";
+import type {
+	Lix,
+	LixBatchStatement,
+	LixTransaction,
+	SqlParam,
+} from "@lix-js/sdk";
 
 /** Kysely bridge for Lix's DataFusion SQL interface. */
 export class LixDialect implements Dialect {
@@ -110,7 +115,6 @@ class LixConnection implements DatabaseConnection {
 		const parameters = prepared.parameterPositions.map(
 			(position) => compiledQuery.parameters[position - 1]
 		);
-
 		const result = await executor.execute(
 			prepared.sql,
 			parameters as SqlParam[]
@@ -131,10 +135,26 @@ type PreparedLixQuery = {
 	parameterPositions: number[];
 };
 
-function prepareLixQuery(compiledSql: string): PreparedLixQuery {
+/** Convert Kysely's compiled query to the one Lix SQL/parameter contract. */
+export function compileLixQuery(
+	compiledQuery: CompiledQuery
+): LixBatchStatement {
+	const prepared = prepareLixQuery(compiledQuery.sql);
+	const parameters = prepared.parameterPositions.map(
+		(position) => compiledQuery.parameters[position - 1]
+	);
+	return {
+		sql: prepared.sql,
+		params: parameters as SqlParam[],
+	};
+}
+
+function prepareLixQuery(compiledSql: string): {
+	sql: string;
+	parameterPositions: number[];
+} {
 	const sql = omitPrimaryKeyAssignments(
-		compiledSql
-		.replaceAll('"file"', '"lix_file"')
+		compiledSql.replaceAll('"file"', '"lix_file"')
 	);
 	const compacted = compactSqlParameters(sql);
 	return {
@@ -173,8 +193,7 @@ function omitPrimaryKeyAssignments(sql: string): string {
 
 function publicRow(row: Record<string, unknown>): Record<string, unknown> {
 	return Object.fromEntries(
-		Object.entries(row)
-			.filter(([column]) => !column.startsWith("lixcol_"))
+		Object.entries(row).filter(([column]) => !column.startsWith("lixcol_"))
 	);
 }
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -18,6 +18,7 @@ export * from "./query-utilities/index.js";
 export * from "./plugin/errors.js";
 export { humanId } from "./human-id/human-id.js";
 export type { InlangDatabaseSchema } from "./database/schema.js";
+export { executeLixBatch } from "./database/lixBatch.js";
 export type { ImportFile, ExportFile } from "./project/api.js";
 export type {
 	InlangPlugin,

--- a/packages/sdk/src/query-utilities/compileBundleNestedBatch.ts
+++ b/packages/sdk/src/query-utilities/compileBundleNestedBatch.ts
@@ -1,0 +1,76 @@
+import type { CompiledQuery, Kysely } from "kysely";
+import type {
+	InlangDatabaseSchema,
+	NewBundleNested,
+} from "../database/schema.js";
+
+type NestedWriteMode = "insert" | "upsert";
+
+export function compileBundleNestedBatch(
+	db: Kysely<InlangDatabaseSchema>,
+	bundle: NewBundleNested,
+	mode: NestedWriteMode
+): readonly CompiledQuery[] {
+	const bundleId = bundle.id ?? crypto.randomUUID();
+	const queries: CompiledQuery[] = [];
+
+	const bundleInsert = db
+		.insertInto("bundle")
+		.values({ id: bundleId, declarations: bundle.declarations });
+	queries.push(
+		(mode === "upsert"
+			? bundleInsert.onConflict((oc) =>
+					oc.column("id").doUpdateSet({
+						declarations: bundle.declarations,
+					})
+				)
+			: bundleInsert
+		).compile()
+	);
+
+	for (const message of bundle.messages) {
+		const messageId = message.id ?? crypto.randomUUID();
+		const messageInsert = db.insertInto("message").values({
+			id: messageId,
+			bundleId,
+			locale: message.locale,
+			selectors: message.selectors,
+		});
+		queries.push(
+			(mode === "upsert"
+				? messageInsert.onConflict((oc) =>
+						oc.column("id").doUpdateSet({
+							bundleId,
+							locale: message.locale,
+							selectors: message.selectors,
+						})
+					)
+				: messageInsert
+			).compile()
+		);
+
+		for (const variant of message.variants) {
+			const variantId = variant.id ?? crypto.randomUUID();
+			const variantInsert = db.insertInto("variant").values({
+				id: variantId,
+				messageId,
+				matches: variant.matches,
+				pattern: variant.pattern,
+			});
+			queries.push(
+				(mode === "upsert"
+					? variantInsert.onConflict((oc) =>
+							oc.column("id").doUpdateSet({
+								messageId,
+								matches: variant.matches,
+								pattern: variant.pattern,
+							})
+						)
+					: variantInsert
+				).compile()
+			);
+		}
+	}
+
+	return queries;
+}

--- a/packages/sdk/src/query-utilities/insertBundleNested.ts
+++ b/packages/sdk/src/query-utilities/insertBundleNested.ts
@@ -3,44 +3,12 @@ import type {
 	InlangDatabaseSchema,
 	NewBundleNested,
 } from "../database/schema.js";
+import { executeLixBatch } from "../database/lixBatch.js";
+import { compileBundleNestedBatch } from "./compileBundleNestedBatch.js";
 
 export const insertBundleNested = async (
 	db: Kysely<InlangDatabaseSchema>,
 	bundle: NewBundleNested
 ): Promise<void> => {
-	await db.transaction().execute(async (trx) => {
-		const insertedBundle = await trx
-			.insertInto("bundle")
-			.values({
-				id: bundle.id,
-				declarations: bundle.declarations,
-			})
-			.returning("id")
-			.executeTakeFirstOrThrow();
-
-		for (const message of bundle.messages) {
-			const insertedMessage = await trx
-				.insertInto("message")
-				.values({
-					id: message.id,
-					bundleId: insertedBundle.id,
-					locale: message.locale,
-					selectors: message.selectors,
-				})
-				.returning("id")
-				.executeTakeFirstOrThrow();
-
-			for (const variant of message.variants) {
-				await trx
-					.insertInto("variant")
-					.values({
-						id: variant.id,
-						messageId: insertedMessage.id,
-						matches: variant.matches,
-						pattern: variant.pattern,
-					})
-					.execute();
-			}
-		}
-	});
+	await executeLixBatch(db, compileBundleNestedBatch(db, bundle, "insert"));
 };

--- a/packages/sdk/src/query-utilities/upsertBundleNested.ts
+++ b/packages/sdk/src/query-utilities/upsertBundleNested.ts
@@ -3,59 +3,12 @@ import type {
 	InlangDatabaseSchema,
 	NewBundleNested,
 } from "../database/schema.js";
+import { executeLixBatch } from "../database/lixBatch.js";
+import { compileBundleNestedBatch } from "./compileBundleNestedBatch.js";
 
 export const upsertBundleNested = async (
 	db: Kysely<InlangDatabaseSchema>,
 	bundle: NewBundleNested
 ): Promise<void> => {
-	await db.transaction().execute(async (trx) => {
-		const insertedBundle = await trx
-			.insertInto("bundle")
-			.values({
-				id: bundle.id,
-				declarations: bundle.declarations,
-			})
-			.returning("id")
-			.onConflict((oc) =>
-				oc.column("id").doUpdateSet({
-					...bundle,
-					// @ts-expect-error - undefined
-					messages: undefined,
-				})
-			)
-			.executeTakeFirstOrThrow();
-
-		for (const message of bundle.messages) {
-			const insertedMessage = await trx
-				.insertInto("message")
-				.values({
-					id: message.id,
-					bundleId: insertedBundle.id,
-					locale: message.locale,
-					selectors: message.selectors,
-				})
-				.onConflict((oc) =>
-					oc.column("id").doUpdateSet({
-						...message,
-						// @ts-expect-error - undefined
-						variants: undefined,
-					})
-				)
-				.returning("id")
-				.executeTakeFirstOrThrow();
-
-			for (const variant of message.variants) {
-				await trx
-					.insertInto("variant")
-					.values({
-						id: variant.id,
-						messageId: insertedMessage.id,
-						matches: variant.matches,
-						pattern: variant.pattern,
-					})
-					.onConflict((oc) => oc.column("id").doUpdateSet(variant))
-					.execute();
-			}
-		}
-	});
+	await executeLixBatch(db, compileBundleNestedBatch(db, bundle, "upsert"));
 };


### PR DESCRIPTION
## Summary

- expose one typed compiled-query batch boundary from the inlang database wrapper to Lix's existing atomic `executeBatch`
- compile ordinary Kysely statements once and submit nested insert/upsert mutations as one transaction
- delete the previous per-statement bridge/transaction sequence for these generic utilities
- preserve Kysely SQL generation and parameter binding; no application, query-text, or fixture-specific route

This PR is intentionally stacked on #4389.

## Real-application evidence

Exact sources:

- inlang #4389 base: `7ea66f85e0137a171173e050ae56b372b7cc4f16`
- candidate: `6356c17725f44c119d0dd0a3640f81a89824dbc3`
- Lix JS/native build: `4fafa449136b6001c63ff6e1505db112fb3c5ff7`
- Paraglide JS: `c9da524f8e5c21e3048debbfc21cc0a4c195845d`
- Sherlock: `5cc056294162f9e1d549e11e05d2026da7d7d943`

Representative pinned repository fixtures, warm p50/p95:

| Workload | Before | After | After vs raw SQLite | Lix bridge calls |
|---|---:|---:|---:|---:|
| Paraglide nested insert | 5.965 / 7.730 ms | 1.936 / 4.572 ms | 1.07× | 6 → 1 |
| Sherlock nested insert | 7.304 / 11.949 ms | 2.186 / 4.347 ms | 1.19× | 6 → 1 |

A separate captured two-statement transactional mutation improved:

- Paraglide p50: 5.315 → 1.326 ms
- Sherlock p50: 5.244 → 1.368 ms
- bridge calls: 3 → 1

Result cardinalities and final-state hashes match. An injected failure in a later batch statement rejects the operation and leaves the repository unchanged.

## Complexity and physical effect

For `S` nested statements:

- before: `O(S)` JS↔Lix crossings and transaction boundaries
- after: `O(1)` crossings and one atomic Lix transaction, while SQL compilation/execution work remains `O(S)`

This removes repeated bridge serialization, transaction setup, publication, and response materialization. IDs are preassigned, so statements no longer request redundant `RETURNING` payloads.

## Validation

- focused SDK build, lint, and formatting passed
- 33 focused tests passed, including the new atomicity failure case and project import/export flows
- Paraglide and Sherlock result hashes/cardinalities matched the SQLite controls
- locally built Lix JS SDK resolution and native binary hashes were recorded; no published Lix package was substituted

Point reads are explicitly out of scope; their remaining cost is inside native multi-entity execution and is being pursued independently.
