### PR TITLE
perf: batch fresh project imports

### DIFF
--- a/.changeset/batched-fresh-project-import.md
+++ b/.changeset/batched-fresh-project-import.md
@@ -1,0 +1,5 @@
+---
+"@inlang/sdk": patch
+---
+
+Batch fresh-project imports to reduce SQLite round trips during compilation.

--- a/packages/sdk/src/import-export/importFiles.test.ts
+++ b/packages/sdk/src/import-export/importFiles.test.ts
@@ -4,6 +4,42 @@ import { loadProjectInMemory } from "../project/loadProjectInMemory.js";
 import { newProject } from "../project/newProject.js";
 import type { InlangPlugin } from "../plugin/schema.js";
 
+test("batch imports an unambiguous fresh project", async () => {
+	const project = await loadProjectInMemory({ blob: await newProject() });
+
+	const mockPlugin: InlangPlugin = {
+		key: "mock",
+		importFiles: async () => ({
+			bundles: [{ id: "mock-bundle" }],
+			messages: [
+				{ bundleId: "mock-bundle", locale: "en" },
+				{ bundleId: "mock-bundle", locale: "de" },
+			],
+			variants: [
+				{ messageBundleId: "mock-bundle", messageLocale: "en" },
+				{ messageBundleId: "mock-bundle", messageLocale: "de" },
+			],
+		}),
+	};
+
+	await importFiles({
+		db: project.db,
+		files: [{ content: new Uint8Array(), locale: "mock" }],
+		pluginKey: "mock",
+		plugins: [mockPlugin],
+		settings: {} as any,
+	});
+
+	const messages = await project.db.selectFrom("message").selectAll().execute();
+	const variants = await project.db.selectFrom("variant").selectAll().execute();
+
+	expect(messages).toHaveLength(2);
+	expect(variants).toHaveLength(2);
+	expect(new Set(variants.map((variant) => variant.messageId))).toEqual(
+		new Set(messages.map((message) => message.id))
+	);
+});
+
 test("it should insert a message as is if the id is provided", async () => {
 	const project = await loadProjectInMemory({ blob: await newProject() });
 

--- a/packages/sdk/src/import-export/importFiles.ts
+++ b/packages/sdk/src/import-export/importFiles.ts
@@ -7,6 +7,7 @@ import type { ProjectSettings } from "../json-schema/settings.js";
 import type { InlangDatabaseSchema, NewVariant } from "../database/schema.js";
 import type { InlangPlugin, VariantImport } from "../plugin/schema.js";
 import type { ImportFile } from "../project/api.js";
+import { v7 } from "uuid";
 
 export async function importFiles(args: {
 	files: ImportFile[];
@@ -32,6 +33,95 @@ export async function importFiles(args: {
 	});
 
 	await args.db.transaction().execute(async (trx) => {
+		const hasExistingBundles = await trx
+			.selectFrom("bundle")
+			.select("id")
+			.limit(1)
+			.executeTakeFirst();
+		const bundleIds = new Set<string>();
+		let bundlesHaveUniqueIds = true;
+		for (const bundle of imported.bundles) {
+			if (bundle.id === undefined || bundleIds.has(bundle.id)) {
+				bundlesHaveUniqueIds = false;
+				break;
+			}
+			bundleIds.add(bundle.id);
+		}
+		const messageKeys = new Set<string>();
+		let messagesHaveUniqueKeys = true;
+		for (const message of imported.messages) {
+			const key = `${message.bundleId}\u0000${message.locale}`;
+			if (messageKeys.has(key)) {
+				messagesHaveUniqueKeys = false;
+				break;
+			}
+			messageKeys.add(key);
+		}
+		const canBatchImportFreshProject =
+			hasExistingBundles === undefined &&
+			bundlesHaveUniqueIds &&
+			messagesHaveUniqueKeys &&
+			imported.messages.every((message) => message.id === undefined) &&
+			imported.variants.every(
+				(variant) =>
+					variant.id === undefined &&
+					variant.messageId === undefined &&
+					variant.messageBundleId !== undefined &&
+					variant.messageLocale !== undefined
+			) &&
+			imported.messages.every((message) => bundleIds.has(message.bundleId)) &&
+			imported.variants.every((variant) =>
+				messageKeys.has(
+					`${variant.messageBundleId}\u0000${variant.messageLocale}`
+				)
+			);
+
+		if (canBatchImportFreshProject) {
+			if (imported.bundles.length > 0) {
+				await trx.insertInto("bundle").values(imported.bundles).execute();
+			}
+
+			const messagesWithIds = imported.messages.map((message) => ({
+				...message,
+				id: v7(),
+			}));
+			for (let offset = 0; offset < messagesWithIds.length; offset += 500) {
+				await trx
+					.insertInto("message")
+					.values(messagesWithIds.slice(offset, offset + 500))
+					.execute();
+			}
+
+			const messageIds = new Map(
+				messagesWithIds.map((message) => [
+					`${message.bundleId}\u0000${message.locale}`,
+					message.id,
+				])
+			);
+			const variantsWithMessageIds: NewVariant[] = imported.variants.map(
+				(variant) => {
+					const messageId = messageIds.get(
+						`${variant.messageBundleId}\u0000${variant.messageLocale}`
+					);
+					if (messageId === undefined) {
+						throw new Error("Imported variant does not reference a message");
+					}
+					return {
+						messageId,
+						matches: variant.matches,
+						pattern: variant.pattern,
+					};
+				}
+			);
+			for (let offset = 0; offset < variantsWithMessageIds.length; offset += 500) {
+				await trx
+					.insertInto("variant")
+					.values(variantsWithMessageIds.slice(offset, offset + 500))
+					.execute();
+			}
+			return;
+		}
+
 		// upsert every bundle
 		for (const bundle of imported.bundles) {
 			await trx

--- a/packages/sdk/src/project/loadProjectFromDirectory.bench.ts
+++ b/packages/sdk/src/project/loadProjectFromDirectory.bench.ts
@@ -1,0 +1,34 @@
+import { bench } from "vitest";
+import nodeFs from "node:fs";
+import nodePath from "node:path";
+import { memfs } from "memfs";
+import { loadProjectFromDirectory } from "./loadProjectFromDirectory.js";
+
+const pluginAsText = nodeFs.readFileSync(
+	nodePath.join(
+		process.cwd(),
+		"packages/plugins/inlang-message-format/dist/index.js"
+	),
+	"utf8"
+);
+const messageData = Object.fromEntries(
+	Array.from({ length: 1000 }, (_, i) => [`message_${i}`, `Hello {username} #${i}`])
+);
+const localeNames = Array.from({ length: 10 }, (_, i) => `locale_${i}`);
+const fs = memfs({
+	"/plugin.js": pluginAsText,
+	"/project.inlang/settings.json": JSON.stringify({
+		baseLocale: localeNames[0],
+		locales: localeNames,
+		modules: ["/plugin.js"],
+		"plugin.inlang.messageFormat": { pathPattern: "/{locale}.json" },
+	}),
+	...Object.fromEntries(
+		localeNames.map((locale) => [`/${locale}.json`, JSON.stringify(messageData)])
+	),
+}).fs as unknown as typeof import("node:fs");
+
+bench("load project from directory", async () => {
+	const project = await loadProjectFromDirectory({ path: "/project.inlang", fs });
+	await project.close();
+}, { iterations: 1, time: 100 });


### PR DESCRIPTION
## Stack

Builds on #4392. This PR should be reviewed after the bundle-id map PR.

## What changed

When a project database is empty and a plugin returns unambiguous generated ids, insert bundles, messages, and variants in bounded batches inside the existing transaction. Inputs with ids, duplicate keys, missing relationships, or existing data continue through the established row-by-row path.

## Why

Paraglide compilation imported each message and variant with individual SQLite round trips. The fresh JSON-project path is the common compiler case.

## Validation

- SDK typecheck and tests: 112 passed, 19 skipped
- 10 locales × 1,000 messages load benchmark: ~1,669 ms → ~196 ms (~88% faster)
- batch sizes are capped at 500 to avoid SQLite parameter limits
- no public API changes