### PR TITLE
Add first-class Android XML and Apple Strings plugins

### DIFF
--- a/.changeset/brave-parrots-export.md
+++ b/.changeset/brave-parrots-export.md
@@ -1,0 +1,6 @@
+---
+"@inlang/plugin-android": minor
+"@inlang/plugin-apple-strings": minor
+---
+
+Add first-class Android XML and Apple `.strings` import/export plugins using the Inlang v2 message model. Android supports positional variables and CLDR plurals; Apple `.strings` supports plain messages and positional variables and rejects selectors that the format cannot represent.

--- a/.changeset/soft-snakes-guard.md
+++ b/.changeset/soft-snakes-guard.md
@@ -1,0 +1,5 @@
+---
+"@inlang/plugin-i18next": patch
+---
+
+Reject selectors that i18next cannot represent instead of silently dropping variants during export.

--- a/.changeset/tidy-plugins-declare.md
+++ b/.changeset/tidy-plugins-declare.md
@@ -1,0 +1,5 @@
+---
+"@inlang/plugin-i18next": patch
+---
+
+Emit the TypeScript declarations advertised by the package during production builds.

--- a/packages/marketplace-registry/registry.json
+++ b/packages/marketplace-registry/registry.json
@@ -15,6 +15,8 @@
 		"698iow33": "https://raw.githubusercontent.com/opral/inlang/refs/heads/main/packages/plugins/t-function-matcher/marketplace-manifest.json",
 		"193hsyds": "https://raw.githubusercontent.com/opral/inlang/refs/heads/main/packages/plugins/next-intl/marketplace-manifest.json",
 		"p7c8m1d2": "https://raw.githubusercontent.com/opral/inlang/refs/heads/main/packages/plugins/icu1/marketplace-manifest.json",
+		"andr0id2": "https://raw.githubusercontent.com/opral/inlang/refs/heads/main/packages/plugins/android/marketplace-manifest.json",
+		"applstr1": "https://raw.githubusercontent.com/opral/inlang/refs/heads/main/packages/plugins/apple-strings/marketplace-manifest.json",
 		"neh2d6w7": "https://cdn.jsdelivr.net/npm/inlang-plugin-xcstrings@latest/marketplace-manifest.json",
 		"3gk8n4n4": "https://raw.githubusercontent.com/opral/inlang/refs/heads/inlang-v1/inlang/source-code/github-lint-action/marketplace-manifest.json",
 		"y0eo8f66": "https://raw.githubusercontent.com/opral/inlang/refs/heads/inlang-v1/inlang/source-code/message-lint-rules/emptyPattern/marketplace-manifest.json",

--- a/packages/plugins/android/README.md
+++ b/packages/plugins/android/README.md
@@ -1,0 +1,19 @@
+# Android Resources plugin for Inlang
+
+Reads and writes Android `strings.xml` files through Inlang's v2 message model.
+
+Supported: exact message keys, XML escaping, positional string variables, and CLDR plural quantities (`zero`, `one`, `two`, `few`, `many`, `other`). Unsupported selector shapes and annotated expressions fail explicitly instead of being dropped.
+
+```json
+{
+  "modules": [
+    "https://cdn.jsdelivr.net/npm/@inlang/plugin-android@latest/dist/index.js"
+  ],
+  "plugin.inlang.android": {
+    "pathPattern": "./res/values{locale}/strings.xml"
+  }
+}
+```
+
+`{locale}` expands to an Android resource qualifier: the base locale uses no
+suffix, `de` uses `-de`, and `en-US` uses `-b+en+US`.

--- a/packages/plugins/android/build.js
+++ b/packages/plugins/android/build.js
@@ -17,6 +17,8 @@ if (isProduction) {
   execFileSync(
     "tsc",
     [
+      "-p",
+      "tsconfig.build.json",
       "--emitDeclarationOnly",
       "--declaration",
       "--declarationMap",

--- a/packages/plugins/android/build.js
+++ b/packages/plugins/android/build.js
@@ -1,4 +1,5 @@
 import { context } from "esbuild";
+import { execFileSync } from "node:child_process";
 const isProduction = process.env.NODE_ENV === "production";
 const ctx = await context({
   entryPoints: ["./src/index.ts"],
@@ -13,6 +14,20 @@ const ctx = await context({
 if (isProduction) {
   await ctx.rebuild();
   await ctx.dispose();
+  execFileSync(
+    "tsc",
+    [
+      "--emitDeclarationOnly",
+      "--declaration",
+      "--declarationMap",
+      "false",
+      "--outDir",
+      "dist",
+      "--noEmit",
+      "false",
+    ],
+    { stdio: "inherit" },
+  );
 } else {
   await ctx.watch();
   console.info("Watching for changes...");

--- a/packages/plugins/android/build.js
+++ b/packages/plugins/android/build.js
@@ -1,0 +1,19 @@
+import { context } from "esbuild";
+const isProduction = process.env.NODE_ENV === "production";
+const ctx = await context({
+  entryPoints: ["./src/index.ts"],
+  outdir: "./dist",
+  minify: isProduction,
+  target: "es2022",
+  bundle: true,
+  format: "esm",
+  platform: "browser",
+  sourcemap: false,
+});
+if (isProduction) {
+  await ctx.rebuild();
+  await ctx.dispose();
+} else {
+  await ctx.watch();
+  console.info("Watching for changes...");
+}

--- a/packages/plugins/android/marketplace-manifest.json
+++ b/packages/plugins/android/marketplace-manifest.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://inlang.com/schema/marketplace-manifest",
+  "id": "plugin.inlang.android",
+  "displayName": { "en": "Android Resources" },
+  "description": {
+    "en": "Read and write Android strings.xml resources with variables and CLDR plurals."
+  },
+  "pages": { "/": "./README.md" },
+  "keywords": [
+    "android",
+    "xml",
+    "strings",
+    "resources",
+    "localization",
+    "plugin"
+  ],
+  "publisherName": "inlang",
+  "publisherIcon": "https://inlang.com/favicon/safari-pinned-tab.svg",
+  "license": "Apache-2.0",
+  "module": "https://cdn.jsdelivr.net/npm/@inlang/plugin-android@latest/dist/index.js"
+}

--- a/packages/plugins/android/package.json
+++ b/packages/plugins/android/package.json
@@ -2,6 +2,7 @@
   "name": "@inlang/plugin-android",
   "version": "0.1.0",
   "type": "module",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": "./dist/index.js"
   },

--- a/packages/plugins/android/package.json
+++ b/packages/plugins/android/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@inlang/plugin-android",
+  "version": "0.1.0",
+  "type": "module",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "files": [
+    "./dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/opral/inlang",
+    "directory": "packages/plugins/android"
+  },
+  "scripts": {
+    "dev": "node ./build.js",
+    "build": "NODE_ENV=production node ./build.js",
+    "test": "tsc --noEmit && vitest run",
+    "format": "prettier ./src --write",
+    "clean": "rm -rf ./dist ./node_modules"
+  },
+  "dependencies": {
+    "@inlang/sdk": "workspace:*",
+    "@sinclair/typebox": "^0.31.17",
+    "fast-xml-parser": "^4.5.3"
+  },
+  "devDependencies": {
+    "@inlang/tsconfig": "workspace:*",
+    "esbuild": "^0.25.9",
+    "prettier": "3.3.3",
+    "typescript": "^5.5.2",
+    "vitest": "^4.0.6"
+  }
+}

--- a/packages/plugins/android/src/index.ts
+++ b/packages/plugins/android/src/index.ts
@@ -1,0 +1,3 @@
+import { plugin } from "./plugin.js";
+export default plugin;
+export { plugin };

--- a/packages/plugins/android/src/plugin.test.ts
+++ b/packages/plugins/android/src/plugin.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, test } from "vitest";
+import { loadProjectInMemory, newProject } from "@inlang/sdk";
+import { plugin as icuPlugin } from "../../icu1/src/plugin.js";
+import { plugin, PLUGIN_KEY } from "./plugin.js";
+
+const settings = {
+  baseLocale: "en",
+  locales: ["en"],
+  modules: [],
+  [PLUGIN_KEY]: { pathPattern: "./res/values{locale}/strings.xml" },
+  "plugin.inlang.icu-messageformat-1": {
+    pathPattern: "./messages/{locale}.json",
+  },
+};
+
+describe("Android resources plugin", () => {
+  test("round-trips exact keys, escaping, variables, and plurals", async () => {
+    const source = `<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="ManageSale.PricePlaceholder">Hello %1$s &amp; welcome</string>
+  <plurals name="cart_items">
+    <item quantity="one">%1$d item</item>
+    <item quantity="other">%1$d items</item>
+  </plurals>
+</resources>`;
+    const imported = await plugin.importFiles!({
+      settings,
+      files: [{ locale: "en", content: new TextEncoder().encode(source) }],
+    });
+    expect(imported.bundles.map((bundle) => bundle.id)).toEqual([
+      "ManageSale.PricePlaceholder",
+      "cart_items",
+    ]);
+    const withIds = {
+      bundles: imported.bundles as any,
+      messages: imported.messages.map((message, index) => ({
+        ...message,
+        id: `message-${index}`,
+      })) as any,
+      variants: imported.variants.map((variant, index) => ({
+        ...variant,
+        id: `variant-${index}`,
+        messageId: `message-${imported.messages.findIndex(
+          (message) =>
+            message.bundleId === variant.messageBundleId &&
+            message.locale === variant.messageLocale,
+        )}`,
+      })) as any,
+    };
+    const [file] = await plugin.exportFiles!({ ...withIds, settings });
+    const output = new TextDecoder().decode(file!.content);
+    expect(output).toContain('name="ManageSale.PricePlaceholder"');
+    expect(output).toContain("Hello %1$s &amp; welcome");
+    expect(output).toContain('<plurals name="cart_items">');
+    expect(output).toContain('quantity="one"');
+    expect(output).toContain("%1$d item");
+    const roundtrip = await plugin.importFiles!({ settings, files: [file!] });
+    expect(roundtrip.bundles.map((bundle) => bundle.id)).toEqual(
+      imported.bundles.map((bundle) => bundle.id),
+    );
+  });
+
+  test("preserves printf types, positions, repetition, literals, and Android escaping", async () => {
+    const source = `<resources>
+  <string name="types">"id=%2$d price=%1$.2f name=%3$s again=%2$d 100%% \\n @home ?query"</string>
+</resources>`;
+    const imported = await plugin.importFiles!({
+      settings,
+      files: [{ locale: "en", content: new TextEncoder().encode(source) }],
+    });
+    expect(imported.variants[0]!.pattern).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "expression",
+          annotation: expect.objectContaining({ name: "android-printf" }),
+        }),
+        expect.objectContaining({
+          type: "text",
+          value: expect.stringContaining("100%"),
+        }),
+      ]),
+    );
+    const withIds = identify(imported);
+    const [file] = await plugin.exportFiles!({ ...withIds, settings });
+    const output = new TextDecoder().decode(file!.content);
+    expect(output).toContain("%2$d");
+    expect(output).toContain("%1$.2f");
+    expect(output).toContain("%3$s");
+    expect(output).toContain("100%%");
+  });
+
+  test("round-trips standalone escaped percent literals", async () => {
+    const imported = await plugin.importFiles!({
+      settings,
+      files: [
+        {
+          locale: "en",
+          content: new TextEncoder().encode(
+            '<resources><string name="literal">%%s %%d %%f %%</string></resources>',
+          ),
+        },
+      ],
+    });
+    expect(imported.variants[0]!.pattern).toEqual([
+      { type: "text", value: "%%s %%d %%f %%" },
+    ]);
+    const [file] = await plugin.exportFiles!({
+      ...identify(imported),
+      settings,
+    });
+    expect(new TextDecoder().decode(file!.content)).toContain("%%s %%d %%f %%");
+  });
+
+  test.each(["Save 20%", "100% complete", "100%%"])(
+    "preserves plain percent text exactly: %s",
+    async (value) => {
+      const imported = await plugin.importFiles!({
+        settings,
+        files: [
+          {
+            locale: "en",
+            content: new TextEncoder().encode(
+              `<resources><string name="plain_percent">${value}</string></resources>`,
+            ),
+          },
+        ],
+      });
+      expect(imported.variants[0]!.pattern).toEqual([{ type: "text", value }]);
+      const [file] = await plugin.exportFiles!({
+        ...identify(imported),
+        settings,
+      });
+      expect(new TextDecoder().decode(file!.content)).toContain(`"${value}"`);
+    },
+  );
+
+  test("exports canonical ICU1 plurals through the SDK and preserves exact keys", async () => {
+    const project = await loadProjectInMemory({
+      blob: await newProject({ settings }),
+      providePlugins: [icuPlugin as any, plugin as any],
+    });
+    try {
+      await project.importFiles({
+        pluginKey: icuPlugin.key,
+        files: [
+          {
+            locale: "en",
+            content: new TextEncoder().encode(
+              JSON.stringify({
+                cart_items_exact:
+                  "{count, plural, one {{count} item} other {{count} items}}",
+              }),
+            ),
+          },
+        ],
+      });
+      const [file] = await project.exportFiles({ pluginKey: plugin.key });
+      const output = new TextDecoder().decode(file!.content);
+      expect(output).toContain('name="cart_items_exact"');
+      expect(output).toContain('quantity="other"');
+    } finally {
+      await project.close();
+    }
+  });
+
+  test("imports annotated printf expressions through the SDK lifecycle", async () => {
+    const project = await loadProjectInMemory({
+      blob: await newProject({ settings }),
+      providePlugins: [plugin as any],
+    });
+    try {
+      const files = [
+        {
+          locale: "en",
+          content: new TextEncoder().encode(
+            '<resources><string name="typed_value">%2$d / %1$.2f / %3$s</string></resources>',
+          ),
+        },
+      ];
+      await project.importFiles({ pluginKey: plugin.key, files });
+      await project.importFiles({ pluginKey: plugin.key, files });
+      const [file] = await project.exportFiles({ pluginKey: plugin.key });
+      expect(new TextDecoder().decode(file!.content)).toContain(
+        "%2$d / %1$.2f / %3$s",
+      );
+      expect(
+        await project.db.selectFrom("message").selectAll().execute(),
+      ).toHaveLength(1);
+    } finally {
+      await project.close();
+    }
+  });
+
+  test("rejects malformed, unnamed, duplicate, and mixed-content XML", async () => {
+    for (const source of [
+      '<resources><string name="broken">oops</resources>',
+      "<resources><string>missing</string></resources>",
+      '<resources><string name="same">a</string><string name="same">b</string></resources>',
+      '<resources><string name="rich">before <b>bold</b> after</string></resources>',
+      '<resources><plurals name="dup"><item quantity="other">a</item><item quantity="other">b</item></plurals></resources>',
+      '<resources><plurals name="missing"><item quantity="one">a</item></plurals></resources>',
+    ]) {
+      expect(() =>
+        plugin.importFiles!({
+          settings,
+          files: [{ locale: "en", content: new TextEncoder().encode(source) }],
+        }),
+      ).toThrow();
+    }
+  });
+
+  test("rejects selectors that Android resources cannot represent", async () => {
+    expect(() =>
+      plugin.exportFiles!({
+        settings,
+        bundles: [{ id: "greeting", declarations: [] }],
+        messages: [
+          {
+            id: "message",
+            bundleId: "greeting",
+            locale: "en",
+            selectors: [{ type: "variable-reference", name: "gender" }],
+          },
+        ],
+        variants: [],
+      }),
+    ).toThrow("require one selector backed by a cardinal plural declaration");
+  });
+
+  test.each(["cart/items", "has space", "1leading", ".leading", "-leading"])(
+    "rejects an unrepresentable key without rewriting it: %s",
+    (id) => {
+      expect(() =>
+        plugin.exportFiles!({
+          settings,
+          bundles: [{ id, declarations: [] }],
+          messages: [
+            { id: "message", bundleId: id, locale: "en", selectors: [] },
+          ],
+          variants: [
+            {
+              id: "variant",
+              messageId: "message",
+              matches: [],
+              pattern: [{ type: "text", value: "value" }],
+            },
+          ],
+        }),
+      ).toThrow("cannot preserve resource key");
+    },
+  );
+});
+
+function identify(
+  imported: Awaited<ReturnType<NonNullable<typeof plugin.importFiles>>>,
+) {
+  const messages = imported.messages.map((message, index) => ({
+    ...message,
+    id: `message-${index}`,
+  }));
+  return {
+    bundles: imported.bundles as any,
+    messages: messages as any,
+    variants: imported.variants.map((variant, index) => ({
+      ...variant,
+      id: `variant-${index}`,
+      messageId: messages.find(
+        (message) =>
+          message.bundleId === variant.messageBundleId &&
+          message.locale === variant.messageLocale,
+      )!.id,
+    })) as any,
+  };
+}

--- a/packages/plugins/android/src/plugin.ts
+++ b/packages/plugins/android/src/plugin.ts
@@ -1,0 +1,479 @@
+import { XMLParser, XMLValidator } from "fast-xml-parser";
+import type {
+  Bundle,
+  InlangPlugin,
+  Message,
+  MessageImport,
+  Pattern,
+  Variant,
+  VariantImport,
+} from "@inlang/sdk";
+import { PluginSettings } from "./settings.js";
+
+export const PLUGIN_KEY = "plugin.inlang.android";
+type Config = { [PLUGIN_KEY]: PluginSettings };
+type ImportArgs = Parameters<
+  NonNullable<InlangPlugin<Config>["importFiles"]>
+>[0];
+type ExportArgs = Parameters<
+  NonNullable<InlangPlugin<Config>["exportFiles"]>
+>[0];
+const quantities = new Set(["zero", "one", "two", "few", "many", "other"]);
+
+export const plugin: InlangPlugin<Config> = {
+  key: PLUGIN_KEY,
+  settingsSchema: PluginSettings,
+  toBeImportedFiles: ({ settings }) =>
+    settings.locales.map((locale) => ({
+      locale,
+      path: androidPath(
+        settings[PLUGIN_KEY].pathPattern,
+        locale,
+        settings.baseLocale,
+      ),
+    })),
+  importFiles: ({ files }: ImportArgs) => importAndroidFiles(files),
+  exportFiles: (args: ExportArgs) => exportAndroidFiles(args),
+};
+
+function importAndroidFiles(
+  files: ImportArgs["files"],
+): ReturnType<NonNullable<InlangPlugin<Config>["importFiles"]>> {
+  const bundles = new Map<string, Bundle>();
+  const seen = new Set<string>();
+  const messages: MessageImport[] = [];
+  const variants: VariantImport[] = [];
+  const parser = new XMLParser({
+    ignoreAttributes: false,
+    attributeNamePrefix: "",
+    trimValues: false,
+    parseTagValue: false,
+    parseAttributeValue: false,
+  });
+  for (const file of files) {
+    const source = decode(file.content);
+    const validation = XMLValidator.validate(source);
+    if (validation !== true)
+      throw new Error(`Invalid Android resources XML: ${validation.err.msg}`);
+    const resources = parser.parse(source)?.resources;
+    if (!resources || typeof resources !== "object")
+      throw new Error("Android resources XML must contain a <resources> root");
+    for (const item of array(resources.string)) {
+      if (!item || typeof item !== "object" || !("name" in item))
+        throw new Error("Every Android <string> must have a name attribute");
+      const id = String(item.name);
+      assertUnique(seen, file.locale, id);
+      const parsed = parseAndroidPattern(textValue(item));
+      bundles.set(
+        id,
+        mergeBundle(bundles.get(id), id, parsed.variables, false),
+      );
+      messages.push({ bundleId: id, locale: file.locale, selectors: [] });
+      variants.push({
+        messageBundleId: id,
+        messageLocale: file.locale,
+        matches: [],
+        pattern: parsed.pattern,
+      });
+    }
+    for (const plural of array(resources.plurals)) {
+      if (!plural || typeof plural !== "object" || !("name" in plural))
+        throw new Error("Every Android <plurals> must have a name attribute");
+      const id = String(plural.name);
+      assertUnique(seen, file.locale, id);
+      const parsedItems = array(plural.item).map((item) => {
+        const quantity = String(item.quantity);
+        if (!quantities.has(quantity))
+          throw new Error(`Unsupported Android plural quantity "${quantity}"`);
+        return { quantity, parsed: parseAndroidPattern(textValue(item)) };
+      });
+      const pluralQuantities = parsedItems.map((item) => item.quantity);
+      if (new Set(pluralQuantities).size !== pluralQuantities.length)
+        throw new Error(`Android plural "${id}" has duplicate quantities`);
+      if (!pluralQuantities.includes("other"))
+        throw new Error(`Android plural "${id}" must define quantity "other"`);
+      bundles.set(
+        id,
+        mergeBundle(
+          bundles.get(id),
+          id,
+          ["count", ...parsedItems.flatMap(({ parsed }) => parsed.variables)],
+          true,
+        ),
+      );
+      messages.push({
+        bundleId: id,
+        locale: file.locale,
+        selectors: [{ type: "variable-reference", name: "countPlural" }],
+      });
+      for (const { quantity, parsed } of parsedItems) {
+        variants.push({
+          messageBundleId: id,
+          messageLocale: file.locale,
+          matches: [
+            quantity === "other"
+              ? { type: "catchall-match", key: "countPlural" }
+              : { type: "literal-match", key: "countPlural", value: quantity },
+          ],
+          pattern: parsed.pattern,
+        });
+      }
+    }
+  }
+  return { bundles: [...bundles.values()], messages, variants };
+}
+
+function exportAndroidFiles({
+  bundles,
+  messages,
+  variants,
+  settings,
+}: ExportArgs) {
+  const files = new Map<string, string[]>();
+  for (const message of messages) {
+    const bundle = requiredBundle(bundles, message);
+    assertAndroidResourceName(bundle.id);
+    const messageVariants = variants.filter(
+      (variant) => variant.messageId === message.id,
+    );
+    const lines = files.get(message.locale) ?? [];
+    if (message.selectors.length === 0) {
+      if (
+        messageVariants.length !== 1 ||
+        messageVariants[0]!.matches.length !== 0
+      )
+        throw new Error(
+          `Android string "${bundle.id}" must have exactly one unconditional variant`,
+        );
+      lines.push(
+        `  <string name="${escapeXmlAttribute(bundle.id)}">${serializePattern(messageVariants[0]!.pattern, bundle)}</string>`,
+      );
+    } else {
+      const selector = message.selectors[0];
+      const plural =
+        selector && message.selectors.length === 1
+          ? pluralDeclaration(bundle, selector.name)
+          : undefined;
+      if (!selector || !plural)
+        throw new Error(
+          `Android plurals require one selector backed by a cardinal plural declaration (bundle "${bundle.id}")`,
+        );
+      const items = messageVariants.map((variant) => {
+        const match = variant.matches[0];
+        if (
+          variant.matches.length !== 1 ||
+          !match ||
+          match.key !== selector.name ||
+          (match.type !== "catchall-match" &&
+            (match.type !== "literal-match" ||
+              match.value === "other" ||
+              !quantities.has(match.value)))
+        )
+          throw new Error(
+            `Android plural "${bundle.id}" has an unsupported match`,
+          );
+        const quantity =
+          match.type === "catchall-match" ? "other" : match.value;
+        return `    <item quantity="${quantity}">${serializePattern(variant.pattern, bundle)}</item>`;
+      });
+      const exportedQuantities = items.map(
+        (item) => item.match(/quantity="([^"]+)"/)?.[1],
+      );
+      if (
+        new Set(exportedQuantities).size !== exportedQuantities.length ||
+        exportedQuantities.filter((quantity) => quantity === "other").length !==
+          1
+      )
+        throw new Error(
+          `Android plural "${bundle.id}" must export unique quantities and exactly one other`,
+        );
+      lines.push(
+        `  <plurals name="${escapeXmlAttribute(bundle.id)}">\n${items.join("\n")}\n  </plurals>`,
+      );
+    }
+    files.set(message.locale, lines);
+  }
+  return [...files].map(([locale, lines]) => ({
+    locale,
+    name: settings[PLUGIN_KEY]?.pathPattern
+      ? androidPath(
+          settings[PLUGIN_KEY].pathPattern,
+          locale,
+          settings.baseLocale,
+        )
+      : `res/values${androidLocaleSuffix(locale, settings.baseLocale)}/strings.xml`,
+    content: encode(
+      `<?xml version="1.0" encoding="utf-8"?>\n<resources>\n${lines.sort().join("\n")}\n</resources>\n`,
+    ),
+  }));
+}
+
+function mergeBundle(
+  current: Bundle | undefined,
+  id: string,
+  variables: string[],
+  plural: boolean,
+): Bundle {
+  const declarations: Bundle["declarations"] = current
+    ? [...current.declarations]
+    : [];
+  for (const name of [...new Set(variables)])
+    if (!declarations.some((declaration) => declaration.name === name))
+      declarations.push({ type: "input-variable", name });
+  if (
+    plural &&
+    !declarations.some((declaration) => declaration.name === "countPlural")
+  )
+    declarations.push({
+      type: "local-variable",
+      name: "countPlural",
+      value: {
+        type: "expression",
+        arg: { type: "variable-reference", name: "count" },
+        annotation: { type: "function-reference", name: "plural", options: [] },
+      },
+    });
+  return { id, declarations };
+}
+
+function parseAndroidPattern(value: string) {
+  const pattern: Pattern = [];
+  const variables: string[] = [];
+  const source = unquoteAndroid(value);
+  const regex = /^%(?:(\d+)\$([-+# 0,(]*\d*(?:\.\d+)?[sdf])|([sdf]))/;
+  if (!hasPrintfExpression(source, regex)) {
+    if (/%\d+\$/.test(source))
+      throw new Error(`Unsupported Android positional format in "${source}"`);
+    return {
+      pattern: [{ type: "text", value: unescapeAndroid(source) }] as Pattern,
+      variables,
+    };
+  }
+  let cursor = 0;
+  let implicit = 0;
+  let text = "";
+  while (cursor < source.length) {
+    if (source.startsWith("%%", cursor)) {
+      text += "%";
+      cursor += 2;
+      continue;
+    }
+    const match = source.slice(cursor).match(regex);
+    if (!match) {
+      if (source[cursor] === "%")
+        throw new Error(
+          `Unsupported Android format specifier near "${source.slice(cursor, cursor + 12)}"`,
+        );
+      text += source[cursor++];
+      continue;
+    }
+    if (text) {
+      pattern.push({ type: "text", value: unescapeAndroid(text) });
+      text = "";
+    }
+    const position = match[1] ? Number(match[1]) : ++implicit;
+    const specifier = match[2] ?? match[3]!;
+    const conversion = specifier.at(-1)!;
+    const name =
+      conversion === "d" && position === 1 ? "count" : `arg${position}`;
+    variables.push(name);
+    pattern.push({
+      type: "expression",
+      arg: { type: "variable-reference", name },
+      annotation: {
+        type: "function-reference",
+        name: "android-printf",
+        options: [
+          { name: "specifier", value: { type: "literal", value: specifier } },
+          {
+            name: "position",
+            value: { type: "literal", value: String(position) },
+          },
+        ],
+      },
+    });
+    cursor += match[0].length;
+  }
+  if (text) pattern.push({ type: "text", value: unescapeAndroid(text) });
+  if (pattern.length === 0) pattern.push({ type: "text", value: "" });
+  return { pattern, variables };
+}
+
+function serializePattern(pattern: Pattern, bundle: Bundle) {
+  const inputs = bundle.declarations.filter(
+    (declaration) => declaration.type === "input-variable",
+  );
+  const formatted = pattern.some((part) => part.type === "expression");
+  const content = pattern
+    .map((part) => {
+      if (part.type === "text")
+        return escapeXmlText(escapeAndroid(part.value, formatted));
+      if (part.type !== "expression" || part.arg.type !== "variable-reference")
+        throw new Error(
+          `Android export only supports plain variable expressions (bundle "${bundle.id}")`,
+        );
+      const variableName = part.arg.name;
+      const position =
+        inputs.findIndex((declaration) => declaration.name === variableName) +
+        1;
+      if (position === 0)
+        throw new Error(
+          `Variable "${variableName}" is not declared in "${bundle.id}"`,
+        );
+      const format = printfFormat(part.annotation, position, variableName);
+      return `%${format.position}$${format.specifier}`;
+    })
+    .join("");
+  return `"${content}"`;
+}
+
+function printfFormat(
+  annotation: Extract<Pattern[number], { type: "expression" }>["annotation"],
+  fallbackPosition: number,
+  variableName: string,
+) {
+  if (!annotation)
+    return {
+      position: fallbackPosition,
+      specifier: variableName === "count" ? "d" : "s",
+    };
+  if (
+    annotation.type !== "function-reference" ||
+    annotation.name !== "android-printf"
+  )
+    throw new Error(
+      `Android export does not support the ${annotation.type} annotation`,
+    );
+  const option = (name: string) =>
+    annotation.options.find((candidate) => candidate.name === name)?.value;
+  const specifier = option("specifier");
+  const position = option("position");
+  if (
+    specifier?.type !== "literal" ||
+    !/^[-+# 0,(]*\d*(?:\.\d+)?[sdf]$/.test(specifier.value) ||
+    position?.type !== "literal" ||
+    !/^\d+$/.test(position.value)
+  )
+    throw new Error("Invalid Android printf annotation");
+  return { specifier: specifier.value, position: Number(position.value) };
+}
+
+function requiredBundle(bundles: Bundle[], message: Message) {
+  const bundle = bundles.find((candidate) => candidate.id === message.bundleId);
+  if (!bundle) throw new Error(`Missing bundle "${message.bundleId}"`);
+  return bundle;
+}
+function pluralDeclaration(bundle: Bundle, selector: string) {
+  return bundle.declarations.find(
+    (declaration) =>
+      declaration.type === "local-variable" &&
+      declaration.name === selector &&
+      declaration.value.annotation?.type === "function-reference" &&
+      declaration.value.annotation.name === "plural" &&
+      !declaration.value.annotation.options.some(
+        (option) =>
+          option.name === "type" &&
+          option.value.type === "literal" &&
+          option.value.value === "ordinal",
+      ),
+  );
+}
+function array<T>(value: T | T[] | undefined): T[] {
+  return value === undefined ? [] : Array.isArray(value) ? value : [value];
+}
+function textValue(value: unknown): string {
+  if (typeof value !== "object" || value === null) return String(value ?? "");
+  const nested = Object.keys(value).filter(
+    (key) => key !== "#text" && key !== "name" && key !== "quantity",
+  );
+  if (nested.length)
+    throw new Error(
+      `Android inline XML markup is not supported (${nested.join(", ")})`,
+    );
+  return "#text" in value ? String((value as any)["#text"]) : "";
+}
+function escapeXmlText(value: string) {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+function escapeXmlAttribute(value: string) {
+  return escapeXmlText(value).replace(/"/g, "&quot;");
+}
+function unescapeAndroid(value: string) {
+  return value.replace(
+    /\\([\\"'ntr@?])/g,
+    (_, escaped: string) =>
+      ({
+        "\\": "\\",
+        '"': '"',
+        "'": "'",
+        n: "\n",
+        t: "\t",
+        r: "\r",
+        "@": "@",
+        "?": "?",
+      })[escaped]!,
+  );
+}
+function unquoteAndroid(value: string) {
+  return value.length >= 2 && value.startsWith('"') && value.endsWith('"')
+    ? value.slice(1, -1)
+    : value;
+}
+function escapeAndroid(value: string, formatted: boolean) {
+  const escaped = value
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/'/g, "\\'")
+    .replace(/\n/g, "\\n")
+    .replace(/\r/g, "\\r")
+    .replace(/\t/g, "\\t");
+  return formatted ? escaped.replace(/%/g, "%%") : escaped;
+}
+function encode(value: string) {
+  return new TextEncoder().encode(value);
+}
+function decode(value: Uint8Array) {
+  return new TextDecoder().decode(value);
+}
+
+function androidLocaleSuffix(locale: string, baseLocale: string) {
+  if (locale === baseLocale) return "";
+  const [language, ...parts] = locale.split("-");
+  if (!language) throw new Error(`Invalid locale "${locale}"`);
+  if (parts.length === 0) return `-${language}`;
+  return `-b+${[language, ...parts].join("+")}`;
+}
+
+function androidPath(pattern: string, locale: string, baseLocale: string) {
+  return pattern.replace("{locale}", androidLocaleSuffix(locale, baseLocale));
+}
+
+function assertUnique(seen: Set<string>, locale: string, id: string) {
+  const key = `${locale}\0${id}`;
+  if (seen.has(key))
+    throw new Error(
+      `Duplicate Android resource "${id}" for locale "${locale}"`,
+    );
+  seen.add(key);
+}
+
+function assertAndroidResourceName(id: string) {
+  if (!/^[\p{L}_][\p{L}\p{N}._-]*$/u.test(id))
+    throw new Error(
+      `Android cannot preserve resource key "${id}"; AAPT names may contain letters, numbers, dot, underscore, and hyphen`,
+    );
+}
+
+function hasPrintfExpression(source: string, regex: RegExp) {
+  for (let cursor = 0; cursor < source.length; cursor++) {
+    if (source.startsWith("%%", cursor)) {
+      cursor++;
+      continue;
+    }
+    if (source[cursor] === "%" && regex.test(source.slice(cursor))) return true;
+  }
+  return false;
+}

--- a/packages/plugins/android/src/settings.ts
+++ b/packages/plugins/android/src/settings.ts
@@ -1,0 +1,9 @@
+import { Type, type Static } from "@sinclair/typebox";
+
+export type PluginSettings = Static<typeof PluginSettings>;
+export const PluginSettings = Type.Object({
+  pathPattern: Type.String({
+    pattern: ".*\\{locale\\}.*\\.xml$",
+    examples: ["./res/values{locale}/strings.xml"],
+  }),
+});

--- a/packages/plugins/android/tsconfig.build.json
+++ b/packages/plugins/android/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"],
+  "compilerOptions": {
+    "rootDir": "src"
+  }
+}

--- a/packages/plugins/android/tsconfig.json
+++ b/packages/plugins/android/tsconfig.json
@@ -1,0 +1,1 @@
+{ "extends": "@inlang/tsconfig/default", "include": ["src/**/*"] }

--- a/packages/plugins/apple-strings/README.md
+++ b/packages/plugins/apple-strings/README.md
@@ -1,0 +1,16 @@
+# Apple Strings plugin for Inlang
+
+Reads and writes Apple `.strings` files through Inlang's v2 message model.
+
+Supported: exact message keys, quoted-string escaping, Unicode, and positional variables. Apple `.strings` has no plural construct, so selector/plural messages fail explicitly. Use a future `.xcstrings` or `.stringsdict` plugin for Apple plurals.
+
+```json
+{
+  "modules": [
+    "https://cdn.jsdelivr.net/npm/@inlang/plugin-apple-strings@latest/dist/index.js"
+  ],
+  "plugin.inlang.apple-strings": {
+    "pathPattern": "./Localizations/{locale}.lproj/Localizable.strings"
+  }
+}
+```

--- a/packages/plugins/apple-strings/build.js
+++ b/packages/plugins/apple-strings/build.js
@@ -17,6 +17,8 @@ if (isProduction) {
   execFileSync(
     "tsc",
     [
+      "-p",
+      "tsconfig.build.json",
       "--emitDeclarationOnly",
       "--declaration",
       "--declarationMap",

--- a/packages/plugins/apple-strings/build.js
+++ b/packages/plugins/apple-strings/build.js
@@ -1,4 +1,5 @@
 import { context } from "esbuild";
+import { execFileSync } from "node:child_process";
 const isProduction = process.env.NODE_ENV === "production";
 const ctx = await context({
   entryPoints: ["./src/index.ts"],
@@ -13,6 +14,20 @@ const ctx = await context({
 if (isProduction) {
   await ctx.rebuild();
   await ctx.dispose();
+  execFileSync(
+    "tsc",
+    [
+      "--emitDeclarationOnly",
+      "--declaration",
+      "--declarationMap",
+      "false",
+      "--outDir",
+      "dist",
+      "--noEmit",
+      "false",
+    ],
+    { stdio: "inherit" },
+  );
 } else {
   await ctx.watch();
   console.info("Watching for changes...");

--- a/packages/plugins/apple-strings/build.js
+++ b/packages/plugins/apple-strings/build.js
@@ -1,0 +1,19 @@
+import { context } from "esbuild";
+const isProduction = process.env.NODE_ENV === "production";
+const ctx = await context({
+  entryPoints: ["./src/index.ts"],
+  outdir: "./dist",
+  minify: isProduction,
+  target: "es2022",
+  bundle: true,
+  format: "esm",
+  platform: "browser",
+  sourcemap: false,
+});
+if (isProduction) {
+  await ctx.rebuild();
+  await ctx.dispose();
+} else {
+  await ctx.watch();
+  console.info("Watching for changes...");
+}

--- a/packages/plugins/apple-strings/marketplace-manifest.json
+++ b/packages/plugins/apple-strings/marketplace-manifest.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://inlang.com/schema/marketplace-manifest",
+  "id": "plugin.inlang.apple-strings",
+  "displayName": { "en": "Apple Strings" },
+  "description": {
+    "en": "Read and write Apple .strings localization files with positional variables."
+  },
+  "pages": { "/": "./README.md" },
+  "keywords": ["apple", "ios", "macos", "strings", "localization", "plugin"],
+  "publisherName": "inlang",
+  "publisherIcon": "https://inlang.com/favicon/safari-pinned-tab.svg",
+  "license": "Apache-2.0",
+  "module": "https://cdn.jsdelivr.net/npm/@inlang/plugin-apple-strings@latest/dist/index.js"
+}

--- a/packages/plugins/apple-strings/package.json
+++ b/packages/plugins/apple-strings/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@inlang/plugin-apple-strings",
+  "version": "0.1.0",
+  "type": "module",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "files": [
+    "./dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/opral/inlang",
+    "directory": "packages/plugins/apple-strings"
+  },
+  "scripts": {
+    "dev": "node ./build.js",
+    "build": "NODE_ENV=production node ./build.js",
+    "test": "tsc --noEmit && vitest run",
+    "format": "prettier ./src --write",
+    "clean": "rm -rf ./dist ./node_modules"
+  },
+  "dependencies": {
+    "@inlang/sdk": "workspace:*",
+    "@sinclair/typebox": "^0.31.17"
+  },
+  "devDependencies": {
+    "@inlang/tsconfig": "workspace:*",
+    "esbuild": "^0.25.9",
+    "prettier": "3.3.3",
+    "typescript": "^5.5.2",
+    "vitest": "^4.0.6"
+  }
+}

--- a/packages/plugins/apple-strings/package.json
+++ b/packages/plugins/apple-strings/package.json
@@ -2,6 +2,7 @@
   "name": "@inlang/plugin-apple-strings",
   "version": "0.1.0",
   "type": "module",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": "./dist/index.js"
   },

--- a/packages/plugins/apple-strings/src/index.ts
+++ b/packages/plugins/apple-strings/src/index.ts
@@ -1,0 +1,3 @@
+import { plugin } from "./plugin.js";
+export default plugin;
+export { plugin };

--- a/packages/plugins/apple-strings/src/plugin.test.ts
+++ b/packages/plugins/apple-strings/src/plugin.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, test } from "vitest";
+import { loadProjectInMemory, newProject } from "@inlang/sdk";
+import { plugin, PLUGIN_KEY } from "./plugin.js";
+
+const settings = {
+  baseLocale: "en",
+  locales: ["en"],
+  modules: [],
+  [PLUGIN_KEY]: {
+    pathPattern: "./Localizations/{locale}.lproj/Localizable.strings",
+  },
+};
+
+describe("Apple strings plugin", () => {
+  test("round-trips exact keys, escapes, Unicode, and positional variables", async () => {
+    const source = `/* Translator note */
+"ManageSale.PricePlaceholder" = "Hello \\"world\\" %1$@";
+"member.你好" = "你好";
+`;
+    const imported = await plugin.importFiles!({
+      settings,
+      files: [{ locale: "en", content: new TextEncoder().encode(source) }],
+    });
+    expect(imported.bundles.map((bundle) => bundle.id)).toEqual([
+      "ManageSale.PricePlaceholder",
+      "member.你好",
+    ]);
+    const messages = imported.messages.map((message, index) => ({
+      ...message,
+      id: `message-${index}`,
+    }));
+    const variants = imported.variants.map((variant, index) => ({
+      ...variant,
+      id: `variant-${index}`,
+      messageId: `message-${imported.messages.findIndex(
+        (message) =>
+          message.bundleId === variant.messageBundleId &&
+          message.locale === variant.messageLocale,
+      )}`,
+    }));
+    const [file] = await plugin.exportFiles!({
+      settings,
+      bundles: imported.bundles as any,
+      messages: messages as any,
+      variants: variants as any,
+    });
+    const output = new TextDecoder().decode(file!.content);
+    expect(output).toContain(
+      '"ManageSale.PricePlaceholder" = "Hello \\"world\\" %1$@";',
+    );
+    expect(output).toContain('"member.你好" = "你好";');
+    const roundtrip = await plugin.importFiles!({ settings, files: [file!] });
+    expect(roundtrip.bundles.map((bundle) => bundle.id)).toEqual(
+      imported.bundles.map((bundle) => bundle.id),
+    );
+  });
+
+  test("preserves format types, positions, repetitions, literal percent, and comment-looking text", async () => {
+    const source = `/* real comment */
+"types/key" = "go // home /* literal */ %2$lld %1$.2f %3$@ %2$lld 100%%";
+"unicode" = "\\U4F60\\U597D";
+`;
+    const imported = await plugin.importFiles!({
+      settings,
+      files: [{ locale: "en", content: new TextEncoder().encode(source) }],
+    });
+    expect(imported.bundles.map((bundle) => bundle.id)).toEqual([
+      "types/key",
+      "unicode",
+    ]);
+    expect(imported.variants[0]!.pattern).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "text",
+          value: expect.stringContaining("go // home /* literal */"),
+        }),
+        expect.objectContaining({
+          type: "expression",
+          annotation: expect.objectContaining({ name: "apple-printf" }),
+        }),
+        expect.objectContaining({
+          type: "text",
+          value: expect.stringContaining("100%"),
+        }),
+      ]),
+    );
+    expect(imported.variants[1]!.pattern).toEqual([
+      { type: "text", value: "你好" },
+    ]);
+    const messages = imported.messages.map((message, index) => ({
+      ...message,
+      id: `message-${index}`,
+    }));
+    const [file] = await plugin.exportFiles!({
+      settings,
+      bundles: imported.bundles as any,
+      messages: messages as any,
+      variants: imported.variants.map((variant, index) => ({
+        ...variant,
+        id: `variant-${index}`,
+        messageId: messages.find(
+          (message) =>
+            message.bundleId === variant.messageBundleId &&
+            message.locale === variant.messageLocale,
+        )!.id,
+      })) as any,
+    });
+    const output = new TextDecoder().decode(file!.content);
+    expect(output).toContain("%2$lld %1$.2f %3$@ %2$lld 100%%");
+    expect(output).toContain('"types/key"');
+  });
+
+  test("rejects duplicates and unsupported format syntax", async () => {
+    for (const source of [
+      '"same" = "a"; "same" = "b";',
+      '"bad" = "%1$Q";',
+      '"bad" = "\\a";',
+    ]) {
+      expect(() =>
+        plugin.importFiles!({
+          settings,
+          files: [{ locale: "en", content: new TextEncoder().encode(source) }],
+        }),
+      ).toThrow();
+    }
+  });
+
+  test("round-trips standalone escaped percent literals", async () => {
+    const imported = await plugin.importFiles!({
+      settings,
+      files: [
+        {
+          locale: "en",
+          content: new TextEncoder().encode('"literal" = "%%@ %%d %%f %%";'),
+        },
+      ],
+    });
+    expect(imported.variants[0]!.pattern).toEqual([
+      { type: "text", value: "%%@ %%d %%f %%" },
+    ]);
+    const messages = [{ ...imported.messages[0]!, id: "message" }];
+    const [file] = await plugin.exportFiles!({
+      settings,
+      bundles: imported.bundles as any,
+      messages: messages as any,
+      variants: [
+        { ...imported.variants[0]!, id: "variant", messageId: "message" },
+      ] as any,
+    });
+    expect(new TextDecoder().decode(file!.content)).toContain("%%@ %%d %%f %%");
+  });
+
+  test.each(["Save 20%", "100% complete", "100%%"])(
+    "preserves plain percent text exactly: %s",
+    async (value) => {
+      const imported = await plugin.importFiles!({
+        settings,
+        files: [
+          {
+            locale: "en",
+            content: new TextEncoder().encode(`"plain" = "${value}";`),
+          },
+        ],
+      });
+      expect(imported.variants[0]!.pattern).toEqual([{ type: "text", value }]);
+      const [file] = await plugin.exportFiles!({
+        settings,
+        bundles: imported.bundles as any,
+        messages: [{ ...imported.messages[0]!, id: "message" }] as any,
+        variants: [
+          { ...imported.variants[0]!, id: "variant", messageId: "message" },
+        ] as any,
+      });
+      expect(new TextDecoder().decode(file!.content)).toContain(`"${value}"`);
+    },
+  );
+
+  test("imports annotated printf expressions through the SDK lifecycle", async () => {
+    const project = await loadProjectInMemory({
+      blob: await newProject({ settings }),
+      providePlugins: [plugin as any],
+    });
+    try {
+      const files = [
+        {
+          locale: "en",
+          content: new TextEncoder().encode(
+            '"typed/value" = "%2$lld / %1$.2f / %3$@";\n"Cancel";',
+          ),
+        },
+      ];
+      await project.importFiles({ pluginKey: plugin.key, files });
+      await project.importFiles({ pluginKey: plugin.key, files });
+      const [file] = await project.exportFiles({ pluginKey: plugin.key });
+      const output = new TextDecoder().decode(file!.content);
+      expect(output).toContain('"typed/value" = "%2$lld / %1$.2f / %3$@";');
+      expect(output).toContain('"Cancel" = "Cancel";');
+      expect(
+        await project.db.selectFrom("message").selectAll().execute(),
+      ).toHaveLength(2);
+    } finally {
+      await project.close();
+    }
+  });
+
+  test("rejects plurals instead of silently dropping variants", async () => {
+    expect(() =>
+      plugin.exportFiles!({
+        settings,
+        bundles: [{ id: "cart.items", declarations: [] }],
+        messages: [
+          {
+            id: "message",
+            bundleId: "cart.items",
+            locale: "en",
+            selectors: [{ type: "variable-reference", name: "countPlural" }],
+          },
+        ],
+        variants: [],
+      }),
+    ).toThrow("cannot represent selectors or plurals");
+  });
+});

--- a/packages/plugins/apple-strings/src/plugin.ts
+++ b/packages/plugins/apple-strings/src/plugin.ts
@@ -1,0 +1,332 @@
+import type {
+  Bundle,
+  InlangPlugin,
+  Message,
+  MessageImport,
+  Pattern,
+  Variant,
+  VariantImport,
+} from "@inlang/sdk";
+import { PluginSettings } from "./settings.js";
+
+export const PLUGIN_KEY = "plugin.inlang.apple-strings";
+type Config = { [PLUGIN_KEY]: PluginSettings };
+type ImportArgs = Parameters<
+  NonNullable<InlangPlugin<Config>["importFiles"]>
+>[0];
+type ExportArgs = Parameters<
+  NonNullable<InlangPlugin<Config>["exportFiles"]>
+>[0];
+
+export const plugin: InlangPlugin<Config> = {
+  key: PLUGIN_KEY,
+  settingsSchema: PluginSettings,
+  toBeImportedFiles: ({ settings }) =>
+    settings.locales.map((locale) => ({
+      locale,
+      path: settings[PLUGIN_KEY].pathPattern.replace("{locale}", locale),
+    })),
+  importFiles: ({ files }: ImportArgs) => importAppleStrings(files),
+  exportFiles: (args: ExportArgs) => exportAppleStrings(args),
+};
+
+function importAppleStrings(
+  files: ImportArgs["files"],
+): ReturnType<NonNullable<InlangPlugin<Config>["importFiles"]>> {
+  const bundles = new Map<string, Bundle>();
+  const messages: MessageImport[] = [];
+  const variants: VariantImport[] = [];
+  for (const file of files) {
+    for (const { key, value } of parseStringsFile(decode(file.content))) {
+      const parsed = parsePattern(value);
+      const current = bundles.get(key) ?? { id: key, declarations: [] };
+      for (const name of parsed.variables)
+        if (
+          !current.declarations.some((declaration) => declaration.name === name)
+        )
+          current.declarations.push({ type: "input-variable", name });
+      bundles.set(key, current);
+      messages.push({ bundleId: key, locale: file.locale, selectors: [] });
+      variants.push({
+        messageBundleId: key,
+        messageLocale: file.locale,
+        matches: [],
+        pattern: parsed.pattern,
+      });
+    }
+  }
+  return { bundles: [...bundles.values()], messages, variants };
+}
+
+function exportAppleStrings({
+  bundles,
+  messages,
+  variants,
+  settings,
+}: ExportArgs) {
+  const files = new Map<string, string[]>();
+  for (const message of messages) {
+    const bundle = requiredBundle(bundles, message);
+    if (message.selectors.length !== 0)
+      throw new Error(
+        `Apple .strings cannot represent selectors or plurals (bundle "${bundle.id}")`,
+      );
+    const messageVariants = variants.filter(
+      (variant) => variant.messageId === message.id,
+    );
+    if (
+      messageVariants.length !== 1 ||
+      messageVariants[0]!.matches.length !== 0
+    )
+      throw new Error(
+        `Apple .strings requires one unconditional variant (bundle "${bundle.id}")`,
+      );
+    const lines = files.get(message.locale) ?? [];
+    lines.push(
+      `"${escapeString(bundle.id)}" = "${serializePattern(messageVariants[0]!.pattern, bundle)}";`,
+    );
+    files.set(message.locale, lines);
+  }
+  return [...files].map(([locale, lines]) => ({
+    locale,
+    name:
+      settings[PLUGIN_KEY]?.pathPattern.replace("{locale}", locale) ??
+      `${locale}.lproj/Localizable.strings`,
+    content: encode(`${lines.sort().join("\n")}\n`),
+  }));
+}
+
+function parseStringsFile(source: string) {
+  const entries: Array<{ key: string; value: string }> = [];
+  let cursor = 0;
+  const whitespaceAndComments = () => {
+    while (cursor < source.length) {
+      if (/\s/.test(source[cursor]!)) {
+        cursor++;
+      } else if (source.startsWith("//", cursor)) {
+        cursor = source.indexOf("\n", cursor + 2);
+        if (cursor === -1) cursor = source.length;
+      } else if (source.startsWith("/*", cursor)) {
+        const end = source.indexOf("*/", cursor + 2);
+        if (end === -1) throw new Error("Unterminated Apple .strings comment");
+        cursor = end + 2;
+      } else break;
+    }
+  };
+  const quoted = () => {
+    if (source[cursor] !== '"')
+      throw new Error(
+        `Expected quoted Apple .strings value at offset ${cursor}`,
+      );
+    cursor++;
+    let result = "";
+    while (cursor < source.length) {
+      const char = source[cursor++]!;
+      if (char === '"') return result;
+      if (char !== "\\") {
+        result += char;
+        continue;
+      }
+      if (cursor === source.length)
+        throw new Error("Unterminated Apple .strings escape");
+      result += `\\${source[cursor++]}`;
+    }
+    throw new Error("Unterminated quoted Apple .strings value");
+  };
+  whitespaceAndComments();
+  while (cursor < source.length) {
+    const key = unescapeString(quoted());
+    whitespaceAndComments();
+    if (source[cursor] === ";") {
+      cursor++;
+      if (entries.some((entry) => entry.key === key))
+        throw new Error(`Duplicate Apple .strings key "${key}"`);
+      entries.push({ key, value: key });
+      whitespaceAndComments();
+      continue;
+    }
+    if (source[cursor++] !== "=") throw new Error(`Expected = after "${key}"`);
+    whitespaceAndComments();
+    const value = unescapeString(quoted());
+    whitespaceAndComments();
+    if (source[cursor++] !== ";") throw new Error(`Expected ; after "${key}"`);
+    if (entries.some((entry) => entry.key === key))
+      throw new Error(`Duplicate Apple .strings key "${key}"`);
+    entries.push({ key, value });
+    whitespaceAndComments();
+  }
+  return entries;
+}
+
+function parsePattern(value: string) {
+  const pattern: Pattern = [];
+  const variables: string[] = [];
+  const regex =
+    /^%(?:(\d+)\$([-+# 0,(]*\d*(?:\.\d+)?(?:hh|h|ll|l|q|z|t|j)?[diuoxXfFeEgGaAcCsSp@])|((?:hh|h|ll|l|q|z|t|j)?[diuoxXfFeEgGaAcCsSp@]))/;
+  if (!hasPrintfExpression(value, regex)) {
+    if (/%\d+\$/.test(value))
+      throw new Error(`Unsupported Apple positional format in "${value}"`);
+    return { pattern: [{ type: "text", value }] as Pattern, variables };
+  }
+  let cursor = 0;
+  let implicit = 0;
+  let text = "";
+  while (cursor < value.length) {
+    if (value.startsWith("%%", cursor)) {
+      text += "%";
+      cursor += 2;
+      continue;
+    }
+    const match = value.slice(cursor).match(regex);
+    if (!match) {
+      if (value[cursor] === "%")
+        throw new Error(
+          `Unsupported Apple format specifier near "${value.slice(cursor, cursor + 12)}"`,
+        );
+      text += value[cursor++];
+      continue;
+    }
+    if (text) {
+      pattern.push({ type: "text", value: text });
+      text = "";
+    }
+    const position = match[1] ? Number(match[1]) : ++implicit;
+    const specifier = match[2] ?? match[3]!;
+    const name = `arg${position}`;
+    variables.push(name);
+    pattern.push({
+      type: "expression",
+      arg: { type: "variable-reference", name },
+      annotation: {
+        type: "function-reference",
+        name: "apple-printf",
+        options: [
+          { name: "specifier", value: { type: "literal", value: specifier } },
+          {
+            name: "position",
+            value: { type: "literal", value: String(position) },
+          },
+        ],
+      },
+    });
+    cursor += match[0].length;
+  }
+  if (text) pattern.push({ type: "text", value: text });
+  if (pattern.length === 0) pattern.push({ type: "text", value: "" });
+  return { pattern, variables };
+}
+
+function serializePattern(pattern: Pattern, bundle: Bundle) {
+  const inputs = bundle.declarations.filter(
+    (declaration) => declaration.type === "input-variable",
+  );
+  const formatted = pattern.some((part) => part.type === "expression");
+  return pattern
+    .map((part) => {
+      if (part.type === "text") {
+        const escaped = escapeString(part.value);
+        return formatted ? escaped.replace(/%/g, "%%") : escaped;
+      }
+      if (part.type !== "expression" || part.arg.type !== "variable-reference")
+        throw new Error(
+          `Apple .strings only supports plain variable expressions (bundle "${bundle.id}")`,
+        );
+      const variableName = part.arg.name;
+      const position =
+        inputs.findIndex((declaration) => declaration.name === variableName) +
+        1;
+      if (position === 0)
+        throw new Error(
+          `Variable "${variableName}" is not declared in "${bundle.id}"`,
+        );
+      const format = applePrintfFormat(part.annotation, position);
+      return `%${format.position}$${format.specifier}`;
+    })
+    .join("");
+}
+
+function applePrintfFormat(
+  annotation: Extract<Pattern[number], { type: "expression" }>["annotation"],
+  fallbackPosition: number,
+) {
+  if (!annotation) return { position: fallbackPosition, specifier: "@" };
+  if (
+    annotation.type !== "function-reference" ||
+    annotation.name !== "apple-printf"
+  )
+    throw new Error(
+      `Apple .strings export does not support the ${annotation.type} annotation`,
+    );
+  const option = (name: string) =>
+    annotation.options.find((candidate) => candidate.name === name)?.value;
+  const specifier = option("specifier");
+  const position = option("position");
+  if (
+    specifier?.type !== "literal" ||
+    !/^[-+# 0,(]*\d*(?:\.\d+)?(?:hh|h|ll|l|q|z|t|j)?[diuoxXfFeEgGaAcCsSp@]$/.test(
+      specifier.value,
+    ) ||
+    position?.type !== "literal" ||
+    !/^\d+$/.test(position.value)
+  )
+    throw new Error("Invalid Apple printf annotation");
+  return { specifier: specifier.value, position: Number(position.value) };
+}
+
+function requiredBundle(bundles: Bundle[], message: Message) {
+  const bundle = bundles.find((candidate) => candidate.id === message.bundleId);
+  if (!bundle) throw new Error(`Missing bundle "${message.bundleId}"`);
+  return bundle;
+}
+function escapeString(value: string) {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, "\\n")
+    .replace(/\r/g, "\\r")
+    .replace(/\t/g, "\\t");
+}
+function unescapeString(value: string) {
+  const unknownEscape = value.match(/\\(?![\\"nrtuU]|$)/);
+  if (unknownEscape)
+    throw new Error(`Unsupported Apple .strings escape "${unknownEscape[0]}"`);
+  return value
+    .replace(/\\U([0-9a-fA-F]{4})/g, (_, hex: string) =>
+      String.fromCharCode(Number.parseInt(hex, 16)),
+    )
+    .replace(/\\u([0-9a-fA-F]{4})/g, (_, hex: string) =>
+      String.fromCharCode(Number.parseInt(hex, 16)),
+    )
+    .replace(
+      /\\([\\"nrt])/g,
+      (_, char: string) =>
+        ({ "\\": "\\", '"': '"', n: "\n", r: "\r", t: "\t" })[char]!,
+    );
+}
+function encode(value: string) {
+  return new TextEncoder().encode(value);
+}
+function decode(value: Uint8Array) {
+  if (value[0] === 0xff && value[1] === 0xfe)
+    return new TextDecoder("utf-16le").decode(value.subarray(2));
+  if (value[0] === 0xfe && value[1] === 0xff) {
+    const littleEndian = new Uint8Array(value.length - 2);
+    for (let index = 2; index + 1 < value.length; index += 2) {
+      littleEndian[index - 2] = value[index + 1]!;
+      littleEndian[index - 1] = value[index]!;
+    }
+    return new TextDecoder("utf-16le").decode(littleEndian);
+  }
+  return new TextDecoder().decode(value);
+}
+
+function hasPrintfExpression(source: string, regex: RegExp) {
+  for (let cursor = 0; cursor < source.length; cursor++) {
+    if (source.startsWith("%%", cursor)) {
+      cursor++;
+      continue;
+    }
+    if (source[cursor] === "%" && regex.test(source.slice(cursor))) return true;
+  }
+  return false;
+}

--- a/packages/plugins/apple-strings/src/settings.ts
+++ b/packages/plugins/apple-strings/src/settings.ts
@@ -1,0 +1,9 @@
+import { Type, type Static } from "@sinclair/typebox";
+
+export type PluginSettings = Static<typeof PluginSettings>;
+export const PluginSettings = Type.Object({
+  pathPattern: Type.String({
+    pattern: ".*\\{locale\\}.*\\.strings$",
+    examples: ["./Localizations/{locale}.lproj/Localizable.strings"],
+  }),
+});

--- a/packages/plugins/apple-strings/tsconfig.build.json
+++ b/packages/plugins/apple-strings/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"],
+  "compilerOptions": {
+    "rootDir": "src"
+  }
+}

--- a/packages/plugins/apple-strings/tsconfig.json
+++ b/packages/plugins/apple-strings/tsconfig.json
@@ -1,0 +1,1 @@
+{ "extends": "@inlang/tsconfig/default", "include": ["src/**/*"] }

--- a/packages/plugins/i18next/build.js
+++ b/packages/plugins/i18next/build.js
@@ -1,4 +1,5 @@
 import { context } from "esbuild";
+import { execFileSync } from "node:child_process";
 
 // eslint-disable-next-line no-undef
 const isProduction = process.env.NODE_ENV === "production";
@@ -21,10 +22,24 @@ const ctx = await context({
 });
 
 if (isProduction === false) {
-  await ctx.watch();
-  // eslint-disable-next-line no-undef
-  console.info("Watching for changes...");
+	await ctx.watch();
+	// eslint-disable-next-line no-undef
+	console.info("Watching for changes...");
 } else {
-  await ctx.rebuild();
-  await ctx.dispose();
+	await ctx.rebuild();
+	await ctx.dispose();
+	execFileSync(
+		"tsc",
+		[
+			"--emitDeclarationOnly",
+			"--declaration",
+			"--declarationMap",
+			"false",
+			"--outDir",
+			"dist",
+			"--noEmit",
+			"false",
+		],
+		{ stdio: "inherit" }
+	);
 }

--- a/packages/plugins/i18next/src/import-export/exportFiles.ts
+++ b/packages/plugins/i18next/src/import-export/exportFiles.ts
@@ -85,6 +85,20 @@ function serializeMessage(
 	variants: Variant[],
 	settings?: PluginSettings
 ): Array<{ key: string; value: string; locale: string }> {
+	const supportedSelectors = new Set([
+		"context",
+		"count",
+		"countPlural",
+		"countOrdinal",
+	]);
+	const unsupportedSelector = message.selectors.find(
+		(selector) => !supportedSelectors.has(selector.name)
+	);
+	if (unsupportedSelector) {
+		throw new Error(
+			`i18next export cannot represent selector "${unsupportedSelector.name}" in bundle "${bundle.id}"`
+		);
+	}
 	const result = [];
 
 	// emit base keys first and the most specific keys last, mirroring how

--- a/packages/plugins/i18next/src/import-export/selector-validation.test.ts
+++ b/packages/plugins/i18next/src/import-export/selector-validation.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "vitest";
+import { plugin } from "../plugin.js";
+
+test("rejects unsupported selectors rather than silently dropping variants", async () => {
+	await expect(
+		plugin.exportFiles!({
+			settings: {
+				baseLocale: "en",
+				locales: ["en"],
+				modules: [],
+				"plugin.inlang.i18next": { pathPattern: "./{locale}.json" },
+			},
+			bundles: [{ id: "greeting", declarations: [] }],
+			messages: [
+				{
+					id: "message",
+					bundleId: "greeting",
+					locale: "en",
+					selectors: [{ type: "variable-reference", name: "audience" }],
+				},
+			],
+			variants: [
+				{
+					id: "formal",
+					messageId: "message",
+					matches: [
+						{ type: "literal-match", key: "audience", value: "formal" },
+					],
+					pattern: [{ type: "text", value: "Welcome" }],
+				},
+				{
+					id: "fallback",
+					messageId: "message",
+					matches: [{ type: "catchall-match", key: "audience" }],
+					pattern: [{ type: "text", value: "Hi" }],
+				},
+			],
+		})
+	).rejects.toThrow('cannot represent selector "audience"');
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -493,6 +493,59 @@ importers:
         specifier: ^4.8.0
         version: 4.10.0(webpack@5.99.9)
 
+  packages/plugins/android:
+    dependencies:
+      '@inlang/sdk':
+        specifier: workspace:*
+        version: link:../../sdk
+      '@sinclair/typebox':
+        specifier: ^0.31.17
+        version: 0.31.28
+      fast-xml-parser:
+        specifier: ^4.5.3
+        version: 4.5.3
+    devDependencies:
+      '@inlang/tsconfig':
+        specifier: workspace:*
+        version: link:../../tsconfig
+      esbuild:
+        specifier: ^0.25.9
+        version: 0.25.12
+      prettier:
+        specifier: 3.3.3
+        version: 3.3.3
+      typescript:
+        specifier: ^5.5.2
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.6
+        version: 4.0.16(@types/node@24.10.2)(happy-dom@18.0.1)(jiti@2.6.1)(jsdom@27.3.0(postcss@8.5.6))(lightningcss@1.30.2)(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1)
+
+  packages/plugins/apple-strings:
+    dependencies:
+      '@inlang/sdk':
+        specifier: workspace:*
+        version: link:../../sdk
+      '@sinclair/typebox':
+        specifier: ^0.31.17
+        version: 0.31.28
+    devDependencies:
+      '@inlang/tsconfig':
+        specifier: workspace:*
+        version: link:../../tsconfig
+      esbuild:
+        specifier: ^0.25.9
+        version: 0.25.12
+      prettier:
+        specifier: 3.3.3
+        version: 3.3.3
+      typescript:
+        specifier: ^5.5.2
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.6
+        version: 4.0.16(@types/node@24.10.2)(happy-dom@18.0.1)(jiti@2.6.1)(jsdom@27.3.0(postcss@8.5.6))(lightningcss@1.30.2)(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1)
+
   packages/plugins/i18next:
     dependencies:
       '@inlang/sdk':
@@ -16381,6 +16434,15 @@ snapshots:
       msw: 2.10.2(@types/node@24.10.2)(typescript@5.7.3)
       vite: 7.2.7(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1)
 
+  '@vitest/mocker@4.0.16(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(vite@7.2.7(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))':
+    dependencies:
+      '@vitest/spy': 4.0.16
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.10.2(@types/node@24.10.2)(typescript@5.9.3)
+      vite: 7.2.7(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1)
+
   '@vitest/mocker@4.0.6(msw@2.10.2(@types/node@22.15.33)(typescript@5.7.3))(vite@7.2.7(@types/node@22.15.33)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))':
     dependencies:
       '@vitest/spy': 4.0.6
@@ -18918,7 +18980,6 @@ snapshots:
   fast-xml-parser@4.5.3:
     dependencies:
       strnum: 1.1.2
-    optional: true
 
   fastest-levenshtein@1.0.16: {}
 
@@ -22841,8 +22902,7 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
-  strnum@1.1.2:
-    optional: true
+  strnum@1.1.2: {}
 
   strong-log-transformer@2.1.0:
     dependencies:
@@ -23241,8 +23301,7 @@ snapshots:
 
   typescript@5.7.3: {}
 
-  typescript@5.9.3:
-    optional: true
+  typescript@5.9.3: {}
 
   ufo@1.6.1: {}
 
@@ -24117,6 +24176,45 @@ snapshots:
     dependencies:
       '@vitest/expect': 4.0.16
       '@vitest/mocker': 4.0.16(msw@2.10.2(@types/node@24.10.2)(typescript@5.7.3))(vite@7.2.7(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))
+      '@vitest/pretty-format': 4.0.16
+      '@vitest/runner': 4.0.16
+      '@vitest/snapshot': 4.0.16
+      '@vitest/spy': 4.0.16
+      '@vitest/utils': 4.0.16
+      es-module-lexer: 1.7.0
+      expect-type: 1.2.2
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 7.2.7(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.10.2
+      happy-dom: 18.0.1
+      jsdom: 27.3.0(postcss@8.5.6)
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
+
+  vitest@4.0.16(@types/node@24.10.2)(happy-dom@18.0.1)(jiti@2.6.1)(jsdom@27.3.0(postcss@8.5.6))(lightningcss@1.30.2)(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1):
+    dependencies:
+      '@vitest/expect': 4.0.16
+      '@vitest/mocker': 4.0.16(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(vite@7.2.7(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))
       '@vitest/pretty-format': 4.0.16
       '@vitest/runner': 4.0.16
       '@vitest/snapshot': 4.0.16


### PR DESCRIPTION
## Summary
- add first-class Inlang v2 Android resource XML plugin
- add first-class Inlang v2 Apple `.strings` plugin
- preserve exact representable keys, variables, typed/positional printf placeholders, and Android plurals
- reject format/model combinations that cannot be represented without loss
- make i18next reject unsupported selectors instead of silently dropping variants
- register both new plugins in the marketplace

## Verification
- Android plugin: 15 tests
- Apple plugin: 9 tests
- i18next plugin: 62 passed, 1 skipped
- SDK lifecycle import/export/re-import fixtures
- package typechecks and builds
- package tarball inspection

## Consumer
Stacked Parrot integration: https://github.com/opral/parrot-figma/pull/69