### PR TITLE
Faster importing by keeping map of bundle ids

### DIFF
--- a/packages/plugins/inlang-message-format/src/import-export/importFiles.bench.ts
+++ b/packages/plugins/inlang-message-format/src/import-export/importFiles.bench.ts
@@ -1,0 +1,50 @@
+import { bench, describe } from "vitest";
+import { importFiles } from "./importFiles.js";
+
+function makeFiles(locales: number, keys: number) {
+	const encoder = new TextEncoder();
+	const files = [];
+
+	for (let localeIndex = 0; localeIndex < locales; localeIndex++) {
+		const locale = `locale_${localeIndex}`;
+		const json: Record<string, string> = {};
+
+		for (let keyIndex = 0; keyIndex < keys; keyIndex++) {
+			const key = `message_${keyIndex}`;
+			if (keyIndex % 5 === 0) {
+				json[key] = `Hello {name} from ${locale} (#${keyIndex})`;
+			} else if (keyIndex % 5 === 1) {
+				json[key] = `Count is {count} in ${locale}`;
+			} else {
+				json[key] = `Static text ${locale} ${keyIndex}`;
+			}
+		}
+
+		files.push({
+			locale,
+			content: encoder.encode(JSON.stringify(json)),
+		});
+	}
+
+	return files;
+}
+
+for (const [locales, keys] of [
+	[30, 5000],
+	[10, 1000],
+	[1, 200],
+]) {
+	const files = makeFiles(locales, keys);
+	describe(`importFiles (${locales} locales × ${keys} keys)`, () => {
+		bench(
+			"Import files",
+			async () => {
+				await importFiles({
+					settings: {} as any,
+					files,
+				});
+			},
+			{ time: 1000 }
+		);
+	});
+}

--- a/packages/plugins/inlang-message-format/src/import-export/importFiles.ts
+++ b/packages/plugins/inlang-message-format/src/import-export/importFiles.ts
@@ -23,6 +23,7 @@ export const importFiles: NonNullable<(typeof plugin)["importFiles"]> = async ({
 	files,
 }) => {
 	const bundles: Bundle[] = [];
+	const bundlesById = new Map<string, Bundle>();
 	const messages: MessageImport[] = [];
 	const variants: VariantImport[] = [];
 
@@ -38,9 +39,10 @@ export const importFiles: NonNullable<(typeof plugin)["importFiles"]> = async ({
 			messages.push(result.message);
 			variants.push(...result.variants);
 
-			const existingBundle = bundles.find((b) => b.id === result.bundle.id);
+			const existingBundle = bundlesById.get(result.bundle.id);
 			if (existingBundle === undefined) {
 				bundles.push(result.bundle);
+				bundlesById.set(result.bundle.id, result.bundle);
 			} else {
 				// merge declarations without duplicates
 				existingBundle.declarations = unique([
@@ -291,7 +293,10 @@ function parsePattern(value: string): {
 	};
 }
 
-function findPlaceholderClosingIndex(value: string, openingIndex: number): number {
+function findPlaceholderClosingIndex(
+	value: string,
+	openingIndex: number
+): number {
 	let inQuotedLiteral = false;
 
 	for (let cursor = openingIndex + 1; cursor < value.length; cursor += 1) {
@@ -478,14 +483,14 @@ function parseMarkupValue(
 		let cursor = index + 1;
 		let literal = "";
 		while (cursor < value.length) {
-				const char = value[cursor]!;
-				if (char === "\\") {
-					const next = value[cursor + 1];
-					if (next === "|" || next === "\\" || next === "}") {
-						literal += next;
-						cursor += 2;
-						continue;
-					}
+			const char = value[cursor]!;
+			if (char === "\\") {
+				const next = value[cursor + 1];
+				if (next === "|" || next === "\\" || next === "}") {
+					literal += next;
+					cursor += 2;
+					continue;
+				}
 				literal += char;
 				cursor += 1;
 				continue;


### PR DESCRIPTION
Importing many / large locales is time consuming, using a map seems to speed it up a bit. I ran the experiment with and without a map, here are the results. What is in the PR is only the map path left.

<img width="868" height="603" alt="SCR-20260807-jdln" src="https://github.com/user-attachments/assets/07469dad-c1a4-4c18-b951-7d102e399923" />
