### PR TITLE
feat(sdk): add browser-safe entrypoint

### DIFF
--- a/.changeset/green-parrots-browse.md
+++ b/.changeset/green-parrots-browse.md
@@ -1,0 +1,5 @@
+---
+"@inlang/sdk": minor
+---
+
+Add a browser-safe `@inlang/sdk/browser` entrypoint for caller-owned Lix projects. It exposes `openProject`, project and message types, nested-bundle query utilities, and atomic Lix batches without exporting Node.js directory APIs.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -14,6 +14,7 @@
 	"types": "./dist/index.d.ts",
 	"exports": {
 		".": "./dist/index.js",
+		"./browser": "./dist/browser.js",
 		"./lix": "./dist/lix/index.js",
 		"./settings-schema": "./src/json-schema/settings.ts"
 	},

--- a/packages/sdk/src/browser.ts
+++ b/packages/sdk/src/browser.ts
@@ -1,0 +1,25 @@
+/**
+ * Browser-safe Inlang SDK entrypoint.
+ *
+ * This intentionally excludes the Node.js directory project APIs exported by
+ * the package root so browser bundlers do not need to externalize `node:fs`
+ * or `node:path`.
+ */
+export { openProject, type OpenProjectArgs } from "./project/openProject.js";
+export type {
+	InlangProject,
+	ImportFile,
+	ExportFile,
+} from "./project/api.js";
+export * from "./json-schema/settings.js";
+export * from "./json-schema/pattern.js";
+export * from "./query-utilities/index.js";
+export * from "./plugin/errors.js";
+export { executeLixBatch } from "./database/lixBatch.js";
+export type {
+	InlangPlugin,
+	BundleImport,
+	MessageImport,
+	VariantImport,
+} from "./plugin/schema.js";
+export * from "./database/schema.js";


### PR DESCRIPTION
## Summary

- add `@inlang/sdk/browser`
- expose `openProject`, project/settings/schema types, nested-bundle query utilities, and atomic Lix batches
- omit Node.js directory/filesystem APIs from the browser export graph
- document the new entrypoint in a changeset

## Why

Browser apps such as Parrot only need caller-owned Lix project APIs. Importing the package root also exposes directory project functions backed by `node:fs` and `node:path`, which causes browser bundlers to externalize Node modules even when those functions are unused.

## Consumer impact

Browser consumers can import project APIs from `@inlang/sdk/browser`. The existing package root remains unchanged.

## Verification

- `pnpm --filter @inlang/sdk typecheck`
- `pnpm --filter @inlang/sdk test` — 119 passed, 19 skipped, 4 todo
- `pnpm --filter @inlang/sdk lint`
- `pnpm --filter @inlang/sdk build`
- Parrot `pnpm tsc`, `pnpm test`, `pnpm lint`, and `pnpm build`
- Parrot's previous `node:fs` / `node:path` warnings from the Inlang SDK are gone