### PR TITLE
perf: batch fresh project imports

### DIFF
--- a/.changeset/batched-fresh-project-import.md
+++ b/.changeset/batched-fresh-project-import.md
@@ -1,0 +1,5 @@
+---
+"@inlang/sdk": patch
+---
+
+Batch fresh-project imports to reduce SQLite round trips during compilation.

--- a/.changeset/fast-bundle-import.md
+++ b/.changeset/fast-bundle-import.md
@@ -1,0 +1,5 @@
+---
+"@inlang/plugin-message-format": patch
+---
+
+Speed up importing large message-format projects by indexing bundles by id.

--- a/packages/plugins/inlang-message-format/src/import-export/importFiles.bench.ts
+++ b/packages/plugins/inlang-message-format/src/import-export/importFiles.bench.ts
@@ -1,0 +1,50 @@
+import { bench, describe } from "vitest";
+import { importFiles } from "./importFiles.js";
+
+function makeFiles(locales: number, keys: number) {
+	const encoder = new TextEncoder();
+	const files = [];
+
+	for (let localeIndex = 0; localeIndex < locales; localeIndex++) {
+		const locale = `locale_${localeIndex}`;
+		const json: Record<string, string> = {};
+
+		for (let keyIndex = 0; keyIndex < keys; keyIndex++) {
+			const key = `message_${keyIndex}`;
+			if (keyIndex % 5 === 0) {
+				json[key] = `Hello {name} from ${locale} (#${keyIndex})`;
+			} else if (keyIndex % 5 === 1) {
+				json[key] = `Count is {count} in ${locale}`;
+			} else {
+				json[key] = `Static text ${locale} ${keyIndex}`;
+			}
+		}
+
+		files.push({
+			locale,
+			content: encoder.encode(JSON.stringify(json)),
+		});
+	}
+
+	return files;
+}
+
+for (const [locales, keys] of [
+	[30, 5000],
+	[10, 1000],
+	[1, 200],
+]) {
+	const files = makeFiles(locales, keys);
+	describe(`importFiles (${locales} locales × ${keys} keys)`, () => {
+		bench(
+			"Import files",
+			async () => {
+				await importFiles({
+					settings: {} as any,
+					files,
+				});
+			},
+			{ time: 1000 }
+		);
+	});
+}

--- a/packages/plugins/inlang-message-format/src/import-export/importFiles.bench.ts
+++ b/packages/plugins/inlang-message-format/src/import-export/importFiles.bench.ts
@@ -29,11 +29,13 @@ function makeFiles(locales: number, keys: number) {
 	return files;
 }
 
-for (const [locales, keys] of [
+const benchmarks: [number, number][] = [
 	[30, 5000],
 	[10, 1000],
 	[1, 200],
-]) {
+];
+
+for (const [locales, keys] of benchmarks) {
 	const files = makeFiles(locales, keys);
 	describe(`importFiles (${locales} locales × ${keys} keys)`, () => {
 		bench(

--- a/packages/plugins/inlang-message-format/src/import-export/importFiles.ts
+++ b/packages/plugins/inlang-message-format/src/import-export/importFiles.ts
@@ -23,6 +23,7 @@ export const importFiles: NonNullable<(typeof plugin)["importFiles"]> = async ({
 	files,
 }) => {
 	const bundles: Bundle[] = [];
+	const bundlesById = new Map<string, Bundle>();
 	const messages: MessageImport[] = [];
 	const variants: VariantImport[] = [];
 
@@ -38,9 +39,10 @@ export const importFiles: NonNullable<(typeof plugin)["importFiles"]> = async ({
 			messages.push(result.message);
 			variants.push(...result.variants);
 
-			const existingBundle = bundles.find((b) => b.id === result.bundle.id);
+			const existingBundle = bundlesById.get(result.bundle.id);
 			if (existingBundle === undefined) {
 				bundles.push(result.bundle);
+				bundlesById.set(result.bundle.id, result.bundle);
 			} else {
 				// merge declarations without duplicates
 				existingBundle.declarations = unique([

--- a/packages/sdk/src/import-export/importFiles.test.ts
+++ b/packages/sdk/src/import-export/importFiles.test.ts
@@ -4,6 +4,42 @@ import { loadProjectInMemory } from "../project/loadProjectInMemory.js";
 import { newProject } from "../project/newProject.js";
 import type { InlangPlugin } from "../plugin/schema.js";
 
+test("batch imports an unambiguous fresh project", async () => {
+	const project = await loadProjectInMemory({ blob: await newProject() });
+
+	const mockPlugin: InlangPlugin = {
+		key: "mock",
+		importFiles: async () => ({
+			bundles: [{ id: "mock-bundle" }],
+			messages: [
+				{ bundleId: "mock-bundle", locale: "en" },
+				{ bundleId: "mock-bundle", locale: "de" },
+			],
+			variants: [
+				{ messageBundleId: "mock-bundle", messageLocale: "en" },
+				{ messageBundleId: "mock-bundle", messageLocale: "de" },
+			],
+		}),
+	};
+
+	await importFiles({
+		db: project.db,
+		files: [{ content: new Uint8Array(), locale: "mock" }],
+		pluginKey: "mock",
+		plugins: [mockPlugin],
+		settings: {} as any,
+	});
+
+	const messages = await project.db.selectFrom("message").selectAll().execute();
+	const variants = await project.db.selectFrom("variant").selectAll().execute();
+
+	expect(messages).toHaveLength(2);
+	expect(variants).toHaveLength(2);
+	expect(new Set(variants.map((variant) => variant.messageId))).toEqual(
+		new Set(messages.map((message) => message.id))
+	);
+});
+
 test("it should insert a message as is if the id is provided", async () => {
 	const project = await loadProjectInMemory({ blob: await newProject() });
 

--- a/packages/sdk/src/import-export/importFiles.test.ts
+++ b/packages/sdk/src/import-export/importFiles.test.ts
@@ -40,6 +40,66 @@ test("batch imports an unambiguous fresh project", async () => {
 	);
 });
 
+test("batches rows with mixed optional columns", async () => {
+	const project = await loadProjectInMemory({ blob: await newProject() });
+
+	const mockPlugin: InlangPlugin = {
+		key: "mock",
+		importFiles: async () => ({
+			bundles: [{ id: "plain-bundle" }, { id: "rich-bundle" }],
+			messages: [
+				{ bundleId: "plain-bundle", locale: "en" },
+				{
+					bundleId: "rich-bundle",
+					locale: "de",
+					selectors: [{ type: "variable-reference", name: "platform" }],
+				},
+			],
+			variants: [
+				{ messageBundleId: "plain-bundle", messageLocale: "en" },
+				{
+					messageBundleId: "rich-bundle",
+					messageLocale: "de",
+					matches: [
+						{
+							type: "literal-match",
+							key: "platform",
+							value: "web",
+						},
+					],
+					pattern: [{ type: "text", value: "Hello web" }],
+				},
+			],
+		}),
+	};
+
+	await importFiles({
+		db: project.db,
+		files: [{ content: new Uint8Array(), locale: "mock" }],
+		pluginKey: "mock",
+		plugins: [mockPlugin],
+		settings: {} as any,
+	});
+
+	const messages = await project.db.selectFrom("message").selectAll().execute();
+	const variants = await project.db.selectFrom("variant").selectAll().execute();
+
+	expect(messages).toHaveLength(2);
+	expect(
+		messages.find((message) => message.locale === "en")?.selectors
+	).toStrictEqual([]);
+	expect(
+		messages.find((message) => message.locale === "de")?.selectors
+	).toStrictEqual([{ type: "variable-reference", name: "platform" }]);
+	expect(variants).toHaveLength(2);
+	expect(
+		variants.find((variant) => variant.matches.length === 0)?.pattern
+	).toStrictEqual([]);
+	expect(
+		variants.find((variant) => variant.matches.length > 0)?.pattern
+	).toStrictEqual([{ type: "text", value: "Hello web" }]);
+});
+
 test("preserves variant upsert semantics for duplicate matches", async () => {
 	const project = await loadProjectInMemory({ blob: await newProject() });
 

--- a/packages/sdk/src/import-export/importFiles.test.ts
+++ b/packages/sdk/src/import-export/importFiles.test.ts
@@ -40,6 +40,87 @@ test("batch imports an unambiguous fresh project", async () => {
 	);
 });
 
+test("preserves variant upsert semantics for duplicate matches", async () => {
+	const project = await loadProjectInMemory({ blob: await newProject() });
+
+	const mockPlugin: InlangPlugin = {
+		key: "mock",
+		importFiles: async () => ({
+			bundles: [{ id: "mock-bundle" }],
+			messages: [{ bundleId: "mock-bundle", locale: "en" }],
+			variants: [
+				{
+					messageBundleId: "mock-bundle",
+					messageLocale: "en",
+					matches: [],
+					pattern: [{ type: "text", value: "first" }],
+				},
+				{
+					messageBundleId: "mock-bundle",
+					messageLocale: "en",
+					matches: [],
+					pattern: [{ type: "text", value: "last" }],
+				},
+			],
+		}),
+	};
+
+	await importFiles({
+		db: project.db,
+		files: [{ content: new Uint8Array(), locale: "mock" }],
+		pluginKey: "mock",
+		plugins: [mockPlugin],
+		settings: {} as any,
+	});
+
+	const variants = await project.db.selectFrom("variant").selectAll().execute();
+
+	expect(variants).toHaveLength(1);
+	expect(variants[0]?.pattern).toStrictEqual([{ type: "text", value: "last" }]);
+});
+
+test("does not alias message references containing NUL characters", async () => {
+	const project = await loadProjectInMemory({ blob: await newProject() });
+
+	const mockPlugin: InlangPlugin = {
+		key: "mock",
+		importFiles: async () => ({
+			bundles: [{ id: "a" }, { id: "a\u0000b" }],
+			messages: [
+				{ bundleId: "a", locale: "b\u0000c" },
+				{ bundleId: "a\u0000b", locale: "c" },
+			],
+			variants: [
+				{
+					messageBundleId: "a",
+					messageLocale: "b\u0000c",
+					pattern: [{ type: "text", value: "first" }],
+				},
+				{
+					messageBundleId: "a\u0000b",
+					messageLocale: "c",
+					pattern: [{ type: "text", value: "second" }],
+				},
+			],
+		}),
+	};
+
+	await importFiles({
+		db: project.db,
+		files: [{ content: new Uint8Array(), locale: "mock" }],
+		pluginKey: "mock",
+		plugins: [mockPlugin],
+		settings: {} as any,
+	});
+
+	const messages = await project.db.selectFrom("message").selectAll().execute();
+	const variants = await project.db.selectFrom("variant").selectAll().execute();
+
+	expect(variants).toHaveLength(2);
+	expect(new Set(variants.map((variant) => variant.messageId))).toHaveLength(2);
+	expect(messages).toHaveLength(2);
+});
+
 test("it should insert a message as is if the id is provided", async () => {
 	const project = await loadProjectInMemory({ blob: await newProject() });
 

--- a/packages/sdk/src/import-export/importFiles.ts
+++ b/packages/sdk/src/import-export/importFiles.ts
@@ -20,6 +20,43 @@ const variantReferenceKey = (
 
 const INSERT_BATCH_SIZE = 500;
 
+/**
+ * Kysely uses one column list for every row in a multi-row insert. SQLite's
+ * default-value handling for omitted NOT NULL JSON columns is not reliable
+ * when rows with different optional-column shapes are mixed, so keep each
+ * shape in its own insert statement.
+ */
+async function insertInBatchesByShape<T extends object>(args: {
+	rows: readonly T[];
+	optionalColumns: readonly string[];
+	insert: (rows: T[]) => Promise<void>;
+}) {
+	const rowsByShape = new Map<string, T[]>();
+	for (const row of args.rows) {
+		const shape = args.optionalColumns
+			.map((column) =>
+				(row as Record<string, unknown>)[column] === undefined ? "0" : "1"
+			)
+			.join("");
+		const rowsForShape = rowsByShape.get(shape);
+		if (rowsForShape) {
+			rowsForShape.push(row);
+		} else {
+			rowsByShape.set(shape, [row]);
+		}
+	}
+
+	for (const rowsForShape of rowsByShape.values()) {
+		for (
+			let offset = 0;
+			offset < rowsForShape.length;
+			offset += INSERT_BATCH_SIZE
+		) {
+			await args.insert(rowsForShape.slice(offset, offset + INSERT_BATCH_SIZE));
+		}
+	}
+}
+
 export async function importFiles(args: {
 	files: ImportFile[];
 	readonly pluginKey: string;
@@ -110,31 +147,25 @@ export async function importFiles(args: {
 			);
 
 		if (canBatchImportFreshProject) {
-			for (
-				let offset = 0;
-				offset < imported.bundles.length;
-				offset += INSERT_BATCH_SIZE
-			) {
-				await trx
-					.insertInto("bundle")
-					.values(imported.bundles.slice(offset, offset + INSERT_BATCH_SIZE))
-					.execute();
-			}
+			await insertInBatchesByShape({
+				rows: imported.bundles,
+				optionalColumns: ["declarations"],
+				insert: async (rows) => {
+					await trx.insertInto("bundle").values(rows).execute();
+				},
+			});
 
 			const messagesWithIds = imported.messages.map((message) => ({
 				...message,
 				id: v7(),
 			}));
-			for (
-				let offset = 0;
-				offset < messagesWithIds.length;
-				offset += INSERT_BATCH_SIZE
-			) {
-				await trx
-					.insertInto("message")
-					.values(messagesWithIds.slice(offset, offset + INSERT_BATCH_SIZE))
-					.execute();
-			}
+			await insertInBatchesByShape({
+				rows: messagesWithIds,
+				optionalColumns: ["selectors"],
+				insert: async (rows) => {
+					await trx.insertInto("message").values(rows).execute();
+				},
+			});
 
 			const messageIds = new Map(
 				messagesWithIds.map((message) => [
@@ -160,18 +191,13 @@ export async function importFiles(args: {
 					};
 				}
 			);
-			for (
-				let offset = 0;
-				offset < variantsWithMessageIds.length;
-				offset += INSERT_BATCH_SIZE
-			) {
-				await trx
-					.insertInto("variant")
-					.values(
-						variantsWithMessageIds.slice(offset, offset + INSERT_BATCH_SIZE)
-					)
-					.execute();
-			}
+			await insertInBatchesByShape({
+				rows: variantsWithMessageIds,
+				optionalColumns: ["matches", "pattern"],
+				insert: async (rows) => {
+					await trx.insertInto("variant").values(rows).execute();
+				},
+			});
 			return;
 		}
 

--- a/packages/sdk/src/import-export/importFiles.ts
+++ b/packages/sdk/src/import-export/importFiles.ts
@@ -9,6 +9,17 @@ import type { InlangPlugin, VariantImport } from "../plugin/schema.js";
 import type { ImportFile } from "../project/api.js";
 import { v7 } from "uuid";
 
+const messageReferenceKey = (bundleId: string, locale: string) =>
+	JSON.stringify([bundleId, locale]);
+
+const variantReferenceKey = (
+	bundleId: string,
+	locale: string,
+	matches: unknown
+) => JSON.stringify([bundleId, locale, matches]);
+
+const INSERT_BATCH_SIZE = 500;
+
 export async function importFiles(args: {
 	files: ImportFile[];
 	readonly pluginKey: string;
@@ -50,17 +61,39 @@ export async function importFiles(args: {
 		const messageKeys = new Set<string>();
 		let messagesHaveUniqueKeys = true;
 		for (const message of imported.messages) {
-			const key = `${message.bundleId}\u0000${message.locale}`;
+			const key = messageReferenceKey(message.bundleId, message.locale);
 			if (messageKeys.has(key)) {
 				messagesHaveUniqueKeys = false;
 				break;
 			}
 			messageKeys.add(key);
 		}
+		const variantKeys = new Set<string>();
+		let variantsHaveUniqueKeys = true;
+		for (const variant of imported.variants) {
+			if (
+				variant.messageBundleId === undefined ||
+				variant.messageLocale === undefined
+			) {
+				variantsHaveUniqueKeys = false;
+				break;
+			}
+			const key = variantReferenceKey(
+				variant.messageBundleId,
+				variant.messageLocale,
+				variant.matches
+			);
+			if (variantKeys.has(key)) {
+				variantsHaveUniqueKeys = false;
+				break;
+			}
+			variantKeys.add(key);
+		}
 		const canBatchImportFreshProject =
 			hasExistingBundles === undefined &&
 			bundlesHaveUniqueIds &&
 			messagesHaveUniqueKeys &&
+			variantsHaveUniqueKeys &&
 			imported.messages.every((message) => message.id === undefined) &&
 			imported.variants.every(
 				(variant) =>
@@ -72,36 +105,50 @@ export async function importFiles(args: {
 			imported.messages.every((message) => bundleIds.has(message.bundleId)) &&
 			imported.variants.every((variant) =>
 				messageKeys.has(
-					`${variant.messageBundleId}\u0000${variant.messageLocale}`
+					messageReferenceKey(variant.messageBundleId!, variant.messageLocale!)
 				)
 			);
 
 		if (canBatchImportFreshProject) {
-			if (imported.bundles.length > 0) {
-				await trx.insertInto("bundle").values(imported.bundles).execute();
+			for (
+				let offset = 0;
+				offset < imported.bundles.length;
+				offset += INSERT_BATCH_SIZE
+			) {
+				await trx
+					.insertInto("bundle")
+					.values(imported.bundles.slice(offset, offset + INSERT_BATCH_SIZE))
+					.execute();
 			}
 
 			const messagesWithIds = imported.messages.map((message) => ({
 				...message,
 				id: v7(),
 			}));
-			for (let offset = 0; offset < messagesWithIds.length; offset += 500) {
+			for (
+				let offset = 0;
+				offset < messagesWithIds.length;
+				offset += INSERT_BATCH_SIZE
+			) {
 				await trx
 					.insertInto("message")
-					.values(messagesWithIds.slice(offset, offset + 500))
+					.values(messagesWithIds.slice(offset, offset + INSERT_BATCH_SIZE))
 					.execute();
 			}
 
 			const messageIds = new Map(
 				messagesWithIds.map((message) => [
-					`${message.bundleId}\u0000${message.locale}`,
+					messageReferenceKey(message.bundleId, message.locale),
 					message.id,
 				])
 			);
 			const variantsWithMessageIds: NewVariant[] = imported.variants.map(
 				(variant) => {
 					const messageId = messageIds.get(
-						`${variant.messageBundleId}\u0000${variant.messageLocale}`
+						messageReferenceKey(
+							variant.messageBundleId!,
+							variant.messageLocale!
+						)
 					);
 					if (messageId === undefined) {
 						throw new Error("Imported variant does not reference a message");
@@ -113,10 +160,16 @@ export async function importFiles(args: {
 					};
 				}
 			);
-			for (let offset = 0; offset < variantsWithMessageIds.length; offset += 500) {
+			for (
+				let offset = 0;
+				offset < variantsWithMessageIds.length;
+				offset += INSERT_BATCH_SIZE
+			) {
 				await trx
 					.insertInto("variant")
-					.values(variantsWithMessageIds.slice(offset, offset + 500))
+					.values(
+						variantsWithMessageIds.slice(offset, offset + INSERT_BATCH_SIZE)
+					)
 					.execute();
 			}
 			return;

--- a/packages/sdk/src/import-export/importFiles.ts
+++ b/packages/sdk/src/import-export/importFiles.ts
@@ -7,6 +7,7 @@ import type { ProjectSettings } from "../json-schema/settings.js";
 import type { InlangDatabaseSchema, NewVariant } from "../database/schema.js";
 import type { InlangPlugin, VariantImport } from "../plugin/schema.js";
 import type { ImportFile } from "../project/api.js";
+import { v7 } from "uuid";
 
 export async function importFiles(args: {
 	files: ImportFile[];
@@ -32,6 +33,95 @@ export async function importFiles(args: {
 	});
 
 	await args.db.transaction().execute(async (trx) => {
+		const hasExistingBundles = await trx
+			.selectFrom("bundle")
+			.select("id")
+			.limit(1)
+			.executeTakeFirst();
+		const bundleIds = new Set<string>();
+		let bundlesHaveUniqueIds = true;
+		for (const bundle of imported.bundles) {
+			if (bundle.id === undefined || bundleIds.has(bundle.id)) {
+				bundlesHaveUniqueIds = false;
+				break;
+			}
+			bundleIds.add(bundle.id);
+		}
+		const messageKeys = new Set<string>();
+		let messagesHaveUniqueKeys = true;
+		for (const message of imported.messages) {
+			const key = `${message.bundleId}\u0000${message.locale}`;
+			if (messageKeys.has(key)) {
+				messagesHaveUniqueKeys = false;
+				break;
+			}
+			messageKeys.add(key);
+		}
+		const canBatchImportFreshProject =
+			hasExistingBundles === undefined &&
+			bundlesHaveUniqueIds &&
+			messagesHaveUniqueKeys &&
+			imported.messages.every((message) => message.id === undefined) &&
+			imported.variants.every(
+				(variant) =>
+					variant.id === undefined &&
+					variant.messageId === undefined &&
+					variant.messageBundleId !== undefined &&
+					variant.messageLocale !== undefined
+			) &&
+			imported.messages.every((message) => bundleIds.has(message.bundleId)) &&
+			imported.variants.every((variant) =>
+				messageKeys.has(
+					`${variant.messageBundleId}\u0000${variant.messageLocale}`
+				)
+			);
+
+		if (canBatchImportFreshProject) {
+			if (imported.bundles.length > 0) {
+				await trx.insertInto("bundle").values(imported.bundles).execute();
+			}
+
+			const messagesWithIds = imported.messages.map((message) => ({
+				...message,
+				id: v7(),
+			}));
+			for (let offset = 0; offset < messagesWithIds.length; offset += 500) {
+				await trx
+					.insertInto("message")
+					.values(messagesWithIds.slice(offset, offset + 500))
+					.execute();
+			}
+
+			const messageIds = new Map(
+				messagesWithIds.map((message) => [
+					`${message.bundleId}\u0000${message.locale}`,
+					message.id,
+				])
+			);
+			const variantsWithMessageIds: NewVariant[] = imported.variants.map(
+				(variant) => {
+					const messageId = messageIds.get(
+						`${variant.messageBundleId}\u0000${variant.messageLocale}`
+					);
+					if (messageId === undefined) {
+						throw new Error("Imported variant does not reference a message");
+					}
+					return {
+						messageId,
+						matches: variant.matches,
+						pattern: variant.pattern,
+					};
+				}
+			);
+			for (let offset = 0; offset < variantsWithMessageIds.length; offset += 500) {
+				await trx
+					.insertInto("variant")
+					.values(variantsWithMessageIds.slice(offset, offset + 500))
+					.execute();
+			}
+			return;
+		}
+
 		// upsert every bundle
 		for (const bundle of imported.bundles) {
 			await trx

--- a/packages/sdk/src/project/loadProjectFromDirectory.bench.ts
+++ b/packages/sdk/src/project/loadProjectFromDirectory.bench.ts
@@ -1,0 +1,34 @@
+import { bench } from "vitest";
+import nodeFs from "node:fs";
+import nodePath from "node:path";
+import { memfs } from "memfs";
+import { loadProjectFromDirectory } from "./loadProjectFromDirectory.js";
+
+const pluginAsText = nodeFs.readFileSync(
+	nodePath.join(
+		process.cwd(),
+		"packages/plugins/inlang-message-format/dist/index.js"
+	),
+	"utf8"
+);
+const messageData = Object.fromEntries(
+	Array.from({ length: 1000 }, (_, i) => [`message_${i}`, `Hello {username} #${i}`])
+);
+const localeNames = Array.from({ length: 10 }, (_, i) => `locale_${i}`);
+const fs = memfs({
+	"/plugin.js": pluginAsText,
+	"/project.inlang/settings.json": JSON.stringify({
+		baseLocale: localeNames[0],
+		locales: localeNames,
+		modules: ["/plugin.js"],
+		"plugin.inlang.messageFormat": { pathPattern: "/{locale}.json" },
+	}),
+	...Object.fromEntries(
+		localeNames.map((locale) => [`/${locale}.json`, JSON.stringify(messageData)])
+	),
+}).fs as unknown as typeof import("node:fs");
+
+bench("load project from directory", async () => {
+	const project = await loadProjectFromDirectory({ path: "/project.inlang", fs });
+	await project.close();
+}, { iterations: 1, time: 100 });


### PR DESCRIPTION
## Stack

Builds on #4392. This is the corrected replacement for the accidentally empty stack PR; it is based on the map-only branch.

## What changed

When a project database is empty and a plugin returns unambiguous generated ids, insert bundles, messages, and variants in bounded batches inside the existing transaction. Inputs with ids, duplicate keys, missing relationships, or existing data continue through the established row-by-row path.

## Why

Paraglide compilation imported each message and variant with individual SQLite round trips. The fresh JSON-project path is the common compiler case.

## Validation

- SDK typecheck and tests: 112 passed, 19 skipped
- 10 locales × 1,000 messages load benchmark: ~1,669 ms → ~196 ms (~88% faster)
- batch sizes are capped at 500 to avoid SQLite parameter limits
- no public API changes