### PR TITLE
Add first-class Apple String Catalog plugin

### DIFF
--- a/.changeset/bright-apples-catalog.md
+++ b/.changeset/bright-apples-catalog.md
@@ -1,0 +1,5 @@
+---
+"@inlang/plugin-apple-xcstrings": minor
+---
+
+Add a first-class Apple String Catalog plugin for `.xcstrings` files with exact keys, locales, variables, plurals, and device variations.

--- a/packages/marketplace-registry/registry.json
+++ b/packages/marketplace-registry/registry.json
@@ -17,6 +17,7 @@
 		"p7c8m1d2": "https://raw.githubusercontent.com/opral/inlang/refs/heads/main/packages/plugins/icu1/marketplace-manifest.json",
 		"andr0id2": "https://raw.githubusercontent.com/opral/inlang/refs/heads/main/packages/plugins/android/marketplace-manifest.json",
 		"applstr1": "https://raw.githubusercontent.com/opral/inlang/refs/heads/main/packages/plugins/apple-strings/marketplace-manifest.json",
+		"xcstrng1": "https://raw.githubusercontent.com/opral/inlang/refs/heads/main/packages/plugins/apple-xcstrings/marketplace-manifest.json",
 		"neh2d6w7": "https://cdn.jsdelivr.net/npm/inlang-plugin-xcstrings@latest/marketplace-manifest.json",
 		"3gk8n4n4": "https://raw.githubusercontent.com/opral/inlang/refs/heads/inlang-v1/inlang/source-code/github-lint-action/marketplace-manifest.json",
 		"y0eo8f66": "https://raw.githubusercontent.com/opral/inlang/refs/heads/inlang-v1/inlang/source-code/message-lint-rules/emptyPattern/marketplace-manifest.json",

--- a/packages/plugins/apple-xcstrings/README.md
+++ b/packages/plugins/apple-xcstrings/README.md
@@ -1,0 +1,18 @@
+# Apple String Catalog plugin for Inlang
+
+Reads and writes Xcode 15+ `.xcstrings` catalogs through Inlang's v2 message model.
+
+Supported: exact keys, all catalog locales, positional printf variables, one plural variation, or one Apple device variation per message. Nested or multiple variations and source-only entries without a recoverable value fail explicitly rather than being flattened.
+
+This is a content adapter. Catalog workflow metadata such as comments, extraction state, translation state, and `shouldTranslate` is not represented by Inlang's v2 message tables and is regenerated on export.
+
+```json
+{
+  "modules": [
+    "https://cdn.jsdelivr.net/npm/@inlang/plugin-apple-xcstrings@latest/dist/index.js"
+  ],
+  "plugin.inlang.apple-xcstrings": {
+    "pathPattern": "./Localizations/Localizable.xcstrings"
+  }
+}
+```

--- a/packages/plugins/apple-xcstrings/build.js
+++ b/packages/plugins/apple-xcstrings/build.js
@@ -1,0 +1,36 @@
+import { context } from "esbuild";
+import { execFileSync } from "node:child_process";
+const isProduction = process.env.NODE_ENV === "production";
+const ctx = await context({
+  entryPoints: ["./src/index.ts"],
+  outdir: "./dist",
+  minify: isProduction,
+  target: "es2022",
+  bundle: true,
+  format: "esm",
+  platform: "browser",
+  sourcemap: false,
+});
+if (isProduction) {
+  await ctx.rebuild();
+  await ctx.dispose();
+  execFileSync(
+    "tsc",
+    [
+      "-p",
+      "tsconfig.build.json",
+      "--emitDeclarationOnly",
+      "--declaration",
+      "--declarationMap",
+      "false",
+      "--outDir",
+      "dist",
+      "--noEmit",
+      "false",
+    ],
+    { stdio: "inherit" },
+  );
+} else {
+  await ctx.watch();
+  console.info("Watching for changes...");
+}

--- a/packages/plugins/apple-xcstrings/marketplace-manifest.json
+++ b/packages/plugins/apple-xcstrings/marketplace-manifest.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://inlang.com/schema/marketplace-manifest",
+  "id": "plugin.inlang.apple-xcstrings",
+  "displayName": { "en": "Apple String Catalog" },
+  "description": {
+    "en": "Read and write Apple .xcstrings catalogs with variables, plurals, and device variations."
+  },
+  "pages": { "/": "./README.md" },
+  "keywords": [
+    "apple",
+    "ios",
+    "macos",
+    "xcstrings",
+    "string-catalog",
+    "localization",
+    "plugin"
+  ],
+  "publisherName": "inlang",
+  "publisherIcon": "https://inlang.com/favicon/safari-pinned-tab.svg",
+  "license": "Apache-2.0",
+  "module": "https://cdn.jsdelivr.net/npm/@inlang/plugin-apple-xcstrings@latest/dist/index.js"
+}

--- a/packages/plugins/apple-xcstrings/package.json
+++ b/packages/plugins/apple-xcstrings/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@inlang/plugin-apple-xcstrings",
+  "version": "0.1.0",
+  "type": "module",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "./dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "dev": "node build.js",
+    "build": "NODE_ENV=production node build.js",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@inlang/sdk": "workspace:*",
+    "@sinclair/typebox": "^0.31.17"
+  },
+  "devDependencies": {
+    "@inlang/tsconfig": "workspace:*",
+    "esbuild": "^0.25.9",
+    "typescript": "^5.9.2",
+    "vitest": "^3.2.4"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/opral/inlang.git",
+    "directory": "packages/plugins/apple-xcstrings"
+  },
+  "license": "Apache-2.0"
+}

--- a/packages/plugins/apple-xcstrings/src/index.ts
+++ b/packages/plugins/apple-xcstrings/src/index.ts
@@ -1,0 +1,3 @@
+import { plugin } from "./plugin.js";
+export default plugin;
+export { plugin };

--- a/packages/plugins/apple-xcstrings/src/plugin.test.ts
+++ b/packages/plugins/apple-xcstrings/src/plugin.test.ts
@@ -1,0 +1,485 @@
+import { describe, expect, test } from "vitest";
+import { loadProjectInMemory, newProject } from "@inlang/sdk";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { plugin, PLUGIN_KEY } from "./plugin.js";
+
+const settings = {
+  baseLocale: "en",
+  locales: ["en", "de"],
+  modules: [],
+  [PLUGIN_KEY]: { pathPattern: "./Localizations/Localizable.xcstrings" },
+};
+
+describe("Apple String Catalog plugin", () => {
+  test("imports and exports exact keys, locales, positional variables, plurals, and devices", async () => {
+    const source = catalog({
+      "ManageSale.PricePlaceholder": {
+        extractionState: "manual",
+        localizations: {
+          en: { stringUnit: translated("Hello %1$@") },
+          de: { stringUnit: translated("Hallo %1$@") },
+        },
+      },
+      cart_items: {
+        localizations: {
+          en: {
+            stringUnit: translated("%#@countPlural@"),
+            substitutions: {
+              countPlural: {
+                argNum: 1,
+                formatSpecifier: "lld",
+                variations: {
+                  plural: {
+                    one: { stringUnit: translated("%1$lld item") },
+                    other: { stringUnit: translated("%1$lld items") },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      learn_more: {
+        localizations: {
+          en: {
+            variations: {
+              device: {
+                iphone: { stringUnit: translated("Tap to learn more") },
+                other: { stringUnit: translated("Click to learn more") },
+              },
+            },
+          },
+        },
+      },
+    });
+    const imported = await plugin.importFiles!({
+      settings,
+      files: [{ locale: "en", content: encode(source) }],
+    });
+    expect(imported.bundles.map((bundle) => bundle.id)).toEqual([
+      "ManageSale.PricePlaceholder",
+      "cart_items",
+      "learn_more",
+    ]);
+    const pluralMessage = imported.messages.find(
+      (message) => message.bundleId === "cart_items",
+    )!;
+    expect(pluralMessage.selectors).toEqual([
+      { type: "variable-reference", name: "countPlural" },
+    ]);
+    const deviceMessage = imported.messages.find(
+      (message) => message.bundleId === "learn_more",
+    )!;
+    expect(deviceMessage.selectors).toEqual([
+      { type: "variable-reference", name: "device" },
+    ]);
+
+    const concrete = concretize(imported);
+    const [file] = await plugin.exportFiles!({ settings, ...concrete });
+    expect(file!.name).toBe("./Localizations/Localizable.xcstrings");
+    const output = JSON.parse(decode(file!.content));
+    expect(output.sourceLanguage).toBe("en");
+    expect(
+      output.strings["ManageSale.PricePlaceholder"].localizations.de.stringUnit
+        .value,
+    ).toBe("Hallo %1$@");
+    expect(
+      output.strings.cart_items.localizations.en.substitutions.countPlural
+        .variations.plural.other.stringUnit.value,
+    ).toBe("%1$lld items");
+    expect(
+      output.strings.learn_more.localizations.en.variations.device.iphone
+        .stringUnit.value,
+    ).toBe("Tap to learn more");
+  });
+
+  test("round-trips through the SDK project lifecycle", async () => {
+    const project = await loadProjectInMemory({
+      blob: await newProject({ settings }),
+      providePlugins: [plugin as any],
+    });
+    try {
+      const files = [
+        {
+          locale: "en",
+          content: encode(
+            catalog({
+              greeting: {
+                localizations: {
+                  en: { stringUnit: translated("Hello %1$@") },
+                  de: { stringUnit: translated("Hallo %1$@") },
+                },
+              },
+            }),
+          ),
+        },
+      ];
+      await project.importFiles({ pluginKey: plugin.key, files });
+      const [file] = await project.exportFiles({ pluginKey: plugin.key });
+      const output = JSON.parse(decode(file!.content));
+      expect(output.strings.greeting.localizations).toEqual({
+        de: { stringUnit: translated("Hallo %1$@") },
+        en: { stringUnit: translated("Hello %1$@") },
+      });
+    } finally {
+      await project.close();
+    }
+  });
+
+  test("preserves plural templates, argument positions, and compiles with Xcode", async () => {
+    const source = catalog({
+      cart: {
+        localizations: {
+          en: {
+            stringUnit: translated("You have %#@items@ remaining"),
+            substitutions: {
+              items: {
+                argNum: 2,
+                formatSpecifier: "d",
+                variations: {
+                  plural: {
+                    one: { stringUnit: translated("%1$@ has %2$d item") },
+                    other: { stringUnit: translated("%1$@ has %2$d items") },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    const imported = await plugin.importFiles!({
+      settings,
+      files: [{ locale: "en", content: encode(source) }],
+    });
+    expect(imported.variants[0]?.pattern?.[0]).toEqual({
+      type: "text",
+      value: "You have ",
+    });
+    const [file] = await plugin.exportFiles!({
+      settings,
+      ...concretize(imported),
+    });
+    const localization = JSON.parse(decode(file!.content)).strings.cart
+      .localizations.en;
+    expect(localization.substitutions.items.argNum).toBe(2);
+    expect(localization.substitutions.items.formatSpecifier).toBe("d");
+    expect(
+      localization.substitutions.items.variations.plural.other.stringUnit.value,
+    ).toBe("You have %1$@ has %2$d items remaining");
+    compileWithXcode(file!.content);
+  });
+
+  test("imports and compiles standard direct plural variations", async () => {
+    const source = catalog({
+      "%1$lld item(s)": {
+        localizations: {
+          en: {
+            variations: {
+              plural: {
+                one: { stringUnit: translated("%1$lld item") },
+                other: { stringUnit: translated("%1$lld items") },
+              },
+            },
+          },
+        },
+      },
+    });
+    const imported = await plugin.importFiles!({
+      settings,
+      files: [{ locale: "en", content: encode(source) }],
+    });
+    const [file] = await plugin.exportFiles!({
+      settings,
+      ...concretize(imported),
+    });
+    expect(
+      JSON.parse(decode(file!.content)).strings["%1$lld item(s)"].localizations
+        .en.variations.plural.other.stringUnit.value,
+    ).toBe("%1$lld items");
+    compileWithXcode(file!.content);
+  });
+
+  test("exports canonical Inlang plurals with numeric placeholders", () => {
+    const [file] = plugin.exportFiles!({
+      settings,
+      bundles: [
+        {
+          id: "cart_items",
+          declarations: [
+            { type: "input-variable", name: "count" },
+            {
+              type: "local-variable",
+              name: "countPlural",
+              value: {
+                type: "expression",
+                arg: { type: "variable-reference", name: "count" },
+                annotation: {
+                  type: "function-reference",
+                  name: "plural",
+                  options: [],
+                },
+              },
+            },
+          ],
+        },
+      ] as any,
+      messages: [
+        {
+          id: "message",
+          bundleId: "cart_items",
+          locale: "en",
+          selectors: [{ type: "variable-reference", name: "countPlural" }],
+        },
+      ],
+      variants: [
+        {
+          id: "one",
+          messageId: "message",
+          matches: [
+            { type: "literal-match", key: "countPlural", value: "one" },
+          ],
+          pattern: [
+            {
+              type: "expression",
+              arg: { type: "variable-reference", name: "count" },
+            },
+            { type: "text", value: " item" },
+          ],
+        },
+        {
+          id: "other",
+          messageId: "message",
+          matches: [{ type: "catchall-match", key: "countPlural" }],
+          pattern: [
+            {
+              type: "expression",
+              arg: { type: "variable-reference", name: "count" },
+            },
+            { type: "text", value: " items" },
+          ],
+        },
+      ] as any,
+    }) as any[];
+    expect(
+      JSON.parse(decode(file!.content)).strings.cart_items.localizations.en
+        .substitutions.countPlural.variations.plural.other.stringUnit.value,
+    ).toBe("%1$lld items");
+    compileWithXcode(file!.content);
+  });
+
+  test("preserves plain percent text and escaped percent in formatted patterns", async () => {
+    const source = catalog({
+      raw: {
+        localizations: { en: { stringUnit: translated("Save 20% and 100%%") } },
+      },
+      formatted: {
+        localizations: {
+          en: { stringUnit: translated("%1$@ is 20%% complete") },
+        },
+      },
+    });
+    const imported = await plugin.importFiles!({
+      settings,
+      files: [{ locale: "en", content: encode(source) }],
+    });
+    const [file] = await plugin.exportFiles!({
+      settings,
+      ...concretize(imported),
+    });
+    const output = JSON.parse(decode(file!.content));
+    expect(output.strings.raw.localizations.en.stringUnit.value).toBe(
+      "Save 20% and 100%%",
+    );
+    expect(output.strings.formatted.localizations.en.stringUnit.value).toBe(
+      "%1$@ is 20%% complete",
+    );
+  });
+
+  test("rejects malformed, nested, multi-selector, and missing-other catalogs", async () => {
+    expect(() =>
+      plugin.importFiles!({
+        settings,
+        files: [{ locale: "en", content: encode("not json") }],
+      }),
+    ).toThrow("Invalid Apple .xcstrings JSON");
+    expect(() =>
+      plugin.importFiles!({
+        settings,
+        files: [
+          {
+            locale: "en",
+            content: encode(
+              catalog({
+                bad: {
+                  localizations: {
+                    en: {
+                      variations: {
+                        device: { iphone: { stringUnit: translated("Tap") } },
+                      },
+                    },
+                  },
+                },
+              }),
+            ),
+          },
+        ],
+      }),
+    ).toThrow('require "other"');
+    expect(() =>
+      plugin.importFiles!({
+        settings,
+        files: [
+          {
+            locale: "en",
+            content: encode(
+              catalog({
+                bad: {
+                  localizations: {
+                    en: {
+                      stringUnit: translated("value"),
+                      variations: {
+                        device: { other: { stringUnit: translated("other") } },
+                      },
+                    },
+                  },
+                },
+              }),
+            ),
+          },
+        ],
+      }),
+    ).toThrow("exactly one supported localization shape");
+    expect(() =>
+      plugin.exportFiles!({
+        settings,
+        bundles: [{ id: "bad", declarations: [] }],
+        messages: [
+          {
+            id: "message",
+            bundleId: "bad",
+            locale: "en",
+            selectors: [
+              { type: "variable-reference", name: "a" },
+              { type: "variable-reference", name: "b" },
+            ],
+          },
+        ],
+        variants: [],
+      }),
+    ).toThrow("one selector");
+    expect(() =>
+      plugin.importFiles!({
+        settings,
+        files: [{ locale: "en", content: encode(catalog({ sourceOnly: {} })) }],
+      }),
+    ).toThrow("source-only entry");
+    expect(() =>
+      plugin.importFiles!({
+        settings,
+        files: [
+          {
+            locale: "en",
+            content: encode(
+              JSON.stringify({
+                sourceLanguage: "fr",
+                strings: {},
+                version: "1.0",
+              }),
+            ),
+          },
+        ],
+      }),
+    ).toThrow("must match baseLocale");
+  });
+
+  test("rejects ambiguous printf arguments and duplicate identities", () => {
+    for (const value of ["%1$@ %d", "%1$@ %1$d"]) {
+      expect(() =>
+        plugin.importFiles!({
+          settings,
+          files: [
+            {
+              locale: "en",
+              content: encode(
+                catalog({
+                  bad: {
+                    localizations: { en: { stringUnit: translated(value) } },
+                  },
+                }),
+              ),
+            },
+          ],
+        }),
+      ).toThrow();
+    }
+    expect(() =>
+      plugin.exportFiles!({
+        settings,
+        bundles: [
+          { id: "same", declarations: [] },
+          { id: "same", declarations: [] },
+        ],
+        messages: [],
+        variants: [],
+      }),
+    ).toThrow("Duplicate Apple .xcstrings bundle id");
+  });
+});
+
+function catalog(strings: Record<string, unknown>) {
+  return JSON.stringify({ sourceLanguage: "en", strings, version: "1.0" });
+}
+function translated(value: string) {
+  return { state: "translated", value };
+}
+function encode(value: string) {
+  return new TextEncoder().encode(value);
+}
+function decode(value: Uint8Array) {
+  return new TextDecoder().decode(value);
+}
+function compileWithXcode(content: Uint8Array) {
+  if (process.platform !== "darwin") return;
+  const directory = mkdtempSync(join(tmpdir(), "inlang-xcstrings-"));
+  const input = join(directory, "Localizable.xcstrings");
+  writeFileSync(input, content);
+  execFileSync("xcrun", [
+    "xcstringstool",
+    "compile",
+    input,
+    "--output-directory",
+    directory,
+    "--serialization-format",
+    "text",
+  ]);
+  expect(
+    existsSync(join(directory, "en.lproj", "Localizable.strings")) ||
+      existsSync(join(directory, "en.lproj", "Localizable.stringsdict")),
+  ).toBe(true);
+}
+function concretize(
+  imported: Awaited<ReturnType<NonNullable<typeof plugin.importFiles>>>,
+) {
+  const messages = imported.messages.map((message, index) => ({
+    ...message,
+    id: `message-${index}`,
+  }));
+  const variants = imported.variants.map((variant, index) => ({
+    ...variant,
+    id: `variant-${index}`,
+    messageId: messages.find(
+      (message) =>
+        message.bundleId === variant.messageBundleId &&
+        message.locale === variant.messageLocale,
+    )!.id,
+  }));
+  return {
+    bundles: imported.bundles as any,
+    messages: messages as any,
+    variants: variants as any,
+  };
+}

--- a/packages/plugins/apple-xcstrings/src/plugin.test.ts
+++ b/packages/plugins/apple-xcstrings/src/plugin.test.ts
@@ -141,8 +141,8 @@ describe("Apple String Catalog plugin", () => {
                 formatSpecifier: "d",
                 variations: {
                   plural: {
-                    one: { stringUnit: translated("%1$@ has %2$d item") },
-                    other: { stringUnit: translated("%1$@ has %2$d items") },
+                    one: { stringUnit: translated("%d item") },
+                    other: { stringUnit: translated("%d items") },
                   },
                 },
               },
@@ -169,13 +169,13 @@ describe("Apple String Catalog plugin", () => {
     expect(localization.substitutions.items.formatSpecifier).toBe("d");
     expect(
       localization.substitutions.items.variations.plural.other.stringUnit.value,
-    ).toBe("You have %1$@ has %2$d items remaining");
+    ).toBe("You have %2$d items remaining");
     compileWithXcode(file!.content);
   });
 
   test("imports and compiles standard direct plural variations", async () => {
     const source = catalog({
-      "%1$lld item(s)": {
+      cart_items_direct: {
         localizations: {
           en: {
             variations: {
@@ -197,7 +197,7 @@ describe("Apple String Catalog plugin", () => {
       ...concretize(imported),
     });
     expect(
-      JSON.parse(decode(file!.content)).strings["%1$lld item(s)"].localizations
+      JSON.parse(decode(file!.content)).strings.cart_items_direct.localizations
         .en.variations.plural.other.stringUnit.value,
     ).toBe("%1$lld items");
     compileWithXcode(file!.content);
@@ -427,6 +427,45 @@ describe("Apple String Catalog plugin", () => {
         variants: [],
       }),
     ).toThrow("Duplicate Apple .xcstrings bundle id");
+  });
+
+  test("preserves prototype-looking exact keys and rejects missing bundles", () => {
+    const [file] = plugin.exportFiles!({
+      settings,
+      bundles: [{ id: "__proto__", declarations: [] }],
+      messages: [
+        {
+          id: "message",
+          bundleId: "__proto__",
+          locale: "en",
+          selectors: [],
+        },
+      ],
+      variants: [
+        {
+          id: "variant",
+          messageId: "message",
+          matches: [],
+          pattern: [{ type: "text", value: "safe" }],
+        },
+      ],
+    }) as any[];
+    expect(JSON.parse(decode(file!.content)).strings.__proto__).toBeTruthy();
+    expect(() =>
+      plugin.exportFiles!({
+        settings,
+        bundles: [],
+        messages: [
+          {
+            id: "message",
+            bundleId: "missing",
+            locale: "en",
+            selectors: [],
+          },
+        ],
+        variants: [],
+      }),
+    ).toThrow("references missing bundle");
   });
 });
 

--- a/packages/plugins/apple-xcstrings/src/plugin.ts
+++ b/packages/plugins/apple-xcstrings/src/plugin.ts
@@ -56,13 +56,14 @@ const pluralCategories = new Set([
   "other",
 ]);
 const deviceCategories = new Set([
+  "appletv",
+  "applevision",
   "applewatch",
   "ipad",
   "iphone",
+  "ipod",
   "mac",
   "other",
-  "tv",
-  "vision",
 ]);
 
 export const plugin: InlangPlugin<Config> = {
@@ -165,26 +166,13 @@ function importLocalization(id: string, localization: Localization) {
     const units = localization.variations!.plural!;
     assertVariationUnits(units, id, "plural", pluralCategories);
     const sourcePattern = parsePattern(id);
-    const sourceExpressions = sourcePattern.pattern.filter(
-      (part) => part.type === "expression",
-    );
-    if (sourceExpressions.length !== 1)
-      throw new Error(
-        `Direct Apple plural "${id}" must contain exactly one printf argument in its key`,
-      );
-    const sourceExpression = sourceExpressions[0]!;
-    if (sourceExpression.arg.type !== "variable-reference")
-      throw new Error(`Invalid direct Apple plural argument in "${id}"`);
-    const inputName = sourceExpression.arg.name;
-    const format = printfFormat(
-      sourceExpression.annotation,
-      argumentPosition(inputName),
-    );
-    const selector = "countPlural";
     const parsed = Object.entries(units).map(([key, unit]) => ({
       key,
       parsed: parsePattern(unit.stringUnit.value),
     }));
+    const format = inferDirectPluralFormat(id, sourcePattern.pattern, parsed);
+    const inputName = `arg${format.position}`;
+    const selector = "countPlural";
     return {
       declarations: [
         { type: "input-variable", name: inputName } as Declaration,
@@ -240,7 +228,7 @@ function importLocalization(id: string, localization: Localization) {
     const parsed = Object.entries(substitution.variations.plural).map(
       ([key, unit]) => ({
         key,
-        parsed: parsePattern(unit.stringUnit.value),
+        parsed: parsePattern(unit.stringUnit.value, argNum),
       }),
     );
     return {
@@ -285,12 +273,18 @@ function exportCatalog({ bundles, messages, variants, settings }: ExportArgs) {
   assertUniqueIds(bundles, "bundle");
   assertUniqueIds(messages, "message");
   const messageIds = new Set(messages.map((message) => message.id));
+  const bundleIds = new Set(bundles.map((bundle) => bundle.id));
+  for (const message of messages)
+    if (!bundleIds.has(message.bundleId))
+      throw new Error(
+        `Apple .xcstrings message "${message.id}" references missing bundle "${message.bundleId}"`,
+      );
   for (const variant of variants)
     if (!messageIds.has(variant.messageId))
       throw new Error(
         `Apple .xcstrings variant "${variant.id}" references missing message "${variant.messageId}"`,
       );
-  const strings: Catalog["strings"] = {};
+  const stringEntries: Array<[string, Catalog["strings"][string]]> = [];
   for (const bundle of bundles) {
     const bundleMessages = messages.filter(
       (message) => message.bundleId === bundle.id,
@@ -308,12 +302,15 @@ function exportCatalog({ bundles, messages, variants, settings }: ExportArgs) {
         variants,
       );
     }
-    strings[bundle.id] = { extractionState: "manual", localizations };
+    stringEntries.push([
+      bundle.id,
+      { extractionState: "manual", localizations },
+    ]);
   }
   const catalog: Catalog = {
     sourceLanguage: settings.baseLocale,
     strings: Object.fromEntries(
-      Object.entries(strings).sort(([a], [b]) => a.localeCompare(b)),
+      stringEntries.sort(([a], [b]) => a.localeCompare(b)),
     ),
     version: "1.0",
   };
@@ -445,6 +442,46 @@ function wrapPattern(
   ];
 }
 
+function inferDirectPluralFormat(
+  id: string,
+  sourcePattern: Pattern,
+  variants: Array<{ parsed: { pattern: Pattern } }>,
+) {
+  const sourceExpressions = sourcePattern.filter(
+    (part) => part.type === "expression",
+  );
+  const candidates = sourceExpressions.length
+    ? sourceExpressions
+    : variants.flatMap(({ parsed }) =>
+        parsed.pattern.filter((part) => part.type === "expression"),
+      );
+  if (!candidates.length)
+    throw new Error(
+      `Direct Apple plural "${id}" must contain a numeric printf argument in its key or variants`,
+    );
+  const formats = candidates.map((expression) => {
+    if (expression.arg.type !== "variable-reference")
+      throw new Error(`Invalid direct Apple plural argument in "${id}"`);
+    return printfFormat(
+      expression.annotation,
+      argumentPosition(expression.arg.name),
+    );
+  });
+  const first = formats[0]!;
+  if (
+    !/(?:hh|h|ll|l|q|z|t|j)?[diuoxXfFeEgGaA]$/.test(first.specifier) ||
+    formats.some(
+      (format) =>
+        format.position !== first.position ||
+        format.specifier !== first.specifier,
+    )
+  )
+    throw new Error(
+      `Direct Apple plural "${id}" must use one consistent numeric argument`,
+    );
+  return first;
+}
+
 function parseCatalog(content: Uint8Array): Catalog {
   let parsed: unknown;
   try {
@@ -463,7 +500,7 @@ function parseCatalog(content: Uint8Array): Catalog {
   return parsed as Catalog;
 }
 
-function parsePattern(value: string) {
+function parsePattern(value: string, implicitStart = 1) {
   const pattern: Pattern = [];
   const variables: string[] = [];
   const regex =
@@ -471,7 +508,7 @@ function parsePattern(value: string) {
   if (!hasPrintfExpression(value, regex))
     return { pattern: [{ type: "text", value }] as Pattern, variables };
   let cursor = 0;
-  let implicit = 0;
+  let implicit = implicitStart - 1;
   let sawImplicit = false;
   let sawExplicit = false;
   const specifiersByPosition = new Map<number, string>();
@@ -661,6 +698,8 @@ function pluralDeclaration(
 }
 
 function inputPosition(bundle: Bundle, name: string) {
+  const namedPosition = argumentPosition(name);
+  if (namedPosition !== Number.MAX_SAFE_INTEGER) return namedPosition;
   const inputs = bundle.declarations.filter(
     (declaration) => declaration.type === "input-variable",
   );

--- a/packages/plugins/apple-xcstrings/src/plugin.ts
+++ b/packages/plugins/apple-xcstrings/src/plugin.ts
@@ -223,6 +223,13 @@ function importLocalization(id: string, localization: Localization) {
         `Apple .xcstrings substitution template in "${id}" must contain exactly one ${token}`,
       );
     const [prefix, suffix] = template.split(token);
+    if (
+      hasImplicitPrintfExpression(prefix!) ||
+      hasImplicitPrintfExpression(suffix!)
+    )
+      throw new Error(
+        `Apple .xcstrings substitution template in "${id}" cannot mix implicit printf arguments with positional argNum`,
+      );
     const parsedPrefix = parsePattern(prefix!);
     const parsedSuffix = parsePattern(
       suffix!,
@@ -802,6 +809,20 @@ function hasPrintfExpression(source: string, regex: RegExp) {
       continue;
     }
     if (source[cursor] === "%" && regex.test(source.slice(cursor))) return true;
+  }
+  return false;
+}
+
+function hasImplicitPrintfExpression(source: string) {
+  const implicit =
+    /^%(?!\d+\$)(?:[-+# 0,(]*\d*(?:\.\d+)?(?:hh|h|ll|l|q|z|t|j)?[diuoxXfFeEgGaAcCsSp@])/;
+  for (let cursor = 0; cursor < source.length; cursor++) {
+    if (source.startsWith("%%", cursor)) {
+      cursor++;
+      continue;
+    }
+    if (source[cursor] === "%" && implicit.test(source.slice(cursor)))
+      return true;
   }
   return false;
 }

--- a/packages/plugins/apple-xcstrings/src/plugin.ts
+++ b/packages/plugins/apple-xcstrings/src/plugin.ts
@@ -1,0 +1,753 @@
+import type {
+  Bundle,
+  Declaration,
+  InlangPlugin,
+  Message,
+  MessageImport,
+  Pattern,
+  Variant,
+  VariantImport,
+} from "@inlang/sdk";
+import { PluginSettings } from "./settings.js";
+
+export const PLUGIN_KEY = "plugin.inlang.apple-xcstrings";
+type Config = { [PLUGIN_KEY]: PluginSettings };
+type ImportArgs = Parameters<
+  NonNullable<InlangPlugin<Config>["importFiles"]>
+>[0];
+type ExportArgs = Parameters<
+  NonNullable<InlangPlugin<Config>["exportFiles"]>
+>[0];
+type StringUnit = { state?: string; value: string };
+type VariationUnit = { stringUnit: StringUnit };
+type Localization = {
+  stringUnit?: StringUnit;
+  substitutions?: Record<
+    string,
+    {
+      argNum?: number;
+      formatSpecifier: string;
+      variations: { plural: Record<string, VariationUnit> };
+    }
+  >;
+  variations?: {
+    device?: Record<string, VariationUnit>;
+    plural?: Record<string, VariationUnit>;
+  };
+};
+type Catalog = {
+  sourceLanguage: string;
+  strings: Record<
+    string,
+    {
+      extractionState?: string;
+      localizations?: Record<string, Localization>;
+    }
+  >;
+  version: "1.0";
+};
+
+const pluralCategories = new Set([
+  "zero",
+  "one",
+  "two",
+  "few",
+  "many",
+  "other",
+]);
+const deviceCategories = new Set([
+  "applewatch",
+  "ipad",
+  "iphone",
+  "mac",
+  "other",
+  "tv",
+  "vision",
+]);
+
+export const plugin: InlangPlugin<Config> = {
+  key: PLUGIN_KEY,
+  settingsSchema: PluginSettings,
+  toBeImportedFiles: ({ settings }) => [
+    {
+      locale: settings.baseLocale,
+      path: settings[PLUGIN_KEY].pathPattern,
+    },
+  ],
+  importFiles: ({ files, settings }: ImportArgs) =>
+    importCatalogs(files, settings),
+  exportFiles: (args: ExportArgs) => exportCatalog(args),
+};
+
+function importCatalogs(
+  files: ImportArgs["files"],
+  settings: ImportArgs["settings"],
+) {
+  if (files.length !== 1)
+    throw new Error(
+      `Apple .xcstrings expects exactly one catalog, received ${files.length}`,
+    );
+  const catalog = parseCatalog(files[0]!.content);
+  if (catalog.sourceLanguage !== settings.baseLocale)
+    throw new Error(
+      `Apple .xcstrings sourceLanguage "${catalog.sourceLanguage}" must match baseLocale "${settings.baseLocale}"`,
+    );
+  const bundles = new Map<string, Bundle>();
+  const messages: MessageImport[] = [];
+  const variants: VariantImport[] = [];
+  for (const [id, entry] of Object.entries(catalog.strings)) {
+    if (!entry || typeof entry !== "object")
+      throw new Error(`Invalid catalog entry "${id}"`);
+    if (!entry.localizations || Object.keys(entry.localizations).length === 0)
+      throw new Error(
+        `Apple .xcstrings source-only entry "${id}" has no localization value to import`,
+      );
+    for (const [locale, localization] of Object.entries(
+      entry.localizations ?? {},
+    )) {
+      if (!settings.locales.includes(locale))
+        throw new Error(
+          `Apple .xcstrings locale "${locale}" in "${id}" is not declared in project settings`,
+        );
+      const imported = importLocalization(id, localization);
+      const existing = bundles.get(id) ?? { id, declarations: [] };
+      bundles.set(id, mergeDeclarations(existing, imported.declarations));
+      messages.push({ bundleId: id, locale, selectors: imported.selectors });
+      for (const variant of imported.variants)
+        variants.push({
+          messageBundleId: id,
+          messageLocale: locale,
+          ...variant,
+        });
+    }
+  }
+  return { bundles: [...bundles.values()], messages, variants };
+}
+
+function importLocalization(id: string, localization: Localization) {
+  assertObject(localization, `localization for "${id}"`);
+  const hasPlain = localization.stringUnit !== undefined;
+  const substitutions = localization.substitutions ?? {};
+  const hasPlural = Object.keys(substitutions).length > 0;
+  const hasDevice = localization.variations?.device !== undefined;
+  const hasDirectPlural = localization.variations?.plural !== undefined;
+  if (
+    [hasPlain && !hasPlural, hasPlural, hasDevice, hasDirectPlural].filter(
+      Boolean,
+    ).length !== 1
+  )
+    throw new Error(
+      `Apple .xcstrings entry "${id}" must contain exactly one supported localization shape`,
+    );
+  if (hasDevice) {
+    const units = localization.variations!.device!;
+    assertVariationUnits(units, id, "device", deviceCategories);
+    const parsed = Object.entries(units).map(([key, unit]) => ({
+      key,
+      parsed: parsePattern(unit.stringUnit.value),
+    }));
+    return {
+      declarations: [
+        { type: "input-variable", name: "device" } as Declaration,
+        ...inputDeclarations(
+          parsed.flatMap(({ parsed }) => parsed.variables),
+          ["device"],
+        ),
+      ],
+      selectors: [{ type: "variable-reference" as const, name: "device" }],
+      variants: parsed.map(({ key, parsed }) => ({
+        matches: [match("device", key)],
+        pattern: parsed.pattern,
+      })),
+    };
+  }
+  if (hasDirectPlural) {
+    const units = localization.variations!.plural!;
+    assertVariationUnits(units, id, "plural", pluralCategories);
+    const sourcePattern = parsePattern(id);
+    const sourceExpressions = sourcePattern.pattern.filter(
+      (part) => part.type === "expression",
+    );
+    if (sourceExpressions.length !== 1)
+      throw new Error(
+        `Direct Apple plural "${id}" must contain exactly one printf argument in its key`,
+      );
+    const sourceExpression = sourceExpressions[0]!;
+    if (sourceExpression.arg.type !== "variable-reference")
+      throw new Error(`Invalid direct Apple plural argument in "${id}"`);
+    const inputName = sourceExpression.arg.name;
+    const format = printfFormat(
+      sourceExpression.annotation,
+      argumentPosition(inputName),
+    );
+    const selector = "countPlural";
+    const parsed = Object.entries(units).map(([key, unit]) => ({
+      key,
+      parsed: parsePattern(unit.stringUnit.value),
+    }));
+    return {
+      declarations: [
+        { type: "input-variable", name: inputName } as Declaration,
+        pluralDeclaration(selector, inputName, {
+          appleFormatSpecifier: format.specifier,
+          appleArgNum: String(format.position),
+          applePluralStyle: "direct",
+        }),
+        ...inputDeclarations(
+          parsed.flatMap(({ parsed }) => parsed.variables),
+          [inputName, selector],
+        ),
+      ],
+      selectors: [{ type: "variable-reference" as const, name: selector }],
+      variants: parsed.map(({ key, parsed }) => ({
+        matches: [match(selector, key)],
+        pattern: parsed.pattern,
+      })),
+    };
+  }
+  if (hasPlural) {
+    if (Object.keys(substitutions).length !== 1)
+      throw new Error(
+        `Apple .xcstrings entry "${id}" has multiple substitutions, which are not representable by one Inlang selector`,
+      );
+    const [name, substitution] = Object.entries(substitutions)[0]!;
+    if (!substitution?.variations?.plural)
+      throw new Error(
+        `Apple .xcstrings substitution "${name}" in "${id}" must contain plural variations`,
+      );
+    assertPrintfSpecifier(substitution.formatSpecifier, id);
+    assertVariationUnits(
+      substitution.variations.plural,
+      id,
+      "plural",
+      pluralCategories,
+    );
+    const argNum = substitution.argNum ?? 1;
+    if (!Number.isSafeInteger(argNum) || argNum < 1)
+      throw new Error(
+        `Invalid Apple .xcstrings argNum in substitution "${name}" of "${id}"`,
+      );
+    const inputName = `arg${argNum}`;
+    const template = requiredStringUnit(localization.stringUnit, id).value;
+    const token = `%#@${name}@`;
+    if (template.split(token).length !== 2)
+      throw new Error(
+        `Apple .xcstrings substitution template in "${id}" must contain exactly one ${token}`,
+      );
+    const [prefix, suffix] = template.split(token);
+    const parsedPrefix = parsePattern(prefix!);
+    const parsedSuffix = parsePattern(suffix!);
+    const parsed = Object.entries(substitution.variations.plural).map(
+      ([key, unit]) => ({
+        key,
+        parsed: parsePattern(unit.stringUnit.value),
+      }),
+    );
+    return {
+      declarations: [
+        { type: "input-variable", name: inputName } as Declaration,
+        pluralDeclaration(name, inputName, {
+          appleFormatSpecifier: substitution.formatSpecifier,
+          appleArgNum: String(argNum),
+          applePluralStyle: "substitution",
+        }),
+        ...inputDeclarations(
+          [
+            ...parsedPrefix.variables,
+            ...parsed.flatMap(({ parsed }) => parsed.variables),
+            ...parsedSuffix.variables,
+          ],
+          [inputName, name],
+        ),
+      ],
+      selectors: [{ type: "variable-reference" as const, name }],
+      variants: parsed.map(({ key, parsed }) => ({
+        matches: [match(name, key)],
+        pattern: [
+          ...parsedPrefix.pattern,
+          ...parsed.pattern,
+          ...parsedSuffix.pattern,
+        ],
+      })),
+    };
+  }
+  const parsed = parsePattern(
+    requiredStringUnit(localization.stringUnit, id).value,
+  );
+  return {
+    declarations: inputDeclarations(parsed.variables),
+    selectors: [],
+    variants: [{ matches: [], pattern: parsed.pattern }],
+  };
+}
+
+function exportCatalog({ bundles, messages, variants, settings }: ExportArgs) {
+  assertUniqueIds(bundles, "bundle");
+  assertUniqueIds(messages, "message");
+  const messageIds = new Set(messages.map((message) => message.id));
+  for (const variant of variants)
+    if (!messageIds.has(variant.messageId))
+      throw new Error(
+        `Apple .xcstrings variant "${variant.id}" references missing message "${variant.messageId}"`,
+      );
+  const strings: Catalog["strings"] = {};
+  for (const bundle of bundles) {
+    const bundleMessages = messages.filter(
+      (message) => message.bundleId === bundle.id,
+    );
+    if (bundleMessages.length === 0) continue;
+    const localizations: Record<string, Localization> = {};
+    for (const message of bundleMessages) {
+      if (localizations[message.locale])
+        throw new Error(
+          `Duplicate Apple .xcstrings locale "${message.locale}" in "${bundle.id}"`,
+        );
+      localizations[message.locale] = exportLocalization(
+        bundle,
+        message,
+        variants,
+      );
+    }
+    strings[bundle.id] = { extractionState: "manual", localizations };
+  }
+  const catalog: Catalog = {
+    sourceLanguage: settings.baseLocale,
+    strings: Object.fromEntries(
+      Object.entries(strings).sort(([a], [b]) => a.localeCompare(b)),
+    ),
+    version: "1.0",
+  };
+  return [
+    {
+      locale: settings.baseLocale,
+      name: settings[PLUGIN_KEY]?.pathPattern ?? "Localizable.xcstrings",
+      content: new TextEncoder().encode(
+        `${JSON.stringify(catalog, null, 2)}\n`,
+      ),
+    },
+  ];
+}
+
+function exportLocalization(
+  bundle: Bundle,
+  message: Message,
+  variants: Variant[],
+): Localization {
+  const messageVariants = variants.filter(
+    (variant) => variant.messageId === message.id,
+  );
+  if (message.selectors.length === 0) {
+    if (
+      messageVariants.length !== 1 ||
+      messageVariants[0]!.matches.length !== 0
+    )
+      throw new Error(
+        `Apple .xcstrings requires one unconditional variant in "${bundle.id}"`,
+      );
+    return {
+      stringUnit: translated(
+        serializePattern(messageVariants[0]!.pattern, bundle),
+      ),
+    };
+  }
+  if (message.selectors.length !== 1)
+    throw new Error(
+      `Apple .xcstrings currently supports one selector per message (bundle "${bundle.id}")`,
+    );
+  const selector = message.selectors[0]!.name;
+  const plural = pluralInput(bundle, selector);
+  const units = variationUnits(bundle, messageVariants, selector);
+  if (plural) {
+    for (const key of Object.keys(units))
+      if (!pluralCategories.has(key))
+        throw new Error(
+          `Unsupported Apple plural category "${key}" in "${bundle.id}"`,
+        );
+    const pluralDeclaration = bundle.declarations.find(
+      (declaration) => declaration.name === selector,
+    );
+    const annotation =
+      pluralDeclaration?.type === "local-variable"
+        ? pluralDeclaration.value.annotation
+        : undefined;
+    const storedSpecifier = literalOption(annotation, "appleFormatSpecifier");
+    const storedArgNum = literalOption(annotation, "appleArgNum");
+    const pluralStyle = literalOption(annotation, "applePluralStyle");
+    const argNum = storedArgNum
+      ? Number(storedArgNum)
+      : inputPosition(bundle, plural);
+    const formatSpecifier = storedSpecifier ?? "lld";
+    if (!Number.isSafeInteger(argNum) || argNum < 1)
+      throw new Error(
+        `Invalid Apple plural argument position in "${bundle.id}"`,
+      );
+    assertPrintfSpecifier(formatSpecifier, bundle.id);
+    if (pluralStyle === "direct") {
+      return { variations: { plural: units } };
+    }
+    return {
+      stringUnit: translated(`%#@${selector}@`),
+      substitutions: {
+        [selector]: {
+          argNum,
+          formatSpecifier,
+          variations: { plural: units },
+        },
+      },
+    };
+  }
+  if (selector === "device") return { variations: { device: units } };
+  throw new Error(
+    `Apple .xcstrings cannot represent selector "${selector}" in "${bundle.id}"`,
+  );
+}
+
+function variationUnits(bundle: Bundle, variants: Variant[], selector: string) {
+  const units: Record<string, VariationUnit> = {};
+  let catchalls = 0;
+  for (const variant of variants) {
+    if (variant.matches.length !== 1 || variant.matches[0]!.key !== selector)
+      throw new Error(`Invalid Apple .xcstrings matches in "${bundle.id}"`);
+    const matchValue =
+      variant.matches[0]!.type === "catchall-match"
+        ? "other"
+        : variant.matches[0]!.value;
+    if (variant.matches[0]!.type === "catchall-match") catchalls++;
+    if (units[matchValue])
+      throw new Error(
+        `Duplicate Apple variation "${matchValue}" in "${bundle.id}"`,
+      );
+    units[matchValue] = {
+      stringUnit: translated(
+        serializePattern(variant.pattern, bundle, {
+          variableName: pluralInput(bundle, selector),
+          specifier: pluralSpecifier(bundle, selector),
+        }),
+      ),
+    };
+  }
+  if (catchalls !== 1 || !units.other)
+    throw new Error(
+      `Apple variations in "${bundle.id}" require exactly one catchall/other variant`,
+    );
+  return units;
+}
+
+function wrapPattern(
+  prefix: string,
+  pattern: Pattern,
+  suffix: string,
+): Pattern {
+  return [
+    ...(prefix ? [{ type: "text" as const, value: prefix }] : []),
+    ...pattern,
+    ...(suffix ? [{ type: "text" as const, value: suffix }] : []),
+  ];
+}
+
+function parseCatalog(content: Uint8Array): Catalog {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(new TextDecoder().decode(content));
+  } catch (error) {
+    throw new Error(
+      `Invalid Apple .xcstrings JSON: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  assertObject(parsed, "Apple .xcstrings catalog");
+  if (parsed.version !== "1.0" || typeof parsed.sourceLanguage !== "string")
+    throw new Error(
+      "Apple .xcstrings requires version 1.0 and a sourceLanguage",
+    );
+  assertObject(parsed.strings, "Apple .xcstrings strings");
+  return parsed as Catalog;
+}
+
+function parsePattern(value: string) {
+  const pattern: Pattern = [];
+  const variables: string[] = [];
+  const regex =
+    /^%(?:(\d+)\$([-+# 0,(]*\d*(?:\.\d+)?(?:hh|h|ll|l|q|z|t|j)?[diuoxXfFeEgGaAcCsSp@])|((?:hh|h|ll|l|q|z|t|j)?[diuoxXfFeEgGaAcCsSp@]))/;
+  if (!hasPrintfExpression(value, regex))
+    return { pattern: [{ type: "text", value }] as Pattern, variables };
+  let cursor = 0;
+  let implicit = 0;
+  let sawImplicit = false;
+  let sawExplicit = false;
+  const specifiersByPosition = new Map<number, string>();
+  let text = "";
+  while (cursor < value.length) {
+    if (value.startsWith("%%", cursor)) {
+      text += "%";
+      cursor += 2;
+      continue;
+    }
+    const found = value.slice(cursor).match(regex);
+    if (!found) {
+      if (value[cursor] === "%")
+        throw new Error(
+          `Unsupported Apple format specifier near "${value.slice(cursor, cursor + 12)}"`,
+        );
+      text += value[cursor++];
+      continue;
+    }
+    if (text) {
+      pattern.push({ type: "text", value: text });
+      text = "";
+    }
+    if (found[1]) sawExplicit = true;
+    else sawImplicit = true;
+    if (sawExplicit && sawImplicit)
+      throw new Error(
+        `Apple format strings cannot mix positional and implicit specifiers in "${value}"`,
+      );
+    const position = found[1] ? Number(found[1]) : ++implicit;
+    const specifier = found[2] ?? found[3]!;
+    const previousSpecifier = specifiersByPosition.get(position);
+    if (previousSpecifier && previousSpecifier !== specifier)
+      throw new Error(
+        `Apple argument ${position} uses incompatible specifiers "${previousSpecifier}" and "${specifier}"`,
+      );
+    specifiersByPosition.set(position, specifier);
+    const name = `arg${position}`;
+    variables.push(name);
+    pattern.push({
+      type: "expression",
+      arg: { type: "variable-reference", name },
+      annotation: {
+        type: "function-reference",
+        name: "apple-printf",
+        options: [
+          { name: "specifier", value: { type: "literal", value: specifier } },
+          {
+            name: "position",
+            value: { type: "literal", value: String(position) },
+          },
+        ],
+      },
+    });
+    cursor += found[0].length;
+  }
+  if (text) pattern.push({ type: "text", value: text });
+  return { pattern, variables };
+}
+
+function serializePattern(
+  pattern: Pattern,
+  bundle: Bundle,
+  numericDefault?: {
+    variableName: string | undefined;
+    specifier: string | undefined;
+  },
+) {
+  const formatted = pattern.some((part) => part.type === "expression");
+  return pattern
+    .map((part) => {
+      if (part.type === "text")
+        return formatted ? part.value.replace(/%/g, "%%") : part.value;
+      if (part.type !== "expression" || part.arg.type !== "variable-reference")
+        throw new Error(
+          `Apple .xcstrings only supports plain variable expressions (bundle "${bundle.id}")`,
+        );
+      const fallback = inputPosition(bundle, part.arg.name);
+      const format =
+        !part.annotation &&
+        numericDefault?.variableName === part.arg.name &&
+        numericDefault.specifier
+          ? { position: fallback, specifier: numericDefault.specifier }
+          : printfFormat(part.annotation, fallback);
+      return `%${format.position}$${format.specifier}`;
+    })
+    .join("");
+}
+
+function printfFormat(
+  annotation: Extract<Pattern[number], { type: "expression" }>["annotation"],
+  fallback: number,
+) {
+  if (!annotation) return { position: fallback, specifier: "@" };
+  if (
+    annotation.type !== "function-reference" ||
+    annotation.name !== "apple-printf"
+  )
+    throw new Error(
+      `Apple .xcstrings does not support the ${annotation.type} annotation`,
+    );
+  const option = (name: string) =>
+    annotation.options.find((candidate) => candidate.name === name)?.value;
+  const specifier = option("specifier");
+  const position = option("position");
+  if (
+    specifier?.type !== "literal" ||
+    position?.type !== "literal" ||
+    !/^\d+$/.test(position.value)
+  )
+    throw new Error("Invalid Apple printf annotation");
+  assertPrintfSpecifier(specifier.value, "pattern");
+  return { specifier: specifier.value, position: Number(position.value) };
+}
+
+function literalOption(
+  annotation: Extract<Pattern[number], { type: "expression" }>["annotation"],
+  name: string,
+) {
+  if (annotation?.type !== "function-reference") return undefined;
+  const value = annotation.options.find(
+    (option) => option.name === name,
+  )?.value;
+  return value?.type === "literal" ? value.value : undefined;
+}
+
+function assertUniqueIds(rows: Array<{ id: string }>, kind: string) {
+  const seen = new Set<string>();
+  for (const row of rows) {
+    if (seen.has(row.id))
+      throw new Error(`Duplicate Apple .xcstrings ${kind} id "${row.id}"`);
+    seen.add(row.id);
+  }
+}
+
+function pluralInput(bundle: Bundle, selector: string) {
+  const declaration = bundle.declarations.find(
+    (candidate) => candidate.name === selector,
+  );
+  if (
+    declaration?.type !== "local-variable" ||
+    declaration.value.annotation?.type !== "function-reference" ||
+    declaration.value.annotation.name !== "plural" ||
+    declaration.value.arg.type !== "variable-reference"
+  )
+    return undefined;
+  for (const option of declaration.value.annotation.options) {
+    if (!option.name.startsWith("apple"))
+      throw new Error(
+        `Apple .xcstrings does not support plural option "${option.name}" in "${bundle.id}"`,
+      );
+  }
+  return declaration.value.arg.name;
+}
+
+function pluralSpecifier(bundle: Bundle, selector: string) {
+  const declaration = bundle.declarations.find(
+    (candidate) => candidate.name === selector,
+  );
+  if (declaration?.type !== "local-variable") return undefined;
+  return (
+    literalOption(declaration.value.annotation, "appleFormatSpecifier") ?? "lld"
+  );
+}
+
+function pluralDeclaration(
+  name: string,
+  inputName: string,
+  options: Record<string, string>,
+) {
+  return {
+    type: "local-variable",
+    name,
+    value: {
+      type: "expression",
+      arg: { type: "variable-reference", name: inputName },
+      annotation: {
+        type: "function-reference",
+        name: "plural",
+        options: Object.entries(options).map(([optionName, value]) => ({
+          name: optionName,
+          value: { type: "literal", value },
+        })),
+      },
+    },
+  } as Declaration;
+}
+
+function inputPosition(bundle: Bundle, name: string) {
+  const inputs = bundle.declarations.filter(
+    (declaration) => declaration.type === "input-variable",
+  );
+  const position =
+    inputs.findIndex((declaration) => declaration.name === name) + 1;
+  if (position === 0)
+    throw new Error(`Variable "${name}" is not declared in "${bundle.id}"`);
+  return position;
+}
+
+function mergeDeclarations(bundle: Bundle, declarations: Declaration[]) {
+  const byName = new Map(
+    bundle.declarations.map((declaration) => [declaration.name, declaration]),
+  );
+  for (const declaration of declarations) {
+    const current = byName.get(declaration.name);
+    if (current && JSON.stringify(current) !== JSON.stringify(declaration))
+      throw new Error(
+        `Inconsistent declaration "${declaration.name}" across Apple catalog locales in "${bundle.id}"`,
+      );
+    byName.set(declaration.name, declaration);
+  }
+  return { ...bundle, declarations: [...byName.values()] };
+}
+
+function inputDeclarations(names: string[], excluded: string[] = []) {
+  return [...new Set(names)]
+    .filter((name) => !excluded.includes(name))
+    .sort(
+      (a, b) => argumentPosition(a) - argumentPosition(b) || a.localeCompare(b),
+    )
+    .map((name) => ({ type: "input-variable", name }) as Declaration);
+}
+function argumentPosition(name: string) {
+  const match = /^arg(\d+)$/.exec(name);
+  return match ? Number(match[1]) : Number.MAX_SAFE_INTEGER;
+}
+function translated(value: string): StringUnit {
+  return { state: "translated", value };
+}
+function match(key: string, value: string) {
+  return value === "other"
+    ? { type: "catchall-match" as const, key }
+    : { type: "literal-match" as const, key, value };
+}
+function requiredStringUnit(unit: StringUnit | undefined, id: string) {
+  if (!unit || typeof unit.value !== "string")
+    throw new Error(`Missing stringUnit value in "${id}"`);
+  return unit;
+}
+function assertVariationUnits(
+  units: Record<string, VariationUnit>,
+  id: string,
+  kind: string,
+  allowed: Set<string> | undefined,
+) {
+  assertObject(units, `${kind} variations in "${id}"`);
+  if (Object.keys(units).length === 0 || !units.other)
+    throw new Error(`Apple ${kind} variations in "${id}" require "other"`);
+  for (const [key, unit] of Object.entries(units)) {
+    if (allowed && !allowed.has(key))
+      throw new Error(`Unsupported Apple ${kind} value "${key}" in "${id}"`);
+    requiredStringUnit(unit?.stringUnit, id);
+  }
+}
+function assertPrintfSpecifier(value: string, id: string) {
+  if (
+    !/^[-+# 0,(]*\d*(?:\.\d+)?(?:hh|h|ll|l|q|z|t|j)?[diuoxXfFeEgGaAcCsSp@]$/.test(
+      value,
+    )
+  )
+    throw new Error(`Invalid Apple printf specifier "${value}" in "${id}"`);
+}
+function assertObject(
+  value: unknown,
+  label: string,
+): asserts value is Record<string, any> {
+  if (!value || typeof value !== "object" || Array.isArray(value))
+    throw new Error(`Invalid ${label}`);
+}
+function hasPrintfExpression(source: string, regex: RegExp) {
+  for (let cursor = 0; cursor < source.length; cursor++) {
+    if (source.startsWith("%%", cursor)) {
+      cursor++;
+      continue;
+    }
+    if (source[cursor] === "%" && regex.test(source.slice(cursor))) return true;
+  }
+  return false;
+}

--- a/packages/plugins/apple-xcstrings/src/plugin.ts
+++ b/packages/plugins/apple-xcstrings/src/plugin.ts
@@ -224,7 +224,10 @@ function importLocalization(id: string, localization: Localization) {
       );
     const [prefix, suffix] = template.split(token);
     const parsedPrefix = parsePattern(prefix!);
-    const parsedSuffix = parsePattern(suffix!);
+    const parsedSuffix = parsePattern(
+      suffix!,
+      Math.max(argNum + 1, parsedPrefix.nextImplicit),
+    );
     const parsed = Object.entries(substitution.variations.plural).map(
       ([key, unit]) => ({
         key,
@@ -467,10 +470,13 @@ function inferDirectPluralFormat(
       argumentPosition(expression.arg.name),
     );
   });
-  const first = formats[0]!;
+  const numericFormats = formats.filter((format) =>
+    /(?:hh|h|ll|l|q|z|t|j)?[diuoxXfFeEgGaA]$/.test(format.specifier),
+  );
+  const first = numericFormats[0]!;
   if (
-    !/(?:hh|h|ll|l|q|z|t|j)?[diuoxXfFeEgGaA]$/.test(first.specifier) ||
-    formats.some(
+    !first ||
+    numericFormats.some(
       (format) =>
         format.position !== first.position ||
         format.specifier !== first.specifier,
@@ -506,7 +512,11 @@ function parsePattern(value: string, implicitStart = 1) {
   const regex =
     /^%(?:(\d+)\$([-+# 0,(]*\d*(?:\.\d+)?(?:hh|h|ll|l|q|z|t|j)?[diuoxXfFeEgGaAcCsSp@])|((?:hh|h|ll|l|q|z|t|j)?[diuoxXfFeEgGaAcCsSp@]))/;
   if (!hasPrintfExpression(value, regex))
-    return { pattern: [{ type: "text", value }] as Pattern, variables };
+    return {
+      pattern: [{ type: "text", value }] as Pattern,
+      variables,
+      nextImplicit: implicitStart,
+    };
   let cursor = 0;
   let implicit = implicitStart - 1;
   let sawImplicit = false;
@@ -566,7 +576,7 @@ function parsePattern(value: string, implicitStart = 1) {
     cursor += found[0].length;
   }
   if (text) pattern.push({ type: "text", value: text });
-  return { pattern, variables };
+  return { pattern, variables, nextImplicit: implicit + 1 };
 }
 
 function serializePattern(

--- a/packages/plugins/apple-xcstrings/src/plugin.ts
+++ b/packages/plugins/apple-xcstrings/src/plugin.ts
@@ -460,11 +460,13 @@ function inferDirectPluralFormat(
   const sourceExpressions = sourcePattern.filter(
     (part) => part.type === "expression",
   );
-  const candidates = sourceExpressions.length
+  const variantExpressions = variants.flatMap(({ parsed }) =>
+    parsed.pattern.filter((part) => part.type === "expression"),
+  );
+  const sourceNumeric = numericExpressionFormats(sourceExpressions);
+  const candidates = sourceNumeric.length
     ? sourceExpressions
-    : variants.flatMap(({ parsed }) =>
-        parsed.pattern.filter((part) => part.type === "expression"),
-      );
+    : variantExpressions;
   if (!candidates.length)
     throw new Error(
       `Direct Apple plural "${id}" must contain a numeric printf argument in its key or variants`,
@@ -493,6 +495,19 @@ function inferDirectPluralFormat(
       `Direct Apple plural "${id}" must use one consistent numeric argument`,
     );
   return first;
+}
+
+function numericExpressionFormats(
+  expressions: Array<Extract<Pattern[number], { type: "expression" }>>,
+) {
+  return expressions.filter((expression) => {
+    if (expression.arg.type !== "variable-reference") return false;
+    const format = printfFormat(
+      expression.annotation,
+      argumentPosition(expression.arg.name),
+    );
+    return /(?:hh|h|ll|l|q|z|t|j)?[diuoxXfFeEgGaA]$/.test(format.specifier);
+  });
 }
 
 function parseCatalog(content: Uint8Array): Catalog {

--- a/packages/plugins/apple-xcstrings/src/plugin.ts
+++ b/packages/plugins/apple-xcstrings/src/plugin.ts
@@ -698,11 +698,16 @@ function pluralDeclaration(
 }
 
 function inputPosition(bundle: Bundle, name: string) {
-  const namedPosition = argumentPosition(name);
-  if (namedPosition !== Number.MAX_SAFE_INTEGER) return namedPosition;
   const inputs = bundle.declarations.filter(
     (declaration) => declaration.type === "input-variable",
   );
+  if (!inputs.some((declaration) => declaration.name === name))
+    throw new Error(`Variable "${name}" is not declared in "${bundle.id}"`);
+  const namedMatch = /^arg([1-9]\d*)$/.exec(name);
+  if (namedMatch) {
+    const namedPosition = Number(namedMatch[1]);
+    if (Number.isSafeInteger(namedPosition)) return namedPosition;
+  }
   const position =
     inputs.findIndex((declaration) => declaration.name === name) + 1;
   if (position === 0)

--- a/packages/plugins/apple-xcstrings/src/settings.ts
+++ b/packages/plugins/apple-xcstrings/src/settings.ts
@@ -1,0 +1,9 @@
+import { Type, type Static } from "@sinclair/typebox";
+
+export type PluginSettings = Static<typeof PluginSettings>;
+export const PluginSettings = Type.Object({
+  pathPattern: Type.String({
+    pattern: ".*\\.xcstrings$",
+    examples: ["./Localizations/Localizable.xcstrings"],
+  }),
+});

--- a/packages/plugins/apple-xcstrings/tsconfig.build.json
+++ b/packages/plugins/apple-xcstrings/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"],
+  "compilerOptions": { "rootDir": "src" }
+}

--- a/packages/plugins/apple-xcstrings/tsconfig.json
+++ b/packages/plugins/apple-xcstrings/tsconfig.json
@@ -1,0 +1,1 @@
+{ "extends": "@inlang/tsconfig/default", "include": ["src/**/*"] }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -238,10 +238,10 @@ importers:
         version: 0.15.2
       '@inlang/message':
         specifier: 2.1.0
-        version: 2.1.0(@sinclair/typebox@0.34.40)
+        version: 2.1.0(@sinclair/typebox@0.34.52)
       '@inlang/plugin':
         specifier: 2.0.0
-        version: 2.0.0(@sinclair/typebox@0.34.40)
+        version: 2.0.0(@sinclair/typebox@0.34.52)
       '@inlang/sdk':
         specifier: ^0.9.0
         version: 0.9.0(babel-plugin-macros@3.1.0)
@@ -545,6 +545,28 @@ importers:
       vitest:
         specifier: ^4.0.6
         version: 4.0.16(@types/node@24.10.2)(happy-dom@18.0.1)(jiti@2.6.1)(jsdom@27.3.0(postcss@8.5.6))(lightningcss@1.30.2)(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1)
+
+  packages/plugins/apple-xcstrings:
+    dependencies:
+      '@inlang/sdk':
+        specifier: workspace:*
+        version: link:../../sdk
+      '@sinclair/typebox':
+        specifier: ^0.31.17
+        version: 0.31.28
+    devDependencies:
+      '@inlang/tsconfig':
+        specifier: workspace:*
+        version: link:../../tsconfig
+      esbuild:
+        specifier: ^0.25.9
+        version: 0.25.12
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.2)(@vitest/browser@3.2.4)(happy-dom@18.0.1)(jiti@2.6.1)(jsdom@27.3.0(postcss@8.5.6))(lightningcss@1.30.2)(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1)
 
   packages/plugins/i18next:
     dependencies:
@@ -4036,8 +4058,8 @@ packages:
   '@sinclair/typebox@0.31.28':
     resolution: {integrity: sha512-/s55Jujywdw/Jpan+vsy6JZs1z2ZTGxTmbZTPiuSL2wz9mfzA2gN1zzaqmvfi4pq+uOt7Du85fkiwv5ymW84aQ==}
 
-  '@sinclair/typebox@0.34.40':
-    resolution: {integrity: sha512-gwBNIP8ZAYev/ORDWW0QvxdwPXwxBtLsdsJgSc7eDIRt8ubP+rxUBzPsrwnu16fgEF8Bx4lh/+mvQvJzcTM6Kw==}
+  '@sinclair/typebox@0.34.52':
+    resolution: {integrity: sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==}
 
   '@sindresorhus/is@7.2.0':
     resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
@@ -13383,9 +13405,9 @@ snapshots:
     dependencies:
       '@sinclair/typebox': 0.31.28
 
-  '@inlang/json-types@1.1.0(@sinclair/typebox@0.34.40)':
+  '@inlang/json-types@1.1.0(@sinclair/typebox@0.34.52)':
     dependencies:
-      '@sinclair/typebox': 0.34.40
+      '@sinclair/typebox': 0.34.52
 
   '@inlang/language-tag@1.5.1':
     dependencies:
@@ -13405,10 +13427,10 @@ snapshots:
       '@inlang/language-tag': 1.5.1
       '@sinclair/typebox': 0.31.28
 
-  '@inlang/message@2.1.0(@sinclair/typebox@0.34.40)':
+  '@inlang/message@2.1.0(@sinclair/typebox@0.34.52)':
     dependencies:
       '@inlang/language-tag': 1.5.1
-      '@sinclair/typebox': 0.34.40
+      '@sinclair/typebox': 0.34.52
 
   '@inlang/module@1.2.14(@sinclair/typebox@0.31.28)':
     dependencies:
@@ -13416,15 +13438,15 @@ snapshots:
       '@inlang/plugin': 2.4.14(@sinclair/typebox@0.31.28)
       '@sinclair/typebox': 0.31.28
 
-  '@inlang/plugin@2.0.0(@sinclair/typebox@0.34.40)':
+  '@inlang/plugin@2.0.0(@sinclair/typebox@0.34.52)':
     dependencies:
-      '@inlang/json-types': 1.1.0(@sinclair/typebox@0.34.40)
+      '@inlang/json-types': 1.1.0(@sinclair/typebox@0.34.52)
       '@inlang/language-tag': 1.5.1
-      '@inlang/message': 2.1.0(@sinclair/typebox@0.34.40)
-      '@inlang/project-settings': 2.4.2(@sinclair/typebox@0.34.40)
+      '@inlang/message': 2.1.0(@sinclair/typebox@0.34.52)
+      '@inlang/project-settings': 2.4.2(@sinclair/typebox@0.34.52)
       '@inlang/translatable': 1.3.1
       '@lix-js/fs': 2.2.0
-      '@sinclair/typebox': 0.34.40
+      '@sinclair/typebox': 0.34.52
 
   '@inlang/plugin@2.4.14(@sinclair/typebox@0.31.28)':
     dependencies:
@@ -13442,11 +13464,11 @@ snapshots:
       '@inlang/language-tag': 1.5.1
       '@sinclair/typebox': 0.31.28
 
-  '@inlang/project-settings@2.4.2(@sinclair/typebox@0.34.40)':
+  '@inlang/project-settings@2.4.2(@sinclair/typebox@0.34.52)':
     dependencies:
-      '@inlang/json-types': 1.1.0(@sinclair/typebox@0.34.40)
+      '@inlang/json-types': 1.1.0(@sinclair/typebox@0.34.52)
       '@inlang/language-tag': 1.5.1
-      '@sinclair/typebox': 0.34.40
+      '@sinclair/typebox': 0.34.52
 
   '@inlang/result@1.1.0': {}
 
@@ -13589,7 +13611,7 @@ snapshots:
 
   '@jest/schemas@30.0.5':
     dependencies:
-      '@sinclair/typebox': 0.34.40
+      '@sinclair/typebox': 0.34.52
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -14781,7 +14803,7 @@ snapshots:
 
   '@sinclair/typebox@0.31.28': {}
 
-  '@sinclair/typebox@0.34.40': {}
+  '@sinclair/typebox@0.34.52': {}
 
   '@sindresorhus/is@7.2.0': {}
 


### PR DESCRIPTION
## Summary

- add a first-class `@inlang/plugin-apple-xcstrings` package and Marketplace entry
- import/export Apple String Catalogs using the Inlang v2 message model
- support ordinary strings, typed positional variables, cardinal plurals, and Apple device variations
- preserve exact keys and validate relations, locale settings, supported shapes, and unsafe printf combinations
- verify emitted catalogs with Apple `xcstringstool`

## Stack

- Base: #4399 (Android and Apple `.strings` format plugins)
- Consumer: opral/parrot-figma#70

## Verification

- package tests, TypeScript, browser build/import smoke test, npm pack inspection, and diff checks
- real Xcode catalog compilation fixtures
- reviewed for format correctness, key/model integrity, and plugin architecture

This is intentionally a content adapter: unsupported/source-only shapes and unsupported plural options fail closed instead of silently losing data.