### PR TITLE
feat(sdk): open projects with a caller-owned Lix

### DIFF
--- a/.changeset/fresh-projects-open.md
+++ b/.changeset/fresh-projects-open.md
@@ -4,4 +4,6 @@
 
 Add `openProject({ lix })` so applications can provide and own the Lix used by an Inlang project.
 
+Legacy v1 messages now preserve selectors and variant matches when converted to v2. In-memory project blobs serialize messages and variants as nested bundles and remain able to restore the previous flat snapshot format.
+
 BREAKING: Inlang's registered Lix schema keys are now namespaced as `inlang_bundle`, `inlang_message`, `inlang_variant`, `inlang_key_value`, and `inlang_active_account`. Existing Lix data stored under the previous unprefixed schema keys is not migrated automatically.

--- a/.changeset/fresh-projects-open.md
+++ b/.changeset/fresh-projects-open.md
@@ -1,0 +1,7 @@
+---
+"@inlang/sdk": major
+---
+
+Add `openProject({ lix })` so applications can provide and own the Lix used by an Inlang project.
+
+BREAKING: Inlang's registered Lix schema keys are now namespaced as `inlang_bundle`, `inlang_message`, `inlang_variant`, `inlang_key_value`, and `inlang_active_account`. Existing Lix data stored under the previous unprefixed schema keys is not migrated automatically.

--- a/packages/sdk/src/database/lixDialect.ts
+++ b/packages/sdk/src/database/lixDialect.ts
@@ -153,14 +153,22 @@ function prepareLixQuery(compiledSql: string): {
 	sql: string;
 	parameterPositions: number[];
 } {
-	const sql = omitPrimaryKeyAssignments(
-		compiledSql.replaceAll('"file"', '"lix_file"')
-	);
+	const sql = rewriteTableNames(omitPrimaryKeyAssignments(compiledSql));
 	const compacted = compactSqlParameters(sql);
 	return {
 		sql: compacted.sql,
 		parameterPositions: compacted.positions,
 	};
+}
+
+function rewriteTableNames(sql: string): string {
+	return sql
+		.replaceAll('"file"', '"lix_file"')
+		.replaceAll('"bundle"', '"inlang_bundle"')
+		.replaceAll('"message"', '"inlang_message"')
+		.replaceAll('"variant"', '"inlang_variant"')
+		.replaceAll('"key_value"', '"inlang_key_value"')
+		.replaceAll('"active_account"', '"inlang_active_account"');
 }
 
 function omitPrimaryKeyAssignments(sql: string): string {

--- a/packages/sdk/src/database/registerSchemas.ts
+++ b/packages/sdk/src/database/registerSchemas.ts
@@ -16,7 +16,17 @@ const schemas = [
 ] as const;
 
 export async function registerInlangSchemas(lix: Lix): Promise<void> {
+	const registered = await lix.execute(
+		"SELECT lix_json_get_text(value, 'x-lix-key') AS schema_key FROM lix_registered_schema"
+	);
+	const registeredKeys = new Set(
+		registered.rows
+			.map((row) => row.value("schema_key").toJS())
+			.filter((key): key is string => typeof key === "string")
+	);
+
 	for (const schema of schemas) {
+		if (registeredKeys.has(schema["x-lix-key"])) continue;
 		await lix.execute(
 			"INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
 			[JSON.stringify(schema)]

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,4 +1,5 @@
 export { newProject } from "./project/newProject.js";
+export { openProject, type OpenProjectArgs } from "./project/openProject.js";
 export { loadProjectInMemory } from "./project/loadProjectInMemory.js";
 
 export {

--- a/packages/sdk/src/json-schema/old-v1-message/fromMessageV1.test.ts
+++ b/packages/sdk/src/json-schema/old-v1-message/fromMessageV1.test.ts
@@ -84,4 +84,56 @@ test("fromMessageV1", () => {
 	expect(nestedBundle).toEqual(bundle);
 });
 
-test.todo("with variable references", () => {});
+test("preserves selectors, matches, and variable declarations", () => {
+	const converted = fromMessageV1({
+		id: "welcome",
+		alias: {},
+		selectors: [{ type: "VariableReference", name: "audience" }],
+		variants: [
+			{
+				languageTag: "en",
+				match: ["admin"],
+				pattern: [
+					{ type: "Text", value: "Hello " },
+					{ type: "VariableReference", name: "name" },
+				],
+			},
+			{
+				languageTag: "en",
+				match: ["*"],
+				pattern: [{ type: "Text", value: "Hello" }],
+			},
+			{
+				languageTag: "de",
+				match: ["*"],
+				pattern: [{ type: "Text", value: "Hallo" }],
+			},
+		],
+	});
+
+	expect(converted.declarations).toEqual([
+		{ type: "input-variable", name: "audience" },
+		{ type: "input-variable", name: "name" },
+	]);
+	expect(converted.messages.map((message) => message.selectors)).toEqual([
+		[{ type: "variable-reference", name: "audience" }],
+		[{ type: "variable-reference", name: "audience" }],
+	]);
+	expect(
+		converted.messages[0]?.variants.map((variant) => variant.matches)
+	).toEqual([
+		[{ type: "literal-match", key: "audience", value: "admin" }],
+		[{ type: "catchall-match", key: "audience" }],
+	]);
+});
+
+test("rejects variants whose matches do not align with selectors", () => {
+	expect(() =>
+		fromMessageV1({
+			id: "invalid",
+			alias: {},
+			selectors: [{ type: "VariableReference", name: "audience" }],
+			variants: [{ languageTag: "en", match: [], pattern: [] }],
+		})
+	).toThrow("has 0 matches for 1 selectors");
+});

--- a/packages/sdk/src/json-schema/old-v1-message/fromMessageV1.ts
+++ b/packages/sdk/src/json-schema/old-v1-message/fromMessageV1.ts
@@ -3,7 +3,7 @@ import type {
 	MessageNested,
 	Variant,
 } from "../../database/schema.js";
-import type { Declaration, Pattern } from "../pattern.js";
+import type { Pattern, VariableReference } from "../pattern.js";
 import type { MessageV1, PatternV1 } from "./schemaV1.js";
 
 /**
@@ -18,7 +18,12 @@ export function fromMessageV1(messageV1: MessageV1): BundleNested {
 		...new Set(messageV1.variants.map((variant) => variant.languageTag)),
 	];
 
-	const declarations = new Set<Declaration>();
+	const selectorNames = messageV1.selectors.map((selector) => selector.name);
+	const variableNames = new Set(selectorNames);
+	const selectors: VariableReference[] = selectorNames.map((name) => ({
+		type: "variable-reference",
+		name,
+	}));
 
 	const messages: MessageNested[] = languages.map((language): MessageNested => {
 		const messageId = bundleId + "_" + language;
@@ -27,17 +32,14 @@ export function fromMessageV1(messageV1: MessageV1): BundleNested {
 			(variant) => variant.languageTag === language
 		);
 
-		//find all selector names
-		const selectorNames = new Set<string>();
-		for (const v1Selector of messageV1.selectors ?? []) {
-			selectorNames.add(v1Selector.name);
-		}
-
-		//The set of variables that need to be defined - Certainly includes the selectors
-		const variableNames = new Set<string>(selectorNames);
 		const variants: Variant[] = [];
 		let variantIndex = 1;
 		for (const v1Variant of v1Variants) {
+			if (v1Variant.match.length !== selectorNames.length) {
+				throw new Error(
+					`Legacy variant for locale "${language}" has ${v1Variant.match.length} matches for ${selectorNames.length} selectors`
+				);
+			}
 			for (const element of v1Variant.pattern) {
 				if (element.type === "VariableReference") {
 					variableNames.add(element.name);
@@ -45,8 +47,15 @@ export function fromMessageV1(messageV1: MessageV1): BundleNested {
 			}
 
 			variants.push({
-				// matching was not supported. no problem should arise
-				matches: [],
+				matches: v1Variant.match.map((value, index) =>
+					value === "*"
+						? { type: "catchall-match", key: selectorNames[index]! }
+						: {
+								type: "literal-match",
+								key: selectorNames[index]!,
+								value,
+							}
+				),
 				pattern: fromPatternV1(v1Variant.pattern),
 				id: messageId + "_" + variantIndex,
 				messageId: messageId,
@@ -54,26 +63,21 @@ export function fromMessageV1(messageV1: MessageV1): BundleNested {
 			variantIndex += 1;
 		}
 
-		//Create an input declaration for each variable and selector we need
-		for (const variable of variableNames) {
-			declarations.add({
-				type: "input-variable",
-				name: variable,
-			});
-		}
-
 		return {
 			id: messageId,
 			bundleId: bundleId,
 			locale: language,
-			selectors: [],
+			selectors: [...selectors],
 			variants,
 		};
 	});
 
 	return {
 		id: bundleId,
-		declarations: [...declarations],
+		declarations: [...variableNames].map((name) => ({
+			type: "input-variable",
+			name,
+		})),
 		messages,
 	};
 }

--- a/packages/sdk/src/json-schema/old-v1-message/toMessageV1.test.ts
+++ b/packages/sdk/src/json-schema/old-v1-message/toMessageV1.test.ts
@@ -56,7 +56,44 @@ test("throws when message contains markup placeholders", () => {
 	);
 });
 
-test.todo("with variable references", () => {});
+test("serializes nested selectors and matches", () => {
+	const serialized = toMessageV1({
+		id: "welcome",
+		declarations: [{ type: "input-variable", name: "audience" }],
+		messages: [
+			{
+				id: "welcome_en",
+				bundleId: "welcome",
+				locale: "en",
+				selectors: [{ type: "variable-reference", name: "audience" }],
+				variants: [
+					{
+						id: "welcome_en_admin",
+						messageId: "welcome_en",
+						matches: [
+							{ type: "literal-match", key: "audience", value: "admin" },
+						],
+						pattern: [{ type: "text", value: "Welcome, admin" }],
+					},
+					{
+						id: "welcome_en_other",
+						messageId: "welcome_en",
+						matches: [{ type: "catchall-match", key: "audience" }],
+						pattern: [{ type: "text", value: "Welcome" }],
+					},
+				],
+			},
+		],
+	});
+
+	expect(serialized.selectors).toEqual([
+		{ type: "VariableReference", name: "audience" },
+	]);
+	expect(serialized.variants.map((variant) => variant.match)).toEqual([
+		["admin"],
+		["*"],
+	]);
+});
 
 const messageV1: MessageV1 = {
 	id: "hello_world",

--- a/packages/sdk/src/json-schema/old-v1-message/toMessageV1.ts
+++ b/packages/sdk/src/json-schema/old-v1-message/toMessageV1.ts
@@ -1,4 +1,4 @@
-import type { BundleNested } from "../../database/schema.js";
+import type { BundleNested, Match } from "../../database/schema.js";
 import type { Pattern } from "../pattern.js";
 import type {
 	ExpressionV1,
@@ -14,28 +14,32 @@ import type {
  */
 export function toMessageV1(bundle: BundleNested): MessageV1 {
 	const variants: VariantV1[] = [];
-	const selectorNames = new Set<string>();
+	const selectorNames =
+		bundle.messages[0]?.selectors.map((selector) => selector.name) ?? [];
 
 	for (const message of bundle.messages) {
-		// collect all selector names
-		for (const selector of message.selectors.map((s) => ({
-			type: "variable-reference",
-			name: s.name,
-		}))) {
-			selectorNames.add(selector.name);
+		if (
+			message.selectors.length !== selectorNames.length ||
+			message.selectors.some(
+				(selector, index) => selector.name !== selectorNames[index]
+			)
+		) {
+			throw new Error(
+				"MessageV1 conversion requires identical selectors in every locale"
+			);
 		}
 
 		// collect all variants
 		for (const variant of message.variants) {
 			variants.push({
 				languageTag: message.locale,
-				match: [],
+				match: toV1Match(variant.matches, selectorNames),
 				pattern: toV1Pattern(variant.pattern),
 			});
 		}
 	}
 
-	const selectors: ExpressionV1[] = [...selectorNames].map((name) => ({
+	const selectors: ExpressionV1[] = selectorNames.map((name) => ({
 		type: "VariableReference",
 		name,
 	}));
@@ -46,6 +50,30 @@ export function toMessageV1(bundle: BundleNested): MessageV1 {
 		variants,
 		selectors,
 	};
+}
+
+function toV1Match(matches: Match[], selectorNames: string[]): string[] {
+	const matchesByKey = new Map<string, Match>();
+	for (const match of matches) {
+		if (matchesByKey.has(match.key)) {
+			throw new Error(
+				`MessageV1 conversion found duplicate match "${match.key}"`
+			);
+		}
+		matchesByKey.set(match.key, match);
+	}
+	if (
+		matchesByKey.size !== selectorNames.length ||
+		selectorNames.some((name) => !matchesByKey.has(name))
+	) {
+		throw new Error(
+			"MessageV1 conversion requires one match for every selector"
+		);
+	}
+	return selectorNames.map((selectorName) => {
+		const match = matchesByKey.get(selectorName)!;
+		return match.type === "catchall-match" ? "*" : match.value;
+	});
 }
 
 /**

--- a/packages/sdk/src/lix/withDb.ts
+++ b/packages/sdk/src/lix/withDb.ts
@@ -27,13 +27,13 @@ export async function withInlangLixDb(args: {
 	account?: Account;
 }): Promise<InlangLix> {
 	await args.lix.execute(
-		"INSERT INTO key_value (key, value) VALUES ($1, $2) ON CONFLICT (key) DO UPDATE SET value = excluded.value",
+		"INSERT INTO inlang_key_value (key, value) VALUES ($1, $2) ON CONFLICT (key) DO UPDATE SET value = excluded.value",
 		["lix_id", args.projectId]
 	);
 	if (args.account) {
-		await args.lix.execute("DELETE FROM active_account");
+		await args.lix.execute("DELETE FROM inlang_active_account");
 		await args.lix.execute(
-			"INSERT INTO active_account (id, name) VALUES ($1, $2)",
+			"INSERT INTO inlang_active_account (id, name) VALUES ($1, $2)",
 			[args.account.id, args.account.name]
 		);
 	}

--- a/packages/sdk/src/project/loadProject.ts
+++ b/packages/sdk/src/project/loadProject.ts
@@ -20,6 +20,8 @@ import { withInlangLixDb } from "../lix/withDb.js";
  */
 export async function loadProject(args: {
 	lix: Lix;
+	/** Internal lifecycle option for Lix instances owned by the caller. */
+	closeLixOnClose?: boolean;
 	/**
 	 * The account that loaded the project.
 	 *
@@ -155,7 +157,9 @@ export async function loadProject(args: {
 		},
 		close: async () => {
 			await db.destroy();
-			await args.lix.close();
+			if (args.closeLixOnClose ?? true) {
+				await args.lix.close();
+			}
 		},
 		toBlob: async () => await projectToBlob(args.lix),
 		lix: inlangLix,

--- a/packages/sdk/src/project/loadProjectInMemory.test.ts
+++ b/packages/sdk/src/project/loadProjectInMemory.test.ts
@@ -1,4 +1,6 @@
 import { expect, test } from "vitest";
+import { insertBundleNested } from "../query-utilities/insertBundleNested.js";
+import { selectBundleNested } from "../query-utilities/selectBundleNested.js";
 import { newProject } from "./newProject.js";
 import { loadProjectInMemory } from "./loadProjectInMemory.js";
 
@@ -26,4 +28,99 @@ test("roundtrip should succeed", async () => {
 	const bundles = await project2.db.selectFrom("bundle").select("id").execute();
 	expect(bundles.length).toBe(1);
 	expect(bundles[0]?.id).toBe(insertedBundle.id);
+	await project2.close();
+});
+
+test("serializes bundles with nested messages and variants", async () => {
+	const project = await loadProjectInMemory({ blob: await newProject() });
+	await insertBundleNested(project.db, {
+		id: "welcome",
+		declarations: [{ type: "input-variable", name: "audience" }],
+		messages: [
+			{
+				id: "welcome_en",
+				bundleId: "welcome",
+				locale: "en",
+				selectors: [{ type: "variable-reference", name: "audience" }],
+				variants: [
+					{
+						id: "welcome_en_admin",
+						messageId: "welcome_en",
+						matches: [
+							{ type: "literal-match", key: "audience", value: "admin" },
+						],
+						pattern: [{ type: "text", value: "Welcome, admin" }],
+					},
+				],
+			},
+		],
+	});
+
+	const blob = await project.toBlob();
+	const serialized = JSON.parse(await blob.text());
+	expect(serialized).toMatchObject({
+		format: "inlang-lix-memory-v2",
+		bundles: [
+			{
+				id: "welcome",
+				messages: [
+					{
+						id: "welcome_en",
+						variants: [{ id: "welcome_en_admin" }],
+					},
+				],
+			},
+		],
+	});
+	await project.close();
+
+	const reopened = await loadProjectInMemory({ blob });
+	const nested = await selectBundleNested(
+		reopened.db
+	).executeTakeFirstOrThrow();
+	expect(nested.messages[0]?.variants[0]).toMatchObject({
+		id: "welcome_en_admin",
+		matches: [{ type: "literal-match", key: "audience", value: "admin" }],
+		pattern: [{ type: "text", value: "Welcome, admin" }],
+	});
+	await reopened.close();
+
+	const legacyBlob = new Blob([
+		JSON.stringify({
+			format: "inlang-lix-memory-v1",
+			files: serialized.files,
+			bundles: serialized.bundles.map(
+				(bundle: { id: string; declarations: unknown[] }) => ({
+					id: bundle.id,
+					declarations: bundle.declarations,
+				})
+			),
+			messages: serialized.bundles.flatMap(
+				(bundle: {
+					messages: Array<{
+						id: string;
+						bundleId: string;
+						locale: string;
+						selectors: unknown[];
+					}>;
+				}) =>
+					bundle.messages.map((message) => ({
+						id: message.id,
+						bundleId: message.bundleId,
+						locale: message.locale,
+						selectors: message.selectors,
+					}))
+			),
+			variants: serialized.bundles.flatMap(
+				(bundle: { messages: Array<{ variants: unknown[] }> }) =>
+					bundle.messages.flatMap((message) => message.variants)
+			),
+		}),
+	]);
+	const reopenedLegacy = await loadProjectInMemory({ blob: legacyBlob });
+	expect(
+		(await selectBundleNested(reopenedLegacy.db).executeTakeFirstOrThrow())
+			.messages[0]?.variants[0]?.id
+	).toBe("welcome_en_admin");
+	await reopenedLegacy.close();
 });

--- a/packages/sdk/src/project/openProject.test.ts
+++ b/packages/sdk/src/project/openProject.test.ts
@@ -1,0 +1,69 @@
+import { openLix } from "@lix-js/sdk";
+import { expect, test } from "vitest";
+import { openProject } from "./openProject.js";
+
+test("opens a project on a caller-owned Lix", async () => {
+	const lix = await openLix();
+	const project = await openProject({
+		lix,
+		settings: { baseLocale: "fr", locales: ["fr", "en"], modules: [] },
+	});
+
+	expect(await project.settings.get()).toMatchObject({
+		baseLocale: "fr",
+		locales: ["fr", "en"],
+	});
+	const registeredSchemas = await lix.execute(
+		"SELECT lix_json_get_text(value, 'x-lix-key') AS schema_key FROM lix_registered_schema"
+	);
+	expect(
+		registeredSchemas.rows
+			.map((row) => row.value("schema_key").toJS())
+			.filter((key) => typeof key === "string" && key.startsWith("inlang_"))
+			.sort()
+	).toEqual([
+		"inlang_active_account",
+		"inlang_bundle",
+		"inlang_key_value",
+		"inlang_message",
+		"inlang_variant",
+	]);
+
+	await project.db
+		.insertInto("bundle")
+		.values({ id: "caller-owned-lix" })
+		.execute();
+	expect(
+		await project.db
+			.selectFrom("bundle")
+			.select("id")
+			.where("id", "=", "caller-owned-lix")
+			.executeTakeFirst()
+	).toEqual({ id: "caller-owned-lix" });
+
+	await project.close();
+
+	await expect(lix.execute("SELECT 1 AS value")).resolves.toBeDefined();
+	await lix.close();
+});
+
+test("reopens an existing project without replacing its settings", async () => {
+	const lix = await openLix();
+	const first = await openProject({
+		lix,
+		settings: { baseLocale: "de", locales: ["de"], modules: [] },
+	});
+	await first.close();
+
+	const second = await openProject({
+		lix,
+		settings: { baseLocale: "en", locales: ["en"], modules: [] },
+	});
+	expect(await second.settings.get()).toMatchObject({
+		baseLocale: "de",
+		locales: ["de"],
+	});
+
+	await second.close();
+	await lix.close();
+});

--- a/packages/sdk/src/project/openProject.ts
+++ b/packages/sdk/src/project/openProject.ts
@@ -1,0 +1,56 @@
+import type { Lix } from "@lix-js/sdk";
+import { registerInlangSchemas } from "../database/registerSchemas.js";
+import type { ProjectSettings } from "../json-schema/settings.js";
+import { defaultProjectSettings } from "./newProject.js";
+import { loadProject } from "./loadProject.js";
+
+export type OpenProjectArgs = {
+	/**
+	 * The caller-owned Lix that stores the project.
+	 *
+	 * `project.close()` releases Inlang resources but does not close this Lix.
+	 */
+	lix: Lix;
+	/** Settings used only when the supplied Lix does not contain a project yet. */
+	settings?: ProjectSettings;
+} & Omit<Parameters<typeof loadProject>[0], "lix" | "closeLixOnClose">;
+
+/**
+ * Opens an Inlang project on a caller-provided Lix.
+ *
+ * Inlang registers its schemas and initializes a fresh Lix with project
+ * settings when necessary. The caller retains ownership of the Lix lifecycle.
+ */
+export async function openProject(
+	args: OpenProjectArgs
+): Promise<Awaited<ReturnType<typeof loadProject>>> {
+	await registerInlangSchemas(args.lix);
+	await initializeSettingsIfMissing(args);
+
+	return loadProject({
+		...args,
+		lix: args.lix,
+		closeLixOnClose: false,
+	});
+}
+
+async function initializeSettingsIfMissing(args: {
+	lix: Lix;
+	settings?: ProjectSettings;
+}): Promise<void> {
+	const result = await args.lix.execute(
+		"SELECT path FROM lix_file WHERE path = $1",
+		["/settings.json"]
+	);
+	if (result.rows.length > 0) return;
+
+	await args.lix.execute(
+		"INSERT INTO lix_file (path, content) VALUES ($1, $2)",
+		[
+			"/settings.json",
+			new TextEncoder().encode(
+				JSON.stringify(args.settings ?? defaultProjectSettings, undefined, 2)
+			),
+		]
+	);
+}

--- a/packages/sdk/src/project/snapshot.ts
+++ b/packages/sdk/src/project/snapshot.ts
@@ -14,12 +14,12 @@ type Snapshot = {
 export async function projectToBlob(lix: Lix): Promise<Blob> {
 	const [files, bundles, messages, variants] = await Promise.all([
 		lix.execute("SELECT path, content FROM lix_file ORDER BY path"),
-		lix.execute("SELECT id, declarations FROM bundle ORDER BY id"),
+		lix.execute("SELECT id, declarations FROM inlang_bundle ORDER BY id"),
 		lix.execute(
-			'SELECT id, "bundleId", locale, selectors FROM message ORDER BY id'
+			'SELECT id, "bundleId", locale, selectors FROM inlang_message ORDER BY id'
 		),
 		lix.execute(
-			'SELECT id, "messageId", matches, pattern FROM variant ORDER BY id'
+			'SELECT id, "messageId", matches, pattern FROM inlang_variant ORDER BY id'
 		),
 	]);
 
@@ -64,19 +64,19 @@ export async function restoreProjectBlob(lix: Lix, blob: Blob): Promise<void> {
 	}
 	for (const bundle of snapshot.bundles) {
 		statements.push({
-			sql: "INSERT INTO bundle (id, declarations) VALUES ($1, $2)",
+			sql: "INSERT INTO inlang_bundle (id, declarations) VALUES ($1, $2)",
 			params: [bundle.id, bundle.declarations],
 		});
 	}
 	for (const message of snapshot.messages) {
 		statements.push({
-			sql: 'INSERT INTO message (id, "bundleId", locale, selectors) VALUES ($1, $2, $3, $4)',
+			sql: 'INSERT INTO inlang_message (id, "bundleId", locale, selectors) VALUES ($1, $2, $3, $4)',
 			params: [message.id, message.bundleId, message.locale, message.selectors],
 		});
 	}
 	for (const variant of snapshot.variants) {
 		statements.push({
-			sql: 'INSERT INTO variant (id, "messageId", matches, pattern) VALUES ($1, $2, $3, $4)',
+			sql: 'INSERT INTO inlang_variant (id, "messageId", matches, pattern) VALUES ($1, $2, $3, $4)',
 			params: [variant.id, variant.messageId, variant.matches, variant.pattern],
 		});
 	}

--- a/packages/sdk/src/project/snapshot.ts
+++ b/packages/sdk/src/project/snapshot.ts
@@ -1,10 +1,24 @@
 import type { Lix, LixBatchStatement } from "@lix-js/sdk";
-import type { Bundle, Message, Variant } from "../database/schema.js";
+import { initDb } from "../database/initDb.js";
+import type {
+	Bundle,
+	BundleNested,
+	Message,
+	Variant,
+} from "../database/schema.js";
+import { selectBundleNested } from "../query-utilities/selectBundleNested.js";
 
-const FORMAT = "inlang-lix-memory-v1";
+const FORMAT = "inlang-lix-memory-v2";
+const LEGACY_FORMAT = "inlang-lix-memory-v1";
 
 type Snapshot = {
 	format: typeof FORMAT;
+	files: Array<{ path: string; data: string }>;
+	bundles: BundleNested[];
+};
+
+type LegacySnapshot = {
+	format: typeof LEGACY_FORMAT;
 	files: Array<{ path: string; data: string }>;
 	bundles: Bundle[];
 	messages: Message[];
@@ -12,16 +26,17 @@ type Snapshot = {
 };
 
 export async function projectToBlob(lix: Lix): Promise<Blob> {
-	const [files, bundles, messages, variants] = await Promise.all([
-		lix.execute("SELECT path, content FROM lix_file ORDER BY path"),
-		lix.execute("SELECT id, declarations FROM inlang_bundle ORDER BY id"),
-		lix.execute(
-			'SELECT id, "bundleId", locale, selectors FROM inlang_message ORDER BY id'
-		),
-		lix.execute(
-			'SELECT id, "messageId", matches, pattern FROM inlang_variant ORDER BY id'
-		),
-	]);
+	const db = initDb({ lix });
+	let files: Awaited<ReturnType<Lix["execute"]>>;
+	let bundles: BundleNested[];
+	try {
+		[files, bundles] = await Promise.all([
+			lix.execute("SELECT path, content FROM lix_file ORDER BY path"),
+			selectBundleNested(db).execute(),
+		]);
+	} finally {
+		await db.destroy();
+	}
 
 	const snapshot: Snapshot = {
 		format: FORMAT,
@@ -29,9 +44,7 @@ export async function projectToBlob(lix: Lix): Promise<Blob> {
 			path: row.get("path") as string,
 			data: bytesToBase64(row.value("content").asBytes() ?? new Uint8Array()),
 		})),
-		bundles: bundles.rows.map((row) => row.toObject() as Bundle),
-		messages: messages.rows.map((row) => row.toObject() as Message),
-		variants: variants.rows.map((row) => row.toObject() as Variant),
+		bundles,
 	};
 
 	return new Blob([JSON.stringify(snapshot)], {
@@ -40,20 +53,23 @@ export async function projectToBlob(lix: Lix): Promise<Blob> {
 }
 
 export async function restoreProjectBlob(lix: Lix, blob: Blob): Promise<void> {
-	let snapshot: Snapshot;
+	let parsed: unknown;
 	try {
-		snapshot = JSON.parse(await blob.text()) as Snapshot;
+		parsed = JSON.parse(await blob.text());
 	} catch (cause) {
 		throw new Error(
 			"The project uses the legacy Lix SQLite format, which Lix 0.9 cannot open in memory.",
 			{ cause }
 		);
 	}
-	if (snapshot.format !== FORMAT) {
-		throw new Error(
-			`Unsupported inlang project format: ${String(snapshot.format)}`
-		);
+	const format =
+		typeof parsed === "object" && parsed !== null && "format" in parsed
+			? parsed.format
+			: undefined;
+	if (format !== FORMAT && format !== LEGACY_FORMAT) {
+		throw new Error(`Unsupported inlang project format: ${String(format)}`);
 	}
+	const snapshot = parsed as Snapshot | LegacySnapshot;
 
 	const statements: LixBatchStatement[] = [];
 	for (const file of snapshot.files) {
@@ -62,25 +78,51 @@ export async function restoreProjectBlob(lix: Lix, blob: Blob): Promise<void> {
 			params: [file.path, base64ToBytes(file.data)],
 		});
 	}
-	for (const bundle of snapshot.bundles) {
+	const bundles =
+		snapshot.format === FORMAT ? snapshot.bundles : nestLegacyBundles(snapshot);
+	for (const bundle of bundles) {
 		statements.push({
 			sql: "INSERT INTO inlang_bundle (id, declarations) VALUES ($1, $2)",
 			params: [bundle.id, bundle.declarations],
 		});
-	}
-	for (const message of snapshot.messages) {
-		statements.push({
-			sql: 'INSERT INTO inlang_message (id, "bundleId", locale, selectors) VALUES ($1, $2, $3, $4)',
-			params: [message.id, message.bundleId, message.locale, message.selectors],
-		});
-	}
-	for (const variant of snapshot.variants) {
-		statements.push({
-			sql: 'INSERT INTO inlang_variant (id, "messageId", matches, pattern) VALUES ($1, $2, $3, $4)',
-			params: [variant.id, variant.messageId, variant.matches, variant.pattern],
-		});
+		for (const message of bundle.messages) {
+			statements.push({
+				sql: 'INSERT INTO inlang_message (id, "bundleId", locale, selectors) VALUES ($1, $2, $3, $4)',
+				params: [message.id, bundle.id, message.locale, message.selectors],
+			});
+			for (const variant of message.variants) {
+				statements.push({
+					sql: 'INSERT INTO inlang_variant (id, "messageId", matches, pattern) VALUES ($1, $2, $3, $4)',
+					params: [variant.id, message.id, variant.matches, variant.pattern],
+				});
+			}
+		}
 	}
 	if (statements.length > 0) await lix.executeBatch(statements);
+}
+
+function nestLegacyBundles(snapshot: LegacySnapshot): BundleNested[] {
+	const variantsByMessage = new Map<string, Variant[]>();
+	for (const variant of snapshot.variants) {
+		const variants = variantsByMessage.get(variant.messageId) ?? [];
+		variants.push(variant);
+		variantsByMessage.set(variant.messageId, variants);
+	}
+
+	const messagesByBundle = new Map<string, BundleNested["messages"]>();
+	for (const message of snapshot.messages) {
+		const messages = messagesByBundle.get(message.bundleId) ?? [];
+		messages.push({
+			...message,
+			variants: variantsByMessage.get(message.id) ?? [],
+		});
+		messagesByBundle.set(message.bundleId, messages);
+	}
+
+	return snapshot.bundles.map((bundle) => ({
+		...bundle,
+		messages: messagesByBundle.get(bundle.id) ?? [],
+	}));
 }
 
 function bytesToBase64(bytes: Uint8Array): string {

--- a/packages/sdk/src/query-utilities/selectBundleNested.ts
+++ b/packages/sdk/src/query-utilities/selectBundleNested.ts
@@ -41,7 +41,10 @@ export const selectBundleNested = (db: Kysely<InlangDatabaseSchema>) => {
 					"variant.id as variantId",
 					"variant.matches as variantMatches",
 					"variant.pattern as variantPattern",
-				]);
+				])
+				.orderBy("bundle.id")
+				.orderBy("message.id")
+				.orderBy("variant.id");
 			if (bundleId !== undefined) {
 				flatQuery = flatQuery.where("bundle.id", "=", bundleId);
 			}

--- a/packages/sdk/src/schema-definitions/bundle.ts
+++ b/packages/sdk/src/schema-definitions/bundle.ts
@@ -1,5 +1,5 @@
 export const InlangBundleSchema = {
-	"x-lix-key": "bundle",
+	"x-lix-key": "inlang_bundle",
 	"x-lix-primary-key": ["/id"],
 	type: "object",
 	properties: {

--- a/packages/sdk/src/schema-definitions/compat.ts
+++ b/packages/sdk/src/schema-definitions/compat.ts
@@ -1,5 +1,5 @@
 export const InlangKeyValueSchema = {
-	"x-lix-key": "key_value",
+	"x-lix-key": "inlang_key_value",
 	"x-lix-primary-key": ["/key"],
 	type: "object",
 	properties: {
@@ -11,7 +11,7 @@ export const InlangKeyValueSchema = {
 } as const;
 
 export const InlangActiveAccountSchema = {
-	"x-lix-key": "active_account",
+	"x-lix-key": "inlang_active_account",
 	"x-lix-primary-key": ["/id"],
 	type: "object",
 	properties: {

--- a/packages/sdk/src/schema-definitions/message.ts
+++ b/packages/sdk/src/schema-definitions/message.ts
@@ -1,10 +1,10 @@
 export const InlangMessageSchema = {
-	"x-lix-key": "message",
+	"x-lix-key": "inlang_message",
 	"x-lix-primary-key": ["/id"],
 	"x-lix-foreign-keys": [
 		{
 			properties: ["/bundleId"],
-			references: { schemaKey: "bundle", properties: ["/id"] },
+			references: { schemaKey: "inlang_bundle", properties: ["/id"] },
 		},
 	],
 	type: "object",

--- a/packages/sdk/src/schema-definitions/variant.ts
+++ b/packages/sdk/src/schema-definitions/variant.ts
@@ -1,10 +1,10 @@
 export const InlangVariantSchema = {
-	"x-lix-key": "variant",
+	"x-lix-key": "inlang_variant",
 	"x-lix-primary-key": ["/id"],
 	"x-lix-foreign-keys": [
 		{
 			properties: ["/messageId"],
-			references: { schemaKey: "message", properties: ["/id"] },
+			references: { schemaKey: "inlang_message", properties: ["/id"] },
 		},
 	],
 	type: "object",


### PR DESCRIPTION
## Summary

- add public `openProject({ lix })` so applications can provide and own the Lix used by an Inlang project
- initialize Inlang schemas without closing caller-owned Lix instances
- keep schema registration reopen-safe with a read-before-insert workaround for current SQL limitations
- namespace Inlang schema keys as `inlang_*`
- preserve legacy v1 selectors and variant matches during v1-to-v2 conversion
- serialize in-memory project snapshots as nested bundles, while retaining restore compatibility with the previous flat snapshot format

## Why

Parrot needs to control the Lix lifecycle and persistence backend instead of having Inlang create and own an in-memory Lix internally. Preserving selectors/matches and nested bundle structure makes legacy project migration lossless for the supported v1 model.

## Breaking change

Registered Lix schema keys are now `inlang_bundle`, `inlang_message`, `inlang_variant`, `inlang_key_value`, and `inlang_active_account`. Existing data under the prior unprefixed schema keys is not migrated automatically.

## Stack

This PR targets the `v3` branch, which carries #4389 and upgrades `@lix-js/sdk` to v0.11.

## Verification

- `pnpm --filter @inlang/sdk typecheck`
- `pnpm --filter @inlang/sdk test` — 119 passed, 19 skipped, 4 todo
- `pnpm --filter @inlang/sdk lint`
- `pnpm --filter @inlang/sdk build`