### PR TITLE
perf: index message-format bundles during import

### DIFF
--- a/.changeset/fast-bundle-import.md
+++ b/.changeset/fast-bundle-import.md
@@ -1,0 +1,5 @@
+---
+"@inlang/plugin-message-format": patch
+---
+
+Speed up importing large message-format projects by indexing bundles by id.

--- a/packages/plugins/inlang-message-format/src/import-export/importFiles.bench.ts
+++ b/packages/plugins/inlang-message-format/src/import-export/importFiles.bench.ts
@@ -1,0 +1,50 @@
+import { bench, describe } from "vitest";
+import { importFiles } from "./importFiles.js";
+
+function makeFiles(locales: number, keys: number) {
+	const encoder = new TextEncoder();
+	const files = [];
+
+	for (let localeIndex = 0; localeIndex < locales; localeIndex++) {
+		const locale = `locale_${localeIndex}`;
+		const json: Record<string, string> = {};
+
+		for (let keyIndex = 0; keyIndex < keys; keyIndex++) {
+			const key = `message_${keyIndex}`;
+			if (keyIndex % 5 === 0) {
+				json[key] = `Hello {name} from ${locale} (#${keyIndex})`;
+			} else if (keyIndex % 5 === 1) {
+				json[key] = `Count is {count} in ${locale}`;
+			} else {
+				json[key] = `Static text ${locale} ${keyIndex}`;
+			}
+		}
+
+		files.push({
+			locale,
+			content: encoder.encode(JSON.stringify(json)),
+		});
+	}
+
+	return files;
+}
+
+for (const [locales, keys] of [
+	[30, 5000],
+	[10, 1000],
+	[1, 200],
+]) {
+	const files = makeFiles(locales, keys);
+	describe(`importFiles (${locales} locales × ${keys} keys)`, () => {
+		bench(
+			"Import files",
+			async () => {
+				await importFiles({
+					settings: {} as any,
+					files,
+				});
+			},
+			{ time: 1000 }
+		);
+	});
+}

--- a/packages/plugins/inlang-message-format/src/import-export/importFiles.bench.ts
+++ b/packages/plugins/inlang-message-format/src/import-export/importFiles.bench.ts
@@ -29,11 +29,13 @@ function makeFiles(locales: number, keys: number) {
 	return files;
 }
 
-for (const [locales, keys] of [
+const benchmarks: [number, number][] = [
 	[30, 5000],
 	[10, 1000],
 	[1, 200],
-]) {
+];
+
+for (const [locales, keys] of benchmarks) {
 	const files = makeFiles(locales, keys);
 	describe(`importFiles (${locales} locales × ${keys} keys)`, () => {
 		bench(

--- a/packages/plugins/inlang-message-format/src/import-export/importFiles.ts
+++ b/packages/plugins/inlang-message-format/src/import-export/importFiles.ts
@@ -23,6 +23,7 @@ export const importFiles: NonNullable<(typeof plugin)["importFiles"]> = async ({
 	files,
 }) => {
 	const bundles: Bundle[] = [];
+	const bundlesById = new Map<string, Bundle>();
 	const messages: MessageImport[] = [];
 	const variants: VariantImport[] = [];
 
@@ -38,9 +39,10 @@ export const importFiles: NonNullable<(typeof plugin)["importFiles"]> = async ({
 			messages.push(result.message);
 			variants.push(...result.variants);
 
-			const existingBundle = bundles.find((b) => b.id === result.bundle.id);
+			const existingBundle = bundlesById.get(result.bundle.id);
 			if (existingBundle === undefined) {
 				bundles.push(result.bundle);
+				bundlesById.set(result.bundle.id, result.bundle);
 			} else {
 				// merge declarations without duplicates
 				existingBundle.declarations = unique([


### PR DESCRIPTION
## What changed

Keep a map of bundle ids while importing message-format files, avoiding a linear scan for every message. Adds a focused Vitest benchmark and a patch changeset.

## Why

Large projects with many locales repeatedly search the accumulated bundle array. This keeps the public behavior and merge semantics unchanged while making lookup O(1).

## Validation

- `pnpm exec vitest bench packages/plugins/inlang-message-format/src/import-export/importFiles.bench.ts --run`
- 30 locales × 5,000 keys: ~808 ms baseline → ~191 ms (~76% faster)
- small 1 locale × 200 keys remains noise-level
- SDK/CI checks will run on this PR