### PR TITLE
feat: upgrade v3 to Lix 0.12 and fold plugin updates

### DIFF
--- a/.changeset/batched-fresh-project-import.md
+++ b/.changeset/batched-fresh-project-import.md
@@ -1,0 +1,5 @@
+---
+"@inlang/sdk": patch
+---
+
+Batch fresh-project imports to reduce SQLite round trips during compilation.

--- a/.changeset/brave-parrots-export.md
+++ b/.changeset/brave-parrots-export.md
@@ -1,0 +1,6 @@
+---
+"@inlang/plugin-android": minor
+"@inlang/plugin-apple-strings": minor
+---
+
+Add first-class Android XML and Apple `.strings` import/export plugins using the Inlang v2 message model. Android supports positional variables and CLDR plurals; Apple `.strings` supports plain messages and positional variables and rejects selectors that the format cannot represent.

--- a/.changeset/bright-apples-catalog.md
+++ b/.changeset/bright-apples-catalog.md
@@ -1,0 +1,5 @@
+---
+"@inlang/plugin-apple-xcstrings": minor
+---
+
+Add a first-class Apple String Catalog plugin for `.xcstrings` files with exact keys, locales, variables, plurals, and device variations.

--- a/.changeset/fast-bundle-import.md
+++ b/.changeset/fast-bundle-import.md
@@ -1,0 +1,5 @@
+---
+"@inlang/plugin-message-format": patch
+---
+
+Speed up importing large message-format projects by indexing bundles by id.

--- a/.changeset/fast-bundle-import.md
+++ b/.changeset/fast-bundle-import.md
@@ -1,5 +1,0 @@
----
-"@inlang/plugin-message-format": patch
----
-
-Speed up importing large message-format projects by indexing bundles by id.

--- a/.changeset/soft-snakes-guard.md
+++ b/.changeset/soft-snakes-guard.md
@@ -1,0 +1,5 @@
+---
+"@inlang/plugin-i18next": patch
+---
+
+Reject selectors that i18next cannot represent instead of silently dropping variants during export.

--- a/.changeset/tidy-plugins-declare.md
+++ b/.changeset/tidy-plugins-declare.md
@@ -1,0 +1,5 @@
+---
+"@inlang/plugin-i18next": patch
+---
+
+Emit the TypeScript declarations advertised by the package during production builds.

--- a/packages/marketplace-registry/registry.json
+++ b/packages/marketplace-registry/registry.json
@@ -15,6 +15,8 @@
 		"698iow33": "https://raw.githubusercontent.com/opral/inlang/refs/heads/main/packages/plugins/t-function-matcher/marketplace-manifest.json",
 		"193hsyds": "https://raw.githubusercontent.com/opral/inlang/refs/heads/main/packages/plugins/next-intl/marketplace-manifest.json",
 		"p7c8m1d2": "https://raw.githubusercontent.com/opral/inlang/refs/heads/main/packages/plugins/icu1/marketplace-manifest.json",
+		"andr0id2": "https://raw.githubusercontent.com/opral/inlang/refs/heads/main/packages/plugins/android/marketplace-manifest.json",
+		"applstr1": "https://raw.githubusercontent.com/opral/inlang/refs/heads/main/packages/plugins/apple-strings/marketplace-manifest.json",
 		"neh2d6w7": "https://cdn.jsdelivr.net/npm/inlang-plugin-xcstrings@latest/marketplace-manifest.json",
 		"3gk8n4n4": "https://raw.githubusercontent.com/opral/inlang/refs/heads/inlang-v1/inlang/source-code/github-lint-action/marketplace-manifest.json",
 		"y0eo8f66": "https://raw.githubusercontent.com/opral/inlang/refs/heads/inlang-v1/inlang/source-code/message-lint-rules/emptyPattern/marketplace-manifest.json",

--- a/packages/marketplace-registry/registry.json
+++ b/packages/marketplace-registry/registry.json
@@ -17,6 +17,7 @@
 		"p7c8m1d2": "https://raw.githubusercontent.com/opral/inlang/refs/heads/main/packages/plugins/icu1/marketplace-manifest.json",
 		"andr0id2": "https://raw.githubusercontent.com/opral/inlang/refs/heads/main/packages/plugins/android/marketplace-manifest.json",
 		"applstr1": "https://raw.githubusercontent.com/opral/inlang/refs/heads/main/packages/plugins/apple-strings/marketplace-manifest.json",
+		"xcstrng1": "https://raw.githubusercontent.com/opral/inlang/refs/heads/main/packages/plugins/apple-xcstrings/marketplace-manifest.json",
 		"neh2d6w7": "https://cdn.jsdelivr.net/npm/inlang-plugin-xcstrings@latest/marketplace-manifest.json",
 		"3gk8n4n4": "https://raw.githubusercontent.com/opral/inlang/refs/heads/inlang-v1/inlang/source-code/github-lint-action/marketplace-manifest.json",
 		"y0eo8f66": "https://raw.githubusercontent.com/opral/inlang/refs/heads/inlang-v1/inlang/source-code/message-lint-rules/emptyPattern/marketplace-manifest.json",

--- a/packages/plugins/android/README.md
+++ b/packages/plugins/android/README.md
@@ -1,0 +1,19 @@
+# Android Resources plugin for Inlang
+
+Reads and writes Android `strings.xml` files through Inlang's v2 message model.
+
+Supported: exact message keys, XML escaping, positional string variables, and CLDR plural quantities (`zero`, `one`, `two`, `few`, `many`, `other`). Unsupported selector shapes and annotated expressions fail explicitly instead of being dropped.
+
+```json
+{
+  "modules": [
+    "https://cdn.jsdelivr.net/npm/@inlang/plugin-android@latest/dist/index.js"
+  ],
+  "plugin.inlang.android": {
+    "pathPattern": "./res/values{locale}/strings.xml"
+  }
+}
+```
+
+`{locale}` expands to an Android resource qualifier: the base locale uses no
+suffix, `de` uses `-de`, and `en-US` uses `-b+en+US`.

--- a/packages/plugins/android/build.js
+++ b/packages/plugins/android/build.js
@@ -17,6 +17,8 @@ if (isProduction) {
   execFileSync(
     "tsc",
     [
+      "-p",
+      "tsconfig.build.json",
       "--emitDeclarationOnly",
       "--declaration",
       "--declarationMap",

--- a/packages/plugins/android/build.js
+++ b/packages/plugins/android/build.js
@@ -1,4 +1,5 @@
 import { context } from "esbuild";
+import { execFileSync } from "node:child_process";
 const isProduction = process.env.NODE_ENV === "production";
 const ctx = await context({
   entryPoints: ["./src/index.ts"],
@@ -13,6 +14,20 @@ const ctx = await context({
 if (isProduction) {
   await ctx.rebuild();
   await ctx.dispose();
+  execFileSync(
+    "tsc",
+    [
+      "--emitDeclarationOnly",
+      "--declaration",
+      "--declarationMap",
+      "false",
+      "--outDir",
+      "dist",
+      "--noEmit",
+      "false",
+    ],
+    { stdio: "inherit" },
+  );
 } else {
   await ctx.watch();
   console.info("Watching for changes...");

--- a/packages/plugins/android/build.js
+++ b/packages/plugins/android/build.js
@@ -1,0 +1,19 @@
+import { context } from "esbuild";
+const isProduction = process.env.NODE_ENV === "production";
+const ctx = await context({
+  entryPoints: ["./src/index.ts"],
+  outdir: "./dist",
+  minify: isProduction,
+  target: "es2022",
+  bundle: true,
+  format: "esm",
+  platform: "browser",
+  sourcemap: false,
+});
+if (isProduction) {
+  await ctx.rebuild();
+  await ctx.dispose();
+} else {
+  await ctx.watch();
+  console.info("Watching for changes...");
+}

--- a/packages/plugins/android/marketplace-manifest.json
+++ b/packages/plugins/android/marketplace-manifest.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://inlang.com/schema/marketplace-manifest",
+  "id": "plugin.inlang.android",
+  "displayName": { "en": "Android Resources" },
+  "description": {
+    "en": "Read and write Android strings.xml resources with variables and CLDR plurals."
+  },
+  "pages": { "/": "./README.md" },
+  "keywords": [
+    "android",
+    "xml",
+    "strings",
+    "resources",
+    "localization",
+    "plugin"
+  ],
+  "publisherName": "inlang",
+  "publisherIcon": "https://inlang.com/favicon/safari-pinned-tab.svg",
+  "license": "Apache-2.0",
+  "module": "https://cdn.jsdelivr.net/npm/@inlang/plugin-android@latest/dist/index.js"
+}

--- a/packages/plugins/android/package.json
+++ b/packages/plugins/android/package.json
@@ -2,6 +2,7 @@
   "name": "@inlang/plugin-android",
   "version": "0.1.0",
   "type": "module",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": "./dist/index.js"
   },

--- a/packages/plugins/android/package.json
+++ b/packages/plugins/android/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@inlang/plugin-android",
+  "version": "0.1.0",
+  "type": "module",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "files": [
+    "./dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/opral/inlang",
+    "directory": "packages/plugins/android"
+  },
+  "scripts": {
+    "dev": "node ./build.js",
+    "build": "NODE_ENV=production node ./build.js",
+    "test": "tsc --noEmit && vitest run",
+    "format": "prettier ./src --write",
+    "clean": "rm -rf ./dist ./node_modules"
+  },
+  "dependencies": {
+    "@inlang/sdk": "workspace:*",
+    "@sinclair/typebox": "^0.31.17",
+    "fast-xml-parser": "^4.5.3"
+  },
+  "devDependencies": {
+    "@inlang/tsconfig": "workspace:*",
+    "esbuild": "^0.25.9",
+    "prettier": "3.3.3",
+    "typescript": "^5.5.2",
+    "vitest": "^4.0.6"
+  }
+}

--- a/packages/plugins/android/src/index.ts
+++ b/packages/plugins/android/src/index.ts
@@ -1,0 +1,3 @@
+import { plugin } from "./plugin.js";
+export default plugin;
+export { plugin };

--- a/packages/plugins/android/src/plugin.test.ts
+++ b/packages/plugins/android/src/plugin.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, test } from "vitest";
+import { loadProjectInMemory, newProject } from "@inlang/sdk";
+import { plugin as icuPlugin } from "../../icu1/src/plugin.js";
+import { plugin, PLUGIN_KEY } from "./plugin.js";
+
+const settings = {
+  baseLocale: "en",
+  locales: ["en"],
+  modules: [],
+  [PLUGIN_KEY]: { pathPattern: "./res/values{locale}/strings.xml" },
+  "plugin.inlang.icu-messageformat-1": {
+    pathPattern: "./messages/{locale}.json",
+  },
+};
+
+describe("Android resources plugin", () => {
+  test("round-trips exact keys, escaping, variables, and plurals", async () => {
+    const source = `<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="ManageSale.PricePlaceholder">Hello %1$s &amp; welcome</string>
+  <plurals name="cart_items">
+    <item quantity="one">%1$d item</item>
+    <item quantity="other">%1$d items</item>
+  </plurals>
+</resources>`;
+    const imported = await plugin.importFiles!({
+      settings,
+      files: [{ locale: "en", content: new TextEncoder().encode(source) }],
+    });
+    expect(imported.bundles.map((bundle) => bundle.id)).toEqual([
+      "ManageSale.PricePlaceholder",
+      "cart_items",
+    ]);
+    const withIds = {
+      bundles: imported.bundles as any,
+      messages: imported.messages.map((message, index) => ({
+        ...message,
+        id: `message-${index}`,
+      })) as any,
+      variants: imported.variants.map((variant, index) => ({
+        ...variant,
+        id: `variant-${index}`,
+        messageId: `message-${imported.messages.findIndex(
+          (message) =>
+            message.bundleId === variant.messageBundleId &&
+            message.locale === variant.messageLocale,
+        )}`,
+      })) as any,
+    };
+    const [file] = await plugin.exportFiles!({ ...withIds, settings });
+    const output = new TextDecoder().decode(file!.content);
+    expect(output).toContain('name="ManageSale.PricePlaceholder"');
+    expect(output).toContain("Hello %1$s &amp; welcome");
+    expect(output).toContain('<plurals name="cart_items">');
+    expect(output).toContain('quantity="one"');
+    expect(output).toContain("%1$d item");
+    const roundtrip = await plugin.importFiles!({ settings, files: [file!] });
+    expect(roundtrip.bundles.map((bundle) => bundle.id)).toEqual(
+      imported.bundles.map((bundle) => bundle.id),
+    );
+  });
+
+  test("preserves printf types, positions, repetition, literals, and Android escaping", async () => {
+    const source = `<resources>
+  <string name="types">"id=%2$d price=%1$.2f name=%3$s again=%2$d 100%% \\n @home ?query"</string>
+</resources>`;
+    const imported = await plugin.importFiles!({
+      settings,
+      files: [{ locale: "en", content: new TextEncoder().encode(source) }],
+    });
+    expect(imported.variants[0]!.pattern).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "expression",
+          annotation: expect.objectContaining({ name: "android-printf" }),
+        }),
+        expect.objectContaining({
+          type: "text",
+          value: expect.stringContaining("100%"),
+        }),
+      ]),
+    );
+    const withIds = identify(imported);
+    const [file] = await plugin.exportFiles!({ ...withIds, settings });
+    const output = new TextDecoder().decode(file!.content);
+    expect(output).toContain("%2$d");
+    expect(output).toContain("%1$.2f");
+    expect(output).toContain("%3$s");
+    expect(output).toContain("100%%");
+  });
+
+  test("round-trips standalone escaped percent literals", async () => {
+    const imported = await plugin.importFiles!({
+      settings,
+      files: [
+        {
+          locale: "en",
+          content: new TextEncoder().encode(
+            '<resources><string name="literal">%%s %%d %%f %%</string></resources>',
+          ),
+        },
+      ],
+    });
+    expect(imported.variants[0]!.pattern).toEqual([
+      { type: "text", value: "%%s %%d %%f %%" },
+    ]);
+    const [file] = await plugin.exportFiles!({
+      ...identify(imported),
+      settings,
+    });
+    expect(new TextDecoder().decode(file!.content)).toContain("%%s %%d %%f %%");
+  });
+
+  test.each(["Save 20%", "100% complete", "100%%"])(
+    "preserves plain percent text exactly: %s",
+    async (value) => {
+      const imported = await plugin.importFiles!({
+        settings,
+        files: [
+          {
+            locale: "en",
+            content: new TextEncoder().encode(
+              `<resources><string name="plain_percent">${value}</string></resources>`,
+            ),
+          },
+        ],
+      });
+      expect(imported.variants[0]!.pattern).toEqual([{ type: "text", value }]);
+      const [file] = await plugin.exportFiles!({
+        ...identify(imported),
+        settings,
+      });
+      expect(new TextDecoder().decode(file!.content)).toContain(`"${value}"`);
+    },
+  );
+
+  test("exports canonical ICU1 plurals through the SDK and preserves exact keys", async () => {
+    const project = await loadProjectInMemory({
+      blob: await newProject({ settings }),
+      providePlugins: [icuPlugin as any, plugin as any],
+    });
+    try {
+      await project.importFiles({
+        pluginKey: icuPlugin.key,
+        files: [
+          {
+            locale: "en",
+            content: new TextEncoder().encode(
+              JSON.stringify({
+                cart_items_exact:
+                  "{count, plural, one {{count} item} other {{count} items}}",
+              }),
+            ),
+          },
+        ],
+      });
+      const [file] = await project.exportFiles({ pluginKey: plugin.key });
+      const output = new TextDecoder().decode(file!.content);
+      expect(output).toContain('name="cart_items_exact"');
+      expect(output).toContain('quantity="other"');
+    } finally {
+      await project.close();
+    }
+  });
+
+  test("imports annotated printf expressions through the SDK lifecycle", async () => {
+    const project = await loadProjectInMemory({
+      blob: await newProject({ settings }),
+      providePlugins: [plugin as any],
+    });
+    try {
+      const files = [
+        {
+          locale: "en",
+          content: new TextEncoder().encode(
+            '<resources><string name="typed_value">%2$d / %1$.2f / %3$s</string></resources>',
+          ),
+        },
+      ];
+      await project.importFiles({ pluginKey: plugin.key, files });
+      await project.importFiles({ pluginKey: plugin.key, files });
+      const [file] = await project.exportFiles({ pluginKey: plugin.key });
+      expect(new TextDecoder().decode(file!.content)).toContain(
+        "%2$d / %1$.2f / %3$s",
+      );
+      expect(
+        await project.db.selectFrom("message").selectAll().execute(),
+      ).toHaveLength(1);
+    } finally {
+      await project.close();
+    }
+  });
+
+  test("rejects malformed, unnamed, duplicate, and mixed-content XML", async () => {
+    for (const source of [
+      '<resources><string name="broken">oops</resources>',
+      "<resources><string>missing</string></resources>",
+      '<resources><string name="same">a</string><string name="same">b</string></resources>',
+      '<resources><string name="rich">before <b>bold</b> after</string></resources>',
+      '<resources><plurals name="dup"><item quantity="other">a</item><item quantity="other">b</item></plurals></resources>',
+      '<resources><plurals name="missing"><item quantity="one">a</item></plurals></resources>',
+    ]) {
+      expect(() =>
+        plugin.importFiles!({
+          settings,
+          files: [{ locale: "en", content: new TextEncoder().encode(source) }],
+        }),
+      ).toThrow();
+    }
+  });
+
+  test("rejects selectors that Android resources cannot represent", async () => {
+    expect(() =>
+      plugin.exportFiles!({
+        settings,
+        bundles: [{ id: "greeting", declarations: [] }],
+        messages: [
+          {
+            id: "message",
+            bundleId: "greeting",
+            locale: "en",
+            selectors: [{ type: "variable-reference", name: "gender" }],
+          },
+        ],
+        variants: [],
+      }),
+    ).toThrow("require one selector backed by a cardinal plural declaration");
+  });
+
+  test.each(["cart/items", "has space", "1leading", ".leading", "-leading"])(
+    "rejects an unrepresentable key without rewriting it: %s",
+    (id) => {
+      expect(() =>
+        plugin.exportFiles!({
+          settings,
+          bundles: [{ id, declarations: [] }],
+          messages: [
+            { id: "message", bundleId: id, locale: "en", selectors: [] },
+          ],
+          variants: [
+            {
+              id: "variant",
+              messageId: "message",
+              matches: [],
+              pattern: [{ type: "text", value: "value" }],
+            },
+          ],
+        }),
+      ).toThrow("cannot preserve resource key");
+    },
+  );
+});
+
+function identify(
+  imported: Awaited<ReturnType<NonNullable<typeof plugin.importFiles>>>,
+) {
+  const messages = imported.messages.map((message, index) => ({
+    ...message,
+    id: `message-${index}`,
+  }));
+  return {
+    bundles: imported.bundles as any,
+    messages: messages as any,
+    variants: imported.variants.map((variant, index) => ({
+      ...variant,
+      id: `variant-${index}`,
+      messageId: messages.find(
+        (message) =>
+          message.bundleId === variant.messageBundleId &&
+          message.locale === variant.messageLocale,
+      )!.id,
+    })) as any,
+  };
+}

--- a/packages/plugins/android/src/plugin.ts
+++ b/packages/plugins/android/src/plugin.ts
@@ -1,0 +1,479 @@
+import { XMLParser, XMLValidator } from "fast-xml-parser";
+import type {
+  Bundle,
+  InlangPlugin,
+  Message,
+  MessageImport,
+  Pattern,
+  Variant,
+  VariantImport,
+} from "@inlang/sdk";
+import { PluginSettings } from "./settings.js";
+
+export const PLUGIN_KEY = "plugin.inlang.android";
+type Config = { [PLUGIN_KEY]: PluginSettings };
+type ImportArgs = Parameters<
+  NonNullable<InlangPlugin<Config>["importFiles"]>
+>[0];
+type ExportArgs = Parameters<
+  NonNullable<InlangPlugin<Config>["exportFiles"]>
+>[0];
+const quantities = new Set(["zero", "one", "two", "few", "many", "other"]);
+
+export const plugin: InlangPlugin<Config> = {
+  key: PLUGIN_KEY,
+  settingsSchema: PluginSettings,
+  toBeImportedFiles: ({ settings }) =>
+    settings.locales.map((locale) => ({
+      locale,
+      path: androidPath(
+        settings[PLUGIN_KEY].pathPattern,
+        locale,
+        settings.baseLocale,
+      ),
+    })),
+  importFiles: ({ files }: ImportArgs) => importAndroidFiles(files),
+  exportFiles: (args: ExportArgs) => exportAndroidFiles(args),
+};
+
+function importAndroidFiles(
+  files: ImportArgs["files"],
+): ReturnType<NonNullable<InlangPlugin<Config>["importFiles"]>> {
+  const bundles = new Map<string, Bundle>();
+  const seen = new Set<string>();
+  const messages: MessageImport[] = [];
+  const variants: VariantImport[] = [];
+  const parser = new XMLParser({
+    ignoreAttributes: false,
+    attributeNamePrefix: "",
+    trimValues: false,
+    parseTagValue: false,
+    parseAttributeValue: false,
+  });
+  for (const file of files) {
+    const source = decode(file.content);
+    const validation = XMLValidator.validate(source);
+    if (validation !== true)
+      throw new Error(`Invalid Android resources XML: ${validation.err.msg}`);
+    const resources = parser.parse(source)?.resources;
+    if (!resources || typeof resources !== "object")
+      throw new Error("Android resources XML must contain a <resources> root");
+    for (const item of array(resources.string)) {
+      if (!item || typeof item !== "object" || !("name" in item))
+        throw new Error("Every Android <string> must have a name attribute");
+      const id = String(item.name);
+      assertUnique(seen, file.locale, id);
+      const parsed = parseAndroidPattern(textValue(item));
+      bundles.set(
+        id,
+        mergeBundle(bundles.get(id), id, parsed.variables, false),
+      );
+      messages.push({ bundleId: id, locale: file.locale, selectors: [] });
+      variants.push({
+        messageBundleId: id,
+        messageLocale: file.locale,
+        matches: [],
+        pattern: parsed.pattern,
+      });
+    }
+    for (const plural of array(resources.plurals)) {
+      if (!plural || typeof plural !== "object" || !("name" in plural))
+        throw new Error("Every Android <plurals> must have a name attribute");
+      const id = String(plural.name);
+      assertUnique(seen, file.locale, id);
+      const parsedItems = array(plural.item).map((item) => {
+        const quantity = String(item.quantity);
+        if (!quantities.has(quantity))
+          throw new Error(`Unsupported Android plural quantity "${quantity}"`);
+        return { quantity, parsed: parseAndroidPattern(textValue(item)) };
+      });
+      const pluralQuantities = parsedItems.map((item) => item.quantity);
+      if (new Set(pluralQuantities).size !== pluralQuantities.length)
+        throw new Error(`Android plural "${id}" has duplicate quantities`);
+      if (!pluralQuantities.includes("other"))
+        throw new Error(`Android plural "${id}" must define quantity "other"`);
+      bundles.set(
+        id,
+        mergeBundle(
+          bundles.get(id),
+          id,
+          ["count", ...parsedItems.flatMap(({ parsed }) => parsed.variables)],
+          true,
+        ),
+      );
+      messages.push({
+        bundleId: id,
+        locale: file.locale,
+        selectors: [{ type: "variable-reference", name: "countPlural" }],
+      });
+      for (const { quantity, parsed } of parsedItems) {
+        variants.push({
+          messageBundleId: id,
+          messageLocale: file.locale,
+          matches: [
+            quantity === "other"
+              ? { type: "catchall-match", key: "countPlural" }
+              : { type: "literal-match", key: "countPlural", value: quantity },
+          ],
+          pattern: parsed.pattern,
+        });
+      }
+    }
+  }
+  return { bundles: [...bundles.values()], messages, variants };
+}
+
+function exportAndroidFiles({
+  bundles,
+  messages,
+  variants,
+  settings,
+}: ExportArgs) {
+  const files = new Map<string, string[]>();
+  for (const message of messages) {
+    const bundle = requiredBundle(bundles, message);
+    assertAndroidResourceName(bundle.id);
+    const messageVariants = variants.filter(
+      (variant) => variant.messageId === message.id,
+    );
+    const lines = files.get(message.locale) ?? [];
+    if (message.selectors.length === 0) {
+      if (
+        messageVariants.length !== 1 ||
+        messageVariants[0]!.matches.length !== 0
+      )
+        throw new Error(
+          `Android string "${bundle.id}" must have exactly one unconditional variant`,
+        );
+      lines.push(
+        `  <string name="${escapeXmlAttribute(bundle.id)}">${serializePattern(messageVariants[0]!.pattern, bundle)}</string>`,
+      );
+    } else {
+      const selector = message.selectors[0];
+      const plural =
+        selector && message.selectors.length === 1
+          ? pluralDeclaration(bundle, selector.name)
+          : undefined;
+      if (!selector || !plural)
+        throw new Error(
+          `Android plurals require one selector backed by a cardinal plural declaration (bundle "${bundle.id}")`,
+        );
+      const items = messageVariants.map((variant) => {
+        const match = variant.matches[0];
+        if (
+          variant.matches.length !== 1 ||
+          !match ||
+          match.key !== selector.name ||
+          (match.type !== "catchall-match" &&
+            (match.type !== "literal-match" ||
+              match.value === "other" ||
+              !quantities.has(match.value)))
+        )
+          throw new Error(
+            `Android plural "${bundle.id}" has an unsupported match`,
+          );
+        const quantity =
+          match.type === "catchall-match" ? "other" : match.value;
+        return `    <item quantity="${quantity}">${serializePattern(variant.pattern, bundle)}</item>`;
+      });
+      const exportedQuantities = items.map(
+        (item) => item.match(/quantity="([^"]+)"/)?.[1],
+      );
+      if (
+        new Set(exportedQuantities).size !== exportedQuantities.length ||
+        exportedQuantities.filter((quantity) => quantity === "other").length !==
+          1
+      )
+        throw new Error(
+          `Android plural "${bundle.id}" must export unique quantities and exactly one other`,
+        );
+      lines.push(
+        `  <plurals name="${escapeXmlAttribute(bundle.id)}">\n${items.join("\n")}\n  </plurals>`,
+      );
+    }
+    files.set(message.locale, lines);
+  }
+  return [...files].map(([locale, lines]) => ({
+    locale,
+    name: settings[PLUGIN_KEY]?.pathPattern
+      ? androidPath(
+          settings[PLUGIN_KEY].pathPattern,
+          locale,
+          settings.baseLocale,
+        )
+      : `res/values${androidLocaleSuffix(locale, settings.baseLocale)}/strings.xml`,
+    content: encode(
+      `<?xml version="1.0" encoding="utf-8"?>\n<resources>\n${lines.sort().join("\n")}\n</resources>\n`,
+    ),
+  }));
+}
+
+function mergeBundle(
+  current: Bundle | undefined,
+  id: string,
+  variables: string[],
+  plural: boolean,
+): Bundle {
+  const declarations: Bundle["declarations"] = current
+    ? [...current.declarations]
+    : [];
+  for (const name of [...new Set(variables)])
+    if (!declarations.some((declaration) => declaration.name === name))
+      declarations.push({ type: "input-variable", name });
+  if (
+    plural &&
+    !declarations.some((declaration) => declaration.name === "countPlural")
+  )
+    declarations.push({
+      type: "local-variable",
+      name: "countPlural",
+      value: {
+        type: "expression",
+        arg: { type: "variable-reference", name: "count" },
+        annotation: { type: "function-reference", name: "plural", options: [] },
+      },
+    });
+  return { id, declarations };
+}
+
+function parseAndroidPattern(value: string) {
+  const pattern: Pattern = [];
+  const variables: string[] = [];
+  const source = unquoteAndroid(value);
+  const regex = /^%(?:(\d+)\$([-+# 0,(]*\d*(?:\.\d+)?[sdf])|([sdf]))/;
+  if (!hasPrintfExpression(source, regex)) {
+    if (/%\d+\$/.test(source))
+      throw new Error(`Unsupported Android positional format in "${source}"`);
+    return {
+      pattern: [{ type: "text", value: unescapeAndroid(source) }] as Pattern,
+      variables,
+    };
+  }
+  let cursor = 0;
+  let implicit = 0;
+  let text = "";
+  while (cursor < source.length) {
+    if (source.startsWith("%%", cursor)) {
+      text += "%";
+      cursor += 2;
+      continue;
+    }
+    const match = source.slice(cursor).match(regex);
+    if (!match) {
+      if (source[cursor] === "%")
+        throw new Error(
+          `Unsupported Android format specifier near "${source.slice(cursor, cursor + 12)}"`,
+        );
+      text += source[cursor++];
+      continue;
+    }
+    if (text) {
+      pattern.push({ type: "text", value: unescapeAndroid(text) });
+      text = "";
+    }
+    const position = match[1] ? Number(match[1]) : ++implicit;
+    const specifier = match[2] ?? match[3]!;
+    const conversion = specifier.at(-1)!;
+    const name =
+      conversion === "d" && position === 1 ? "count" : `arg${position}`;
+    variables.push(name);
+    pattern.push({
+      type: "expression",
+      arg: { type: "variable-reference", name },
+      annotation: {
+        type: "function-reference",
+        name: "android-printf",
+        options: [
+          { name: "specifier", value: { type: "literal", value: specifier } },
+          {
+            name: "position",
+            value: { type: "literal", value: String(position) },
+          },
+        ],
+      },
+    });
+    cursor += match[0].length;
+  }
+  if (text) pattern.push({ type: "text", value: unescapeAndroid(text) });
+  if (pattern.length === 0) pattern.push({ type: "text", value: "" });
+  return { pattern, variables };
+}
+
+function serializePattern(pattern: Pattern, bundle: Bundle) {
+  const inputs = bundle.declarations.filter(
+    (declaration) => declaration.type === "input-variable",
+  );
+  const formatted = pattern.some((part) => part.type === "expression");
+  const content = pattern
+    .map((part) => {
+      if (part.type === "text")
+        return escapeXmlText(escapeAndroid(part.value, formatted));
+      if (part.type !== "expression" || part.arg.type !== "variable-reference")
+        throw new Error(
+          `Android export only supports plain variable expressions (bundle "${bundle.id}")`,
+        );
+      const variableName = part.arg.name;
+      const position =
+        inputs.findIndex((declaration) => declaration.name === variableName) +
+        1;
+      if (position === 0)
+        throw new Error(
+          `Variable "${variableName}" is not declared in "${bundle.id}"`,
+        );
+      const format = printfFormat(part.annotation, position, variableName);
+      return `%${format.position}$${format.specifier}`;
+    })
+    .join("");
+  return `"${content}"`;
+}
+
+function printfFormat(
+  annotation: Extract<Pattern[number], { type: "expression" }>["annotation"],
+  fallbackPosition: number,
+  variableName: string,
+) {
+  if (!annotation)
+    return {
+      position: fallbackPosition,
+      specifier: variableName === "count" ? "d" : "s",
+    };
+  if (
+    annotation.type !== "function-reference" ||
+    annotation.name !== "android-printf"
+  )
+    throw new Error(
+      `Android export does not support the ${annotation.type} annotation`,
+    );
+  const option = (name: string) =>
+    annotation.options.find((candidate) => candidate.name === name)?.value;
+  const specifier = option("specifier");
+  const position = option("position");
+  if (
+    specifier?.type !== "literal" ||
+    !/^[-+# 0,(]*\d*(?:\.\d+)?[sdf]$/.test(specifier.value) ||
+    position?.type !== "literal" ||
+    !/^\d+$/.test(position.value)
+  )
+    throw new Error("Invalid Android printf annotation");
+  return { specifier: specifier.value, position: Number(position.value) };
+}
+
+function requiredBundle(bundles: Bundle[], message: Message) {
+  const bundle = bundles.find((candidate) => candidate.id === message.bundleId);
+  if (!bundle) throw new Error(`Missing bundle "${message.bundleId}"`);
+  return bundle;
+}
+function pluralDeclaration(bundle: Bundle, selector: string) {
+  return bundle.declarations.find(
+    (declaration) =>
+      declaration.type === "local-variable" &&
+      declaration.name === selector &&
+      declaration.value.annotation?.type === "function-reference" &&
+      declaration.value.annotation.name === "plural" &&
+      !declaration.value.annotation.options.some(
+        (option) =>
+          option.name === "type" &&
+          option.value.type === "literal" &&
+          option.value.value === "ordinal",
+      ),
+  );
+}
+function array<T>(value: T | T[] | undefined): T[] {
+  return value === undefined ? [] : Array.isArray(value) ? value : [value];
+}
+function textValue(value: unknown): string {
+  if (typeof value !== "object" || value === null) return String(value ?? "");
+  const nested = Object.keys(value).filter(
+    (key) => key !== "#text" && key !== "name" && key !== "quantity",
+  );
+  if (nested.length)
+    throw new Error(
+      `Android inline XML markup is not supported (${nested.join(", ")})`,
+    );
+  return "#text" in value ? String((value as any)["#text"]) : "";
+}
+function escapeXmlText(value: string) {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+function escapeXmlAttribute(value: string) {
+  return escapeXmlText(value).replace(/"/g, "&quot;");
+}
+function unescapeAndroid(value: string) {
+  return value.replace(
+    /\\([\\"'ntr@?])/g,
+    (_, escaped: string) =>
+      ({
+        "\\": "\\",
+        '"': '"',
+        "'": "'",
+        n: "\n",
+        t: "\t",
+        r: "\r",
+        "@": "@",
+        "?": "?",
+      })[escaped]!,
+  );
+}
+function unquoteAndroid(value: string) {
+  return value.length >= 2 && value.startsWith('"') && value.endsWith('"')
+    ? value.slice(1, -1)
+    : value;
+}
+function escapeAndroid(value: string, formatted: boolean) {
+  const escaped = value
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/'/g, "\\'")
+    .replace(/\n/g, "\\n")
+    .replace(/\r/g, "\\r")
+    .replace(/\t/g, "\\t");
+  return formatted ? escaped.replace(/%/g, "%%") : escaped;
+}
+function encode(value: string) {
+  return new TextEncoder().encode(value);
+}
+function decode(value: Uint8Array) {
+  return new TextDecoder().decode(value);
+}
+
+function androidLocaleSuffix(locale: string, baseLocale: string) {
+  if (locale === baseLocale) return "";
+  const [language, ...parts] = locale.split("-");
+  if (!language) throw new Error(`Invalid locale "${locale}"`);
+  if (parts.length === 0) return `-${language}`;
+  return `-b+${[language, ...parts].join("+")}`;
+}
+
+function androidPath(pattern: string, locale: string, baseLocale: string) {
+  return pattern.replace("{locale}", androidLocaleSuffix(locale, baseLocale));
+}
+
+function assertUnique(seen: Set<string>, locale: string, id: string) {
+  const key = `${locale}\0${id}`;
+  if (seen.has(key))
+    throw new Error(
+      `Duplicate Android resource "${id}" for locale "${locale}"`,
+    );
+  seen.add(key);
+}
+
+function assertAndroidResourceName(id: string) {
+  if (!/^[\p{L}_][\p{L}\p{N}._-]*$/u.test(id))
+    throw new Error(
+      `Android cannot preserve resource key "${id}"; AAPT names may contain letters, numbers, dot, underscore, and hyphen`,
+    );
+}
+
+function hasPrintfExpression(source: string, regex: RegExp) {
+  for (let cursor = 0; cursor < source.length; cursor++) {
+    if (source.startsWith("%%", cursor)) {
+      cursor++;
+      continue;
+    }
+    if (source[cursor] === "%" && regex.test(source.slice(cursor))) return true;
+  }
+  return false;
+}

--- a/packages/plugins/android/src/settings.ts
+++ b/packages/plugins/android/src/settings.ts
@@ -1,0 +1,9 @@
+import { Type, type Static } from "@sinclair/typebox";
+
+export type PluginSettings = Static<typeof PluginSettings>;
+export const PluginSettings = Type.Object({
+  pathPattern: Type.String({
+    pattern: ".*\\{locale\\}.*\\.xml$",
+    examples: ["./res/values{locale}/strings.xml"],
+  }),
+});

--- a/packages/plugins/android/tsconfig.build.json
+++ b/packages/plugins/android/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"],
+  "compilerOptions": {
+    "rootDir": "src"
+  }
+}

--- a/packages/plugins/android/tsconfig.json
+++ b/packages/plugins/android/tsconfig.json
@@ -1,0 +1,1 @@
+{ "extends": "@inlang/tsconfig/default", "include": ["src/**/*"] }

--- a/packages/plugins/apple-strings/README.md
+++ b/packages/plugins/apple-strings/README.md
@@ -1,0 +1,16 @@
+# Apple Strings plugin for Inlang
+
+Reads and writes Apple `.strings` files through Inlang's v2 message model.
+
+Supported: exact message keys, quoted-string escaping, Unicode, and positional variables. Apple `.strings` has no plural construct, so selector/plural messages fail explicitly. Use a future `.xcstrings` or `.stringsdict` plugin for Apple plurals.
+
+```json
+{
+  "modules": [
+    "https://cdn.jsdelivr.net/npm/@inlang/plugin-apple-strings@latest/dist/index.js"
+  ],
+  "plugin.inlang.apple-strings": {
+    "pathPattern": "./Localizations/{locale}.lproj/Localizable.strings"
+  }
+}
+```

--- a/packages/plugins/apple-strings/build.js
+++ b/packages/plugins/apple-strings/build.js
@@ -17,6 +17,8 @@ if (isProduction) {
   execFileSync(
     "tsc",
     [
+      "-p",
+      "tsconfig.build.json",
       "--emitDeclarationOnly",
       "--declaration",
       "--declarationMap",

--- a/packages/plugins/apple-strings/build.js
+++ b/packages/plugins/apple-strings/build.js
@@ -1,4 +1,5 @@
 import { context } from "esbuild";
+import { execFileSync } from "node:child_process";
 const isProduction = process.env.NODE_ENV === "production";
 const ctx = await context({
   entryPoints: ["./src/index.ts"],
@@ -13,6 +14,20 @@ const ctx = await context({
 if (isProduction) {
   await ctx.rebuild();
   await ctx.dispose();
+  execFileSync(
+    "tsc",
+    [
+      "--emitDeclarationOnly",
+      "--declaration",
+      "--declarationMap",
+      "false",
+      "--outDir",
+      "dist",
+      "--noEmit",
+      "false",
+    ],
+    { stdio: "inherit" },
+  );
 } else {
   await ctx.watch();
   console.info("Watching for changes...");

--- a/packages/plugins/apple-strings/build.js
+++ b/packages/plugins/apple-strings/build.js
@@ -1,0 +1,19 @@
+import { context } from "esbuild";
+const isProduction = process.env.NODE_ENV === "production";
+const ctx = await context({
+  entryPoints: ["./src/index.ts"],
+  outdir: "./dist",
+  minify: isProduction,
+  target: "es2022",
+  bundle: true,
+  format: "esm",
+  platform: "browser",
+  sourcemap: false,
+});
+if (isProduction) {
+  await ctx.rebuild();
+  await ctx.dispose();
+} else {
+  await ctx.watch();
+  console.info("Watching for changes...");
+}

--- a/packages/plugins/apple-strings/marketplace-manifest.json
+++ b/packages/plugins/apple-strings/marketplace-manifest.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://inlang.com/schema/marketplace-manifest",
+  "id": "plugin.inlang.apple-strings",
+  "displayName": { "en": "Apple Strings" },
+  "description": {
+    "en": "Read and write Apple .strings localization files with positional variables."
+  },
+  "pages": { "/": "./README.md" },
+  "keywords": ["apple", "ios", "macos", "strings", "localization", "plugin"],
+  "publisherName": "inlang",
+  "publisherIcon": "https://inlang.com/favicon/safari-pinned-tab.svg",
+  "license": "Apache-2.0",
+  "module": "https://cdn.jsdelivr.net/npm/@inlang/plugin-apple-strings@latest/dist/index.js"
+}

--- a/packages/plugins/apple-strings/package.json
+++ b/packages/plugins/apple-strings/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@inlang/plugin-apple-strings",
+  "version": "0.1.0",
+  "type": "module",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "files": [
+    "./dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/opral/inlang",
+    "directory": "packages/plugins/apple-strings"
+  },
+  "scripts": {
+    "dev": "node ./build.js",
+    "build": "NODE_ENV=production node ./build.js",
+    "test": "tsc --noEmit && vitest run",
+    "format": "prettier ./src --write",
+    "clean": "rm -rf ./dist ./node_modules"
+  },
+  "dependencies": {
+    "@inlang/sdk": "workspace:*",
+    "@sinclair/typebox": "^0.31.17"
+  },
+  "devDependencies": {
+    "@inlang/tsconfig": "workspace:*",
+    "esbuild": "^0.25.9",
+    "prettier": "3.3.3",
+    "typescript": "^5.5.2",
+    "vitest": "^4.0.6"
+  }
+}

--- a/packages/plugins/apple-strings/package.json
+++ b/packages/plugins/apple-strings/package.json
@@ -2,6 +2,7 @@
   "name": "@inlang/plugin-apple-strings",
   "version": "0.1.0",
   "type": "module",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": "./dist/index.js"
   },

--- a/packages/plugins/apple-strings/src/index.ts
+++ b/packages/plugins/apple-strings/src/index.ts
@@ -1,0 +1,3 @@
+import { plugin } from "./plugin.js";
+export default plugin;
+export { plugin };

--- a/packages/plugins/apple-strings/src/plugin.test.ts
+++ b/packages/plugins/apple-strings/src/plugin.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, test } from "vitest";
+import { loadProjectInMemory, newProject } from "@inlang/sdk";
+import { plugin, PLUGIN_KEY } from "./plugin.js";
+
+const settings = {
+  baseLocale: "en",
+  locales: ["en"],
+  modules: [],
+  [PLUGIN_KEY]: {
+    pathPattern: "./Localizations/{locale}.lproj/Localizable.strings",
+  },
+};
+
+describe("Apple strings plugin", () => {
+  test("round-trips exact keys, escapes, Unicode, and positional variables", async () => {
+    const source = `/* Translator note */
+"ManageSale.PricePlaceholder" = "Hello \\"world\\" %1$@";
+"member.你好" = "你好";
+`;
+    const imported = await plugin.importFiles!({
+      settings,
+      files: [{ locale: "en", content: new TextEncoder().encode(source) }],
+    });
+    expect(imported.bundles.map((bundle) => bundle.id)).toEqual([
+      "ManageSale.PricePlaceholder",
+      "member.你好",
+    ]);
+    const messages = imported.messages.map((message, index) => ({
+      ...message,
+      id: `message-${index}`,
+    }));
+    const variants = imported.variants.map((variant, index) => ({
+      ...variant,
+      id: `variant-${index}`,
+      messageId: `message-${imported.messages.findIndex(
+        (message) =>
+          message.bundleId === variant.messageBundleId &&
+          message.locale === variant.messageLocale,
+      )}`,
+    }));
+    const [file] = await plugin.exportFiles!({
+      settings,
+      bundles: imported.bundles as any,
+      messages: messages as any,
+      variants: variants as any,
+    });
+    const output = new TextDecoder().decode(file!.content);
+    expect(output).toContain(
+      '"ManageSale.PricePlaceholder" = "Hello \\"world\\" %1$@";',
+    );
+    expect(output).toContain('"member.你好" = "你好";');
+    const roundtrip = await plugin.importFiles!({ settings, files: [file!] });
+    expect(roundtrip.bundles.map((bundle) => bundle.id)).toEqual(
+      imported.bundles.map((bundle) => bundle.id),
+    );
+  });
+
+  test("preserves format types, positions, repetitions, literal percent, and comment-looking text", async () => {
+    const source = `/* real comment */
+"types/key" = "go // home /* literal */ %2$lld %1$.2f %3$@ %2$lld 100%%";
+"unicode" = "\\U4F60\\U597D";
+`;
+    const imported = await plugin.importFiles!({
+      settings,
+      files: [{ locale: "en", content: new TextEncoder().encode(source) }],
+    });
+    expect(imported.bundles.map((bundle) => bundle.id)).toEqual([
+      "types/key",
+      "unicode",
+    ]);
+    expect(imported.variants[0]!.pattern).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "text",
+          value: expect.stringContaining("go // home /* literal */"),
+        }),
+        expect.objectContaining({
+          type: "expression",
+          annotation: expect.objectContaining({ name: "apple-printf" }),
+        }),
+        expect.objectContaining({
+          type: "text",
+          value: expect.stringContaining("100%"),
+        }),
+      ]),
+    );
+    expect(imported.variants[1]!.pattern).toEqual([
+      { type: "text", value: "你好" },
+    ]);
+    const messages = imported.messages.map((message, index) => ({
+      ...message,
+      id: `message-${index}`,
+    }));
+    const [file] = await plugin.exportFiles!({
+      settings,
+      bundles: imported.bundles as any,
+      messages: messages as any,
+      variants: imported.variants.map((variant, index) => ({
+        ...variant,
+        id: `variant-${index}`,
+        messageId: messages.find(
+          (message) =>
+            message.bundleId === variant.messageBundleId &&
+            message.locale === variant.messageLocale,
+        )!.id,
+      })) as any,
+    });
+    const output = new TextDecoder().decode(file!.content);
+    expect(output).toContain("%2$lld %1$.2f %3$@ %2$lld 100%%");
+    expect(output).toContain('"types/key"');
+  });
+
+  test("rejects duplicates and unsupported format syntax", async () => {
+    for (const source of [
+      '"same" = "a"; "same" = "b";',
+      '"bad" = "%1$Q";',
+      '"bad" = "\\a";',
+    ]) {
+      expect(() =>
+        plugin.importFiles!({
+          settings,
+          files: [{ locale: "en", content: new TextEncoder().encode(source) }],
+        }),
+      ).toThrow();
+    }
+  });
+
+  test("round-trips standalone escaped percent literals", async () => {
+    const imported = await plugin.importFiles!({
+      settings,
+      files: [
+        {
+          locale: "en",
+          content: new TextEncoder().encode('"literal" = "%%@ %%d %%f %%";'),
+        },
+      ],
+    });
+    expect(imported.variants[0]!.pattern).toEqual([
+      { type: "text", value: "%%@ %%d %%f %%" },
+    ]);
+    const messages = [{ ...imported.messages[0]!, id: "message" }];
+    const [file] = await plugin.exportFiles!({
+      settings,
+      bundles: imported.bundles as any,
+      messages: messages as any,
+      variants: [
+        { ...imported.variants[0]!, id: "variant", messageId: "message" },
+      ] as any,
+    });
+    expect(new TextDecoder().decode(file!.content)).toContain("%%@ %%d %%f %%");
+  });
+
+  test.each(["Save 20%", "100% complete", "100%%"])(
+    "preserves plain percent text exactly: %s",
+    async (value) => {
+      const imported = await plugin.importFiles!({
+        settings,
+        files: [
+          {
+            locale: "en",
+            content: new TextEncoder().encode(`"plain" = "${value}";`),
+          },
+        ],
+      });
+      expect(imported.variants[0]!.pattern).toEqual([{ type: "text", value }]);
+      const [file] = await plugin.exportFiles!({
+        settings,
+        bundles: imported.bundles as any,
+        messages: [{ ...imported.messages[0]!, id: "message" }] as any,
+        variants: [
+          { ...imported.variants[0]!, id: "variant", messageId: "message" },
+        ] as any,
+      });
+      expect(new TextDecoder().decode(file!.content)).toContain(`"${value}"`);
+    },
+  );
+
+  test("imports annotated printf expressions through the SDK lifecycle", async () => {
+    const project = await loadProjectInMemory({
+      blob: await newProject({ settings }),
+      providePlugins: [plugin as any],
+    });
+    try {
+      const files = [
+        {
+          locale: "en",
+          content: new TextEncoder().encode(
+            '"typed/value" = "%2$lld / %1$.2f / %3$@";\n"Cancel";',
+          ),
+        },
+      ];
+      await project.importFiles({ pluginKey: plugin.key, files });
+      await project.importFiles({ pluginKey: plugin.key, files });
+      const [file] = await project.exportFiles({ pluginKey: plugin.key });
+      const output = new TextDecoder().decode(file!.content);
+      expect(output).toContain('"typed/value" = "%2$lld / %1$.2f / %3$@";');
+      expect(output).toContain('"Cancel" = "Cancel";');
+      expect(
+        await project.db.selectFrom("message").selectAll().execute(),
+      ).toHaveLength(2);
+    } finally {
+      await project.close();
+    }
+  });
+
+  test("rejects plurals instead of silently dropping variants", async () => {
+    expect(() =>
+      plugin.exportFiles!({
+        settings,
+        bundles: [{ id: "cart.items", declarations: [] }],
+        messages: [
+          {
+            id: "message",
+            bundleId: "cart.items",
+            locale: "en",
+            selectors: [{ type: "variable-reference", name: "countPlural" }],
+          },
+        ],
+        variants: [],
+      }),
+    ).toThrow("cannot represent selectors or plurals");
+  });
+});

--- a/packages/plugins/apple-strings/src/plugin.ts
+++ b/packages/plugins/apple-strings/src/plugin.ts
@@ -1,0 +1,332 @@
+import type {
+  Bundle,
+  InlangPlugin,
+  Message,
+  MessageImport,
+  Pattern,
+  Variant,
+  VariantImport,
+} from "@inlang/sdk";
+import { PluginSettings } from "./settings.js";
+
+export const PLUGIN_KEY = "plugin.inlang.apple-strings";
+type Config = { [PLUGIN_KEY]: PluginSettings };
+type ImportArgs = Parameters<
+  NonNullable<InlangPlugin<Config>["importFiles"]>
+>[0];
+type ExportArgs = Parameters<
+  NonNullable<InlangPlugin<Config>["exportFiles"]>
+>[0];
+
+export const plugin: InlangPlugin<Config> = {
+  key: PLUGIN_KEY,
+  settingsSchema: PluginSettings,
+  toBeImportedFiles: ({ settings }) =>
+    settings.locales.map((locale) => ({
+      locale,
+      path: settings[PLUGIN_KEY].pathPattern.replace("{locale}", locale),
+    })),
+  importFiles: ({ files }: ImportArgs) => importAppleStrings(files),
+  exportFiles: (args: ExportArgs) => exportAppleStrings(args),
+};
+
+function importAppleStrings(
+  files: ImportArgs["files"],
+): ReturnType<NonNullable<InlangPlugin<Config>["importFiles"]>> {
+  const bundles = new Map<string, Bundle>();
+  const messages: MessageImport[] = [];
+  const variants: VariantImport[] = [];
+  for (const file of files) {
+    for (const { key, value } of parseStringsFile(decode(file.content))) {
+      const parsed = parsePattern(value);
+      const current = bundles.get(key) ?? { id: key, declarations: [] };
+      for (const name of parsed.variables)
+        if (
+          !current.declarations.some((declaration) => declaration.name === name)
+        )
+          current.declarations.push({ type: "input-variable", name });
+      bundles.set(key, current);
+      messages.push({ bundleId: key, locale: file.locale, selectors: [] });
+      variants.push({
+        messageBundleId: key,
+        messageLocale: file.locale,
+        matches: [],
+        pattern: parsed.pattern,
+      });
+    }
+  }
+  return { bundles: [...bundles.values()], messages, variants };
+}
+
+function exportAppleStrings({
+  bundles,
+  messages,
+  variants,
+  settings,
+}: ExportArgs) {
+  const files = new Map<string, string[]>();
+  for (const message of messages) {
+    const bundle = requiredBundle(bundles, message);
+    if (message.selectors.length !== 0)
+      throw new Error(
+        `Apple .strings cannot represent selectors or plurals (bundle "${bundle.id}")`,
+      );
+    const messageVariants = variants.filter(
+      (variant) => variant.messageId === message.id,
+    );
+    if (
+      messageVariants.length !== 1 ||
+      messageVariants[0]!.matches.length !== 0
+    )
+      throw new Error(
+        `Apple .strings requires one unconditional variant (bundle "${bundle.id}")`,
+      );
+    const lines = files.get(message.locale) ?? [];
+    lines.push(
+      `"${escapeString(bundle.id)}" = "${serializePattern(messageVariants[0]!.pattern, bundle)}";`,
+    );
+    files.set(message.locale, lines);
+  }
+  return [...files].map(([locale, lines]) => ({
+    locale,
+    name:
+      settings[PLUGIN_KEY]?.pathPattern.replace("{locale}", locale) ??
+      `${locale}.lproj/Localizable.strings`,
+    content: encode(`${lines.sort().join("\n")}\n`),
+  }));
+}
+
+function parseStringsFile(source: string) {
+  const entries: Array<{ key: string; value: string }> = [];
+  let cursor = 0;
+  const whitespaceAndComments = () => {
+    while (cursor < source.length) {
+      if (/\s/.test(source[cursor]!)) {
+        cursor++;
+      } else if (source.startsWith("//", cursor)) {
+        cursor = source.indexOf("\n", cursor + 2);
+        if (cursor === -1) cursor = source.length;
+      } else if (source.startsWith("/*", cursor)) {
+        const end = source.indexOf("*/", cursor + 2);
+        if (end === -1) throw new Error("Unterminated Apple .strings comment");
+        cursor = end + 2;
+      } else break;
+    }
+  };
+  const quoted = () => {
+    if (source[cursor] !== '"')
+      throw new Error(
+        `Expected quoted Apple .strings value at offset ${cursor}`,
+      );
+    cursor++;
+    let result = "";
+    while (cursor < source.length) {
+      const char = source[cursor++]!;
+      if (char === '"') return result;
+      if (char !== "\\") {
+        result += char;
+        continue;
+      }
+      if (cursor === source.length)
+        throw new Error("Unterminated Apple .strings escape");
+      result += `\\${source[cursor++]}`;
+    }
+    throw new Error("Unterminated quoted Apple .strings value");
+  };
+  whitespaceAndComments();
+  while (cursor < source.length) {
+    const key = unescapeString(quoted());
+    whitespaceAndComments();
+    if (source[cursor] === ";") {
+      cursor++;
+      if (entries.some((entry) => entry.key === key))
+        throw new Error(`Duplicate Apple .strings key "${key}"`);
+      entries.push({ key, value: key });
+      whitespaceAndComments();
+      continue;
+    }
+    if (source[cursor++] !== "=") throw new Error(`Expected = after "${key}"`);
+    whitespaceAndComments();
+    const value = unescapeString(quoted());
+    whitespaceAndComments();
+    if (source[cursor++] !== ";") throw new Error(`Expected ; after "${key}"`);
+    if (entries.some((entry) => entry.key === key))
+      throw new Error(`Duplicate Apple .strings key "${key}"`);
+    entries.push({ key, value });
+    whitespaceAndComments();
+  }
+  return entries;
+}
+
+function parsePattern(value: string) {
+  const pattern: Pattern = [];
+  const variables: string[] = [];
+  const regex =
+    /^%(?:(\d+)\$([-+# 0,(]*\d*(?:\.\d+)?(?:hh|h|ll|l|q|z|t|j)?[diuoxXfFeEgGaAcCsSp@])|((?:hh|h|ll|l|q|z|t|j)?[diuoxXfFeEgGaAcCsSp@]))/;
+  if (!hasPrintfExpression(value, regex)) {
+    if (/%\d+\$/.test(value))
+      throw new Error(`Unsupported Apple positional format in "${value}"`);
+    return { pattern: [{ type: "text", value }] as Pattern, variables };
+  }
+  let cursor = 0;
+  let implicit = 0;
+  let text = "";
+  while (cursor < value.length) {
+    if (value.startsWith("%%", cursor)) {
+      text += "%";
+      cursor += 2;
+      continue;
+    }
+    const match = value.slice(cursor).match(regex);
+    if (!match) {
+      if (value[cursor] === "%")
+        throw new Error(
+          `Unsupported Apple format specifier near "${value.slice(cursor, cursor + 12)}"`,
+        );
+      text += value[cursor++];
+      continue;
+    }
+    if (text) {
+      pattern.push({ type: "text", value: text });
+      text = "";
+    }
+    const position = match[1] ? Number(match[1]) : ++implicit;
+    const specifier = match[2] ?? match[3]!;
+    const name = `arg${position}`;
+    variables.push(name);
+    pattern.push({
+      type: "expression",
+      arg: { type: "variable-reference", name },
+      annotation: {
+        type: "function-reference",
+        name: "apple-printf",
+        options: [
+          { name: "specifier", value: { type: "literal", value: specifier } },
+          {
+            name: "position",
+            value: { type: "literal", value: String(position) },
+          },
+        ],
+      },
+    });
+    cursor += match[0].length;
+  }
+  if (text) pattern.push({ type: "text", value: text });
+  if (pattern.length === 0) pattern.push({ type: "text", value: "" });
+  return { pattern, variables };
+}
+
+function serializePattern(pattern: Pattern, bundle: Bundle) {
+  const inputs = bundle.declarations.filter(
+    (declaration) => declaration.type === "input-variable",
+  );
+  const formatted = pattern.some((part) => part.type === "expression");
+  return pattern
+    .map((part) => {
+      if (part.type === "text") {
+        const escaped = escapeString(part.value);
+        return formatted ? escaped.replace(/%/g, "%%") : escaped;
+      }
+      if (part.type !== "expression" || part.arg.type !== "variable-reference")
+        throw new Error(
+          `Apple .strings only supports plain variable expressions (bundle "${bundle.id}")`,
+        );
+      const variableName = part.arg.name;
+      const position =
+        inputs.findIndex((declaration) => declaration.name === variableName) +
+        1;
+      if (position === 0)
+        throw new Error(
+          `Variable "${variableName}" is not declared in "${bundle.id}"`,
+        );
+      const format = applePrintfFormat(part.annotation, position);
+      return `%${format.position}$${format.specifier}`;
+    })
+    .join("");
+}
+
+function applePrintfFormat(
+  annotation: Extract<Pattern[number], { type: "expression" }>["annotation"],
+  fallbackPosition: number,
+) {
+  if (!annotation) return { position: fallbackPosition, specifier: "@" };
+  if (
+    annotation.type !== "function-reference" ||
+    annotation.name !== "apple-printf"
+  )
+    throw new Error(
+      `Apple .strings export does not support the ${annotation.type} annotation`,
+    );
+  const option = (name: string) =>
+    annotation.options.find((candidate) => candidate.name === name)?.value;
+  const specifier = option("specifier");
+  const position = option("position");
+  if (
+    specifier?.type !== "literal" ||
+    !/^[-+# 0,(]*\d*(?:\.\d+)?(?:hh|h|ll|l|q|z|t|j)?[diuoxXfFeEgGaAcCsSp@]$/.test(
+      specifier.value,
+    ) ||
+    position?.type !== "literal" ||
+    !/^\d+$/.test(position.value)
+  )
+    throw new Error("Invalid Apple printf annotation");
+  return { specifier: specifier.value, position: Number(position.value) };
+}
+
+function requiredBundle(bundles: Bundle[], message: Message) {
+  const bundle = bundles.find((candidate) => candidate.id === message.bundleId);
+  if (!bundle) throw new Error(`Missing bundle "${message.bundleId}"`);
+  return bundle;
+}
+function escapeString(value: string) {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, "\\n")
+    .replace(/\r/g, "\\r")
+    .replace(/\t/g, "\\t");
+}
+function unescapeString(value: string) {
+  const unknownEscape = value.match(/\\(?![\\"nrtuU]|$)/);
+  if (unknownEscape)
+    throw new Error(`Unsupported Apple .strings escape "${unknownEscape[0]}"`);
+  return value
+    .replace(/\\U([0-9a-fA-F]{4})/g, (_, hex: string) =>
+      String.fromCharCode(Number.parseInt(hex, 16)),
+    )
+    .replace(/\\u([0-9a-fA-F]{4})/g, (_, hex: string) =>
+      String.fromCharCode(Number.parseInt(hex, 16)),
+    )
+    .replace(
+      /\\([\\"nrt])/g,
+      (_, char: string) =>
+        ({ "\\": "\\", '"': '"', n: "\n", r: "\r", t: "\t" })[char]!,
+    );
+}
+function encode(value: string) {
+  return new TextEncoder().encode(value);
+}
+function decode(value: Uint8Array) {
+  if (value[0] === 0xff && value[1] === 0xfe)
+    return new TextDecoder("utf-16le").decode(value.subarray(2));
+  if (value[0] === 0xfe && value[1] === 0xff) {
+    const littleEndian = new Uint8Array(value.length - 2);
+    for (let index = 2; index + 1 < value.length; index += 2) {
+      littleEndian[index - 2] = value[index + 1]!;
+      littleEndian[index - 1] = value[index]!;
+    }
+    return new TextDecoder("utf-16le").decode(littleEndian);
+  }
+  return new TextDecoder().decode(value);
+}
+
+function hasPrintfExpression(source: string, regex: RegExp) {
+  for (let cursor = 0; cursor < source.length; cursor++) {
+    if (source.startsWith("%%", cursor)) {
+      cursor++;
+      continue;
+    }
+    if (source[cursor] === "%" && regex.test(source.slice(cursor))) return true;
+  }
+  return false;
+}

--- a/packages/plugins/apple-strings/src/settings.ts
+++ b/packages/plugins/apple-strings/src/settings.ts
@@ -1,0 +1,9 @@
+import { Type, type Static } from "@sinclair/typebox";
+
+export type PluginSettings = Static<typeof PluginSettings>;
+export const PluginSettings = Type.Object({
+  pathPattern: Type.String({
+    pattern: ".*\\{locale\\}.*\\.strings$",
+    examples: ["./Localizations/{locale}.lproj/Localizable.strings"],
+  }),
+});

--- a/packages/plugins/apple-strings/tsconfig.build.json
+++ b/packages/plugins/apple-strings/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"],
+  "compilerOptions": {
+    "rootDir": "src"
+  }
+}

--- a/packages/plugins/apple-strings/tsconfig.json
+++ b/packages/plugins/apple-strings/tsconfig.json
@@ -1,0 +1,1 @@
+{ "extends": "@inlang/tsconfig/default", "include": ["src/**/*"] }

--- a/packages/plugins/apple-xcstrings/README.md
+++ b/packages/plugins/apple-xcstrings/README.md
@@ -1,0 +1,18 @@
+# Apple String Catalog plugin for Inlang
+
+Reads and writes Xcode 15+ `.xcstrings` catalogs through Inlang's v2 message model.
+
+Supported: exact keys, all catalog locales, positional printf variables, one plural variation, or one Apple device variation per message. Nested or multiple variations and source-only entries without a recoverable value fail explicitly rather than being flattened.
+
+This is a content adapter. Catalog workflow metadata such as comments, extraction state, translation state, and `shouldTranslate` is not represented by Inlang's v2 message tables and is regenerated on export.
+
+```json
+{
+  "modules": [
+    "https://cdn.jsdelivr.net/npm/@inlang/plugin-apple-xcstrings@latest/dist/index.js"
+  ],
+  "plugin.inlang.apple-xcstrings": {
+    "pathPattern": "./Localizations/Localizable.xcstrings"
+  }
+}
+```

--- a/packages/plugins/apple-xcstrings/build.js
+++ b/packages/plugins/apple-xcstrings/build.js
@@ -1,0 +1,36 @@
+import { context } from "esbuild";
+import { execFileSync } from "node:child_process";
+const isProduction = process.env.NODE_ENV === "production";
+const ctx = await context({
+  entryPoints: ["./src/index.ts"],
+  outdir: "./dist",
+  minify: isProduction,
+  target: "es2022",
+  bundle: true,
+  format: "esm",
+  platform: "browser",
+  sourcemap: false,
+});
+if (isProduction) {
+  await ctx.rebuild();
+  await ctx.dispose();
+  execFileSync(
+    "tsc",
+    [
+      "-p",
+      "tsconfig.build.json",
+      "--emitDeclarationOnly",
+      "--declaration",
+      "--declarationMap",
+      "false",
+      "--outDir",
+      "dist",
+      "--noEmit",
+      "false",
+    ],
+    { stdio: "inherit" },
+  );
+} else {
+  await ctx.watch();
+  console.info("Watching for changes...");
+}

--- a/packages/plugins/apple-xcstrings/marketplace-manifest.json
+++ b/packages/plugins/apple-xcstrings/marketplace-manifest.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://inlang.com/schema/marketplace-manifest",
+  "id": "plugin.inlang.apple-xcstrings",
+  "displayName": { "en": "Apple String Catalog" },
+  "description": {
+    "en": "Read and write Apple .xcstrings catalogs with variables, plurals, and device variations."
+  },
+  "pages": { "/": "./README.md" },
+  "keywords": [
+    "apple",
+    "ios",
+    "macos",
+    "xcstrings",
+    "string-catalog",
+    "localization",
+    "plugin"
+  ],
+  "publisherName": "inlang",
+  "publisherIcon": "https://inlang.com/favicon/safari-pinned-tab.svg",
+  "license": "Apache-2.0",
+  "module": "https://cdn.jsdelivr.net/npm/@inlang/plugin-apple-xcstrings@latest/dist/index.js"
+}

--- a/packages/plugins/apple-xcstrings/package.json
+++ b/packages/plugins/apple-xcstrings/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@inlang/plugin-apple-xcstrings",
+  "version": "0.1.0",
+  "type": "module",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "./dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "dev": "node build.js",
+    "build": "NODE_ENV=production node build.js",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@inlang/sdk": "workspace:*",
+    "@sinclair/typebox": "^0.31.17"
+  },
+  "devDependencies": {
+    "@inlang/tsconfig": "workspace:*",
+    "esbuild": "^0.25.9",
+    "typescript": "^5.9.2",
+    "vitest": "^3.2.4"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/opral/inlang.git",
+    "directory": "packages/plugins/apple-xcstrings"
+  },
+  "license": "Apache-2.0"
+}

--- a/packages/plugins/apple-xcstrings/src/index.ts
+++ b/packages/plugins/apple-xcstrings/src/index.ts
@@ -1,0 +1,3 @@
+import { plugin } from "./plugin.js";
+export default plugin;
+export { plugin };

--- a/packages/plugins/apple-xcstrings/src/plugin.test.ts
+++ b/packages/plugins/apple-xcstrings/src/plugin.test.ts
@@ -1,0 +1,485 @@
+import { describe, expect, test } from "vitest";
+import { loadProjectInMemory, newProject } from "@inlang/sdk";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { plugin, PLUGIN_KEY } from "./plugin.js";
+
+const settings = {
+  baseLocale: "en",
+  locales: ["en", "de"],
+  modules: [],
+  [PLUGIN_KEY]: { pathPattern: "./Localizations/Localizable.xcstrings" },
+};
+
+describe("Apple String Catalog plugin", () => {
+  test("imports and exports exact keys, locales, positional variables, plurals, and devices", async () => {
+    const source = catalog({
+      "ManageSale.PricePlaceholder": {
+        extractionState: "manual",
+        localizations: {
+          en: { stringUnit: translated("Hello %1$@") },
+          de: { stringUnit: translated("Hallo %1$@") },
+        },
+      },
+      cart_items: {
+        localizations: {
+          en: {
+            stringUnit: translated("%#@countPlural@"),
+            substitutions: {
+              countPlural: {
+                argNum: 1,
+                formatSpecifier: "lld",
+                variations: {
+                  plural: {
+                    one: { stringUnit: translated("%1$lld item") },
+                    other: { stringUnit: translated("%1$lld items") },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      learn_more: {
+        localizations: {
+          en: {
+            variations: {
+              device: {
+                iphone: { stringUnit: translated("Tap to learn more") },
+                other: { stringUnit: translated("Click to learn more") },
+              },
+            },
+          },
+        },
+      },
+    });
+    const imported = await plugin.importFiles!({
+      settings,
+      files: [{ locale: "en", content: encode(source) }],
+    });
+    expect(imported.bundles.map((bundle) => bundle.id)).toEqual([
+      "ManageSale.PricePlaceholder",
+      "cart_items",
+      "learn_more",
+    ]);
+    const pluralMessage = imported.messages.find(
+      (message) => message.bundleId === "cart_items",
+    )!;
+    expect(pluralMessage.selectors).toEqual([
+      { type: "variable-reference", name: "countPlural" },
+    ]);
+    const deviceMessage = imported.messages.find(
+      (message) => message.bundleId === "learn_more",
+    )!;
+    expect(deviceMessage.selectors).toEqual([
+      { type: "variable-reference", name: "device" },
+    ]);
+
+    const concrete = concretize(imported);
+    const [file] = await plugin.exportFiles!({ settings, ...concrete });
+    expect(file!.name).toBe("./Localizations/Localizable.xcstrings");
+    const output = JSON.parse(decode(file!.content));
+    expect(output.sourceLanguage).toBe("en");
+    expect(
+      output.strings["ManageSale.PricePlaceholder"].localizations.de.stringUnit
+        .value,
+    ).toBe("Hallo %1$@");
+    expect(
+      output.strings.cart_items.localizations.en.substitutions.countPlural
+        .variations.plural.other.stringUnit.value,
+    ).toBe("%1$lld items");
+    expect(
+      output.strings.learn_more.localizations.en.variations.device.iphone
+        .stringUnit.value,
+    ).toBe("Tap to learn more");
+  });
+
+  test("round-trips through the SDK project lifecycle", async () => {
+    const project = await loadProjectInMemory({
+      blob: await newProject({ settings }),
+      providePlugins: [plugin as any],
+    });
+    try {
+      const files = [
+        {
+          locale: "en",
+          content: encode(
+            catalog({
+              greeting: {
+                localizations: {
+                  en: { stringUnit: translated("Hello %1$@") },
+                  de: { stringUnit: translated("Hallo %1$@") },
+                },
+              },
+            }),
+          ),
+        },
+      ];
+      await project.importFiles({ pluginKey: plugin.key, files });
+      const [file] = await project.exportFiles({ pluginKey: plugin.key });
+      const output = JSON.parse(decode(file!.content));
+      expect(output.strings.greeting.localizations).toEqual({
+        de: { stringUnit: translated("Hallo %1$@") },
+        en: { stringUnit: translated("Hello %1$@") },
+      });
+    } finally {
+      await project.close();
+    }
+  });
+
+  test("preserves plural templates, argument positions, and compiles with Xcode", async () => {
+    const source = catalog({
+      cart: {
+        localizations: {
+          en: {
+            stringUnit: translated("You have %#@items@ remaining"),
+            substitutions: {
+              items: {
+                argNum: 2,
+                formatSpecifier: "d",
+                variations: {
+                  plural: {
+                    one: { stringUnit: translated("%1$@ has %2$d item") },
+                    other: { stringUnit: translated("%1$@ has %2$d items") },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    const imported = await plugin.importFiles!({
+      settings,
+      files: [{ locale: "en", content: encode(source) }],
+    });
+    expect(imported.variants[0]?.pattern?.[0]).toEqual({
+      type: "text",
+      value: "You have ",
+    });
+    const [file] = await plugin.exportFiles!({
+      settings,
+      ...concretize(imported),
+    });
+    const localization = JSON.parse(decode(file!.content)).strings.cart
+      .localizations.en;
+    expect(localization.substitutions.items.argNum).toBe(2);
+    expect(localization.substitutions.items.formatSpecifier).toBe("d");
+    expect(
+      localization.substitutions.items.variations.plural.other.stringUnit.value,
+    ).toBe("You have %1$@ has %2$d items remaining");
+    compileWithXcode(file!.content);
+  });
+
+  test("imports and compiles standard direct plural variations", async () => {
+    const source = catalog({
+      "%1$lld item(s)": {
+        localizations: {
+          en: {
+            variations: {
+              plural: {
+                one: { stringUnit: translated("%1$lld item") },
+                other: { stringUnit: translated("%1$lld items") },
+              },
+            },
+          },
+        },
+      },
+    });
+    const imported = await plugin.importFiles!({
+      settings,
+      files: [{ locale: "en", content: encode(source) }],
+    });
+    const [file] = await plugin.exportFiles!({
+      settings,
+      ...concretize(imported),
+    });
+    expect(
+      JSON.parse(decode(file!.content)).strings["%1$lld item(s)"].localizations
+        .en.variations.plural.other.stringUnit.value,
+    ).toBe("%1$lld items");
+    compileWithXcode(file!.content);
+  });
+
+  test("exports canonical Inlang plurals with numeric placeholders", () => {
+    const [file] = plugin.exportFiles!({
+      settings,
+      bundles: [
+        {
+          id: "cart_items",
+          declarations: [
+            { type: "input-variable", name: "count" },
+            {
+              type: "local-variable",
+              name: "countPlural",
+              value: {
+                type: "expression",
+                arg: { type: "variable-reference", name: "count" },
+                annotation: {
+                  type: "function-reference",
+                  name: "plural",
+                  options: [],
+                },
+              },
+            },
+          ],
+        },
+      ] as any,
+      messages: [
+        {
+          id: "message",
+          bundleId: "cart_items",
+          locale: "en",
+          selectors: [{ type: "variable-reference", name: "countPlural" }],
+        },
+      ],
+      variants: [
+        {
+          id: "one",
+          messageId: "message",
+          matches: [
+            { type: "literal-match", key: "countPlural", value: "one" },
+          ],
+          pattern: [
+            {
+              type: "expression",
+              arg: { type: "variable-reference", name: "count" },
+            },
+            { type: "text", value: " item" },
+          ],
+        },
+        {
+          id: "other",
+          messageId: "message",
+          matches: [{ type: "catchall-match", key: "countPlural" }],
+          pattern: [
+            {
+              type: "expression",
+              arg: { type: "variable-reference", name: "count" },
+            },
+            { type: "text", value: " items" },
+          ],
+        },
+      ] as any,
+    }) as any[];
+    expect(
+      JSON.parse(decode(file!.content)).strings.cart_items.localizations.en
+        .substitutions.countPlural.variations.plural.other.stringUnit.value,
+    ).toBe("%1$lld items");
+    compileWithXcode(file!.content);
+  });
+
+  test("preserves plain percent text and escaped percent in formatted patterns", async () => {
+    const source = catalog({
+      raw: {
+        localizations: { en: { stringUnit: translated("Save 20% and 100%%") } },
+      },
+      formatted: {
+        localizations: {
+          en: { stringUnit: translated("%1$@ is 20%% complete") },
+        },
+      },
+    });
+    const imported = await plugin.importFiles!({
+      settings,
+      files: [{ locale: "en", content: encode(source) }],
+    });
+    const [file] = await plugin.exportFiles!({
+      settings,
+      ...concretize(imported),
+    });
+    const output = JSON.parse(decode(file!.content));
+    expect(output.strings.raw.localizations.en.stringUnit.value).toBe(
+      "Save 20% and 100%%",
+    );
+    expect(output.strings.formatted.localizations.en.stringUnit.value).toBe(
+      "%1$@ is 20%% complete",
+    );
+  });
+
+  test("rejects malformed, nested, multi-selector, and missing-other catalogs", async () => {
+    expect(() =>
+      plugin.importFiles!({
+        settings,
+        files: [{ locale: "en", content: encode("not json") }],
+      }),
+    ).toThrow("Invalid Apple .xcstrings JSON");
+    expect(() =>
+      plugin.importFiles!({
+        settings,
+        files: [
+          {
+            locale: "en",
+            content: encode(
+              catalog({
+                bad: {
+                  localizations: {
+                    en: {
+                      variations: {
+                        device: { iphone: { stringUnit: translated("Tap") } },
+                      },
+                    },
+                  },
+                },
+              }),
+            ),
+          },
+        ],
+      }),
+    ).toThrow('require "other"');
+    expect(() =>
+      plugin.importFiles!({
+        settings,
+        files: [
+          {
+            locale: "en",
+            content: encode(
+              catalog({
+                bad: {
+                  localizations: {
+                    en: {
+                      stringUnit: translated("value"),
+                      variations: {
+                        device: { other: { stringUnit: translated("other") } },
+                      },
+                    },
+                  },
+                },
+              }),
+            ),
+          },
+        ],
+      }),
+    ).toThrow("exactly one supported localization shape");
+    expect(() =>
+      plugin.exportFiles!({
+        settings,
+        bundles: [{ id: "bad", declarations: [] }],
+        messages: [
+          {
+            id: "message",
+            bundleId: "bad",
+            locale: "en",
+            selectors: [
+              { type: "variable-reference", name: "a" },
+              { type: "variable-reference", name: "b" },
+            ],
+          },
+        ],
+        variants: [],
+      }),
+    ).toThrow("one selector");
+    expect(() =>
+      plugin.importFiles!({
+        settings,
+        files: [{ locale: "en", content: encode(catalog({ sourceOnly: {} })) }],
+      }),
+    ).toThrow("source-only entry");
+    expect(() =>
+      plugin.importFiles!({
+        settings,
+        files: [
+          {
+            locale: "en",
+            content: encode(
+              JSON.stringify({
+                sourceLanguage: "fr",
+                strings: {},
+                version: "1.0",
+              }),
+            ),
+          },
+        ],
+      }),
+    ).toThrow("must match baseLocale");
+  });
+
+  test("rejects ambiguous printf arguments and duplicate identities", () => {
+    for (const value of ["%1$@ %d", "%1$@ %1$d"]) {
+      expect(() =>
+        plugin.importFiles!({
+          settings,
+          files: [
+            {
+              locale: "en",
+              content: encode(
+                catalog({
+                  bad: {
+                    localizations: { en: { stringUnit: translated(value) } },
+                  },
+                }),
+              ),
+            },
+          ],
+        }),
+      ).toThrow();
+    }
+    expect(() =>
+      plugin.exportFiles!({
+        settings,
+        bundles: [
+          { id: "same", declarations: [] },
+          { id: "same", declarations: [] },
+        ],
+        messages: [],
+        variants: [],
+      }),
+    ).toThrow("Duplicate Apple .xcstrings bundle id");
+  });
+});
+
+function catalog(strings: Record<string, unknown>) {
+  return JSON.stringify({ sourceLanguage: "en", strings, version: "1.0" });
+}
+function translated(value: string) {
+  return { state: "translated", value };
+}
+function encode(value: string) {
+  return new TextEncoder().encode(value);
+}
+function decode(value: Uint8Array) {
+  return new TextDecoder().decode(value);
+}
+function compileWithXcode(content: Uint8Array) {
+  if (process.platform !== "darwin") return;
+  const directory = mkdtempSync(join(tmpdir(), "inlang-xcstrings-"));
+  const input = join(directory, "Localizable.xcstrings");
+  writeFileSync(input, content);
+  execFileSync("xcrun", [
+    "xcstringstool",
+    "compile",
+    input,
+    "--output-directory",
+    directory,
+    "--serialization-format",
+    "text",
+  ]);
+  expect(
+    existsSync(join(directory, "en.lproj", "Localizable.strings")) ||
+      existsSync(join(directory, "en.lproj", "Localizable.stringsdict")),
+  ).toBe(true);
+}
+function concretize(
+  imported: Awaited<ReturnType<NonNullable<typeof plugin.importFiles>>>,
+) {
+  const messages = imported.messages.map((message, index) => ({
+    ...message,
+    id: `message-${index}`,
+  }));
+  const variants = imported.variants.map((variant, index) => ({
+    ...variant,
+    id: `variant-${index}`,
+    messageId: messages.find(
+      (message) =>
+        message.bundleId === variant.messageBundleId &&
+        message.locale === variant.messageLocale,
+    )!.id,
+  }));
+  return {
+    bundles: imported.bundles as any,
+    messages: messages as any,
+    variants: variants as any,
+  };
+}

--- a/packages/plugins/apple-xcstrings/src/plugin.test.ts
+++ b/packages/plugins/apple-xcstrings/src/plugin.test.ts
@@ -141,8 +141,8 @@ describe("Apple String Catalog plugin", () => {
                 formatSpecifier: "d",
                 variations: {
                   plural: {
-                    one: { stringUnit: translated("%1$@ has %2$d item") },
-                    other: { stringUnit: translated("%1$@ has %2$d items") },
+                    one: { stringUnit: translated("%d item") },
+                    other: { stringUnit: translated("%d items") },
                   },
                 },
               },
@@ -169,13 +169,13 @@ describe("Apple String Catalog plugin", () => {
     expect(localization.substitutions.items.formatSpecifier).toBe("d");
     expect(
       localization.substitutions.items.variations.plural.other.stringUnit.value,
-    ).toBe("You have %1$@ has %2$d items remaining");
+    ).toBe("You have %2$d items remaining");
     compileWithXcode(file!.content);
   });
 
   test("imports and compiles standard direct plural variations", async () => {
     const source = catalog({
-      "%1$lld item(s)": {
+      cart_items_direct: {
         localizations: {
           en: {
             variations: {
@@ -197,7 +197,7 @@ describe("Apple String Catalog plugin", () => {
       ...concretize(imported),
     });
     expect(
-      JSON.parse(decode(file!.content)).strings["%1$lld item(s)"].localizations
+      JSON.parse(decode(file!.content)).strings.cart_items_direct.localizations
         .en.variations.plural.other.stringUnit.value,
     ).toBe("%1$lld items");
     compileWithXcode(file!.content);
@@ -427,6 +427,45 @@ describe("Apple String Catalog plugin", () => {
         variants: [],
       }),
     ).toThrow("Duplicate Apple .xcstrings bundle id");
+  });
+
+  test("preserves prototype-looking exact keys and rejects missing bundles", () => {
+    const [file] = plugin.exportFiles!({
+      settings,
+      bundles: [{ id: "__proto__", declarations: [] }],
+      messages: [
+        {
+          id: "message",
+          bundleId: "__proto__",
+          locale: "en",
+          selectors: [],
+        },
+      ],
+      variants: [
+        {
+          id: "variant",
+          messageId: "message",
+          matches: [],
+          pattern: [{ type: "text", value: "safe" }],
+        },
+      ],
+    }) as any[];
+    expect(JSON.parse(decode(file!.content)).strings.__proto__).toBeTruthy();
+    expect(() =>
+      plugin.exportFiles!({
+        settings,
+        bundles: [],
+        messages: [
+          {
+            id: "message",
+            bundleId: "missing",
+            locale: "en",
+            selectors: [],
+          },
+        ],
+        variants: [],
+      }),
+    ).toThrow("references missing bundle");
   });
 });
 

--- a/packages/plugins/apple-xcstrings/src/plugin.ts
+++ b/packages/plugins/apple-xcstrings/src/plugin.ts
@@ -56,13 +56,14 @@ const pluralCategories = new Set([
   "other",
 ]);
 const deviceCategories = new Set([
+  "appletv",
+  "applevision",
   "applewatch",
   "ipad",
   "iphone",
+  "ipod",
   "mac",
   "other",
-  "tv",
-  "vision",
 ]);
 
 export const plugin: InlangPlugin<Config> = {
@@ -165,26 +166,13 @@ function importLocalization(id: string, localization: Localization) {
     const units = localization.variations!.plural!;
     assertVariationUnits(units, id, "plural", pluralCategories);
     const sourcePattern = parsePattern(id);
-    const sourceExpressions = sourcePattern.pattern.filter(
-      (part) => part.type === "expression",
-    );
-    if (sourceExpressions.length !== 1)
-      throw new Error(
-        `Direct Apple plural "${id}" must contain exactly one printf argument in its key`,
-      );
-    const sourceExpression = sourceExpressions[0]!;
-    if (sourceExpression.arg.type !== "variable-reference")
-      throw new Error(`Invalid direct Apple plural argument in "${id}"`);
-    const inputName = sourceExpression.arg.name;
-    const format = printfFormat(
-      sourceExpression.annotation,
-      argumentPosition(inputName),
-    );
-    const selector = "countPlural";
     const parsed = Object.entries(units).map(([key, unit]) => ({
       key,
       parsed: parsePattern(unit.stringUnit.value),
     }));
+    const format = inferDirectPluralFormat(id, sourcePattern.pattern, parsed);
+    const inputName = `arg${format.position}`;
+    const selector = "countPlural";
     return {
       declarations: [
         { type: "input-variable", name: inputName } as Declaration,
@@ -240,7 +228,7 @@ function importLocalization(id: string, localization: Localization) {
     const parsed = Object.entries(substitution.variations.plural).map(
       ([key, unit]) => ({
         key,
-        parsed: parsePattern(unit.stringUnit.value),
+        parsed: parsePattern(unit.stringUnit.value, argNum),
       }),
     );
     return {
@@ -285,12 +273,18 @@ function exportCatalog({ bundles, messages, variants, settings }: ExportArgs) {
   assertUniqueIds(bundles, "bundle");
   assertUniqueIds(messages, "message");
   const messageIds = new Set(messages.map((message) => message.id));
+  const bundleIds = new Set(bundles.map((bundle) => bundle.id));
+  for (const message of messages)
+    if (!bundleIds.has(message.bundleId))
+      throw new Error(
+        `Apple .xcstrings message "${message.id}" references missing bundle "${message.bundleId}"`,
+      );
   for (const variant of variants)
     if (!messageIds.has(variant.messageId))
       throw new Error(
         `Apple .xcstrings variant "${variant.id}" references missing message "${variant.messageId}"`,
       );
-  const strings: Catalog["strings"] = {};
+  const stringEntries: Array<[string, Catalog["strings"][string]]> = [];
   for (const bundle of bundles) {
     const bundleMessages = messages.filter(
       (message) => message.bundleId === bundle.id,
@@ -308,12 +302,15 @@ function exportCatalog({ bundles, messages, variants, settings }: ExportArgs) {
         variants,
       );
     }
-    strings[bundle.id] = { extractionState: "manual", localizations };
+    stringEntries.push([
+      bundle.id,
+      { extractionState: "manual", localizations },
+    ]);
   }
   const catalog: Catalog = {
     sourceLanguage: settings.baseLocale,
     strings: Object.fromEntries(
-      Object.entries(strings).sort(([a], [b]) => a.localeCompare(b)),
+      stringEntries.sort(([a], [b]) => a.localeCompare(b)),
     ),
     version: "1.0",
   };
@@ -445,6 +442,46 @@ function wrapPattern(
   ];
 }
 
+function inferDirectPluralFormat(
+  id: string,
+  sourcePattern: Pattern,
+  variants: Array<{ parsed: { pattern: Pattern } }>,
+) {
+  const sourceExpressions = sourcePattern.filter(
+    (part) => part.type === "expression",
+  );
+  const candidates = sourceExpressions.length
+    ? sourceExpressions
+    : variants.flatMap(({ parsed }) =>
+        parsed.pattern.filter((part) => part.type === "expression"),
+      );
+  if (!candidates.length)
+    throw new Error(
+      `Direct Apple plural "${id}" must contain a numeric printf argument in its key or variants`,
+    );
+  const formats = candidates.map((expression) => {
+    if (expression.arg.type !== "variable-reference")
+      throw new Error(`Invalid direct Apple plural argument in "${id}"`);
+    return printfFormat(
+      expression.annotation,
+      argumentPosition(expression.arg.name),
+    );
+  });
+  const first = formats[0]!;
+  if (
+    !/(?:hh|h|ll|l|q|z|t|j)?[diuoxXfFeEgGaA]$/.test(first.specifier) ||
+    formats.some(
+      (format) =>
+        format.position !== first.position ||
+        format.specifier !== first.specifier,
+    )
+  )
+    throw new Error(
+      `Direct Apple plural "${id}" must use one consistent numeric argument`,
+    );
+  return first;
+}
+
 function parseCatalog(content: Uint8Array): Catalog {
   let parsed: unknown;
   try {
@@ -463,7 +500,7 @@ function parseCatalog(content: Uint8Array): Catalog {
   return parsed as Catalog;
 }
 
-function parsePattern(value: string) {
+function parsePattern(value: string, implicitStart = 1) {
   const pattern: Pattern = [];
   const variables: string[] = [];
   const regex =
@@ -471,7 +508,7 @@ function parsePattern(value: string) {
   if (!hasPrintfExpression(value, regex))
     return { pattern: [{ type: "text", value }] as Pattern, variables };
   let cursor = 0;
-  let implicit = 0;
+  let implicit = implicitStart - 1;
   let sawImplicit = false;
   let sawExplicit = false;
   const specifiersByPosition = new Map<number, string>();
@@ -661,6 +698,8 @@ function pluralDeclaration(
 }
 
 function inputPosition(bundle: Bundle, name: string) {
+  const namedPosition = argumentPosition(name);
+  if (namedPosition !== Number.MAX_SAFE_INTEGER) return namedPosition;
   const inputs = bundle.declarations.filter(
     (declaration) => declaration.type === "input-variable",
   );

--- a/packages/plugins/apple-xcstrings/src/plugin.ts
+++ b/packages/plugins/apple-xcstrings/src/plugin.ts
@@ -223,6 +223,13 @@ function importLocalization(id: string, localization: Localization) {
         `Apple .xcstrings substitution template in "${id}" must contain exactly one ${token}`,
       );
     const [prefix, suffix] = template.split(token);
+    if (
+      hasImplicitPrintfExpression(prefix!) ||
+      hasImplicitPrintfExpression(suffix!)
+    )
+      throw new Error(
+        `Apple .xcstrings substitution template in "${id}" cannot mix implicit printf arguments with positional argNum`,
+      );
     const parsedPrefix = parsePattern(prefix!);
     const parsedSuffix = parsePattern(
       suffix!,
@@ -802,6 +809,20 @@ function hasPrintfExpression(source: string, regex: RegExp) {
       continue;
     }
     if (source[cursor] === "%" && regex.test(source.slice(cursor))) return true;
+  }
+  return false;
+}
+
+function hasImplicitPrintfExpression(source: string) {
+  const implicit =
+    /^%(?!\d+\$)(?:[-+# 0,(]*\d*(?:\.\d+)?(?:hh|h|ll|l|q|z|t|j)?[diuoxXfFeEgGaAcCsSp@])/;
+  for (let cursor = 0; cursor < source.length; cursor++) {
+    if (source.startsWith("%%", cursor)) {
+      cursor++;
+      continue;
+    }
+    if (source[cursor] === "%" && implicit.test(source.slice(cursor)))
+      return true;
   }
   return false;
 }

--- a/packages/plugins/apple-xcstrings/src/plugin.ts
+++ b/packages/plugins/apple-xcstrings/src/plugin.ts
@@ -1,0 +1,753 @@
+import type {
+  Bundle,
+  Declaration,
+  InlangPlugin,
+  Message,
+  MessageImport,
+  Pattern,
+  Variant,
+  VariantImport,
+} from "@inlang/sdk";
+import { PluginSettings } from "./settings.js";
+
+export const PLUGIN_KEY = "plugin.inlang.apple-xcstrings";
+type Config = { [PLUGIN_KEY]: PluginSettings };
+type ImportArgs = Parameters<
+  NonNullable<InlangPlugin<Config>["importFiles"]>
+>[0];
+type ExportArgs = Parameters<
+  NonNullable<InlangPlugin<Config>["exportFiles"]>
+>[0];
+type StringUnit = { state?: string; value: string };
+type VariationUnit = { stringUnit: StringUnit };
+type Localization = {
+  stringUnit?: StringUnit;
+  substitutions?: Record<
+    string,
+    {
+      argNum?: number;
+      formatSpecifier: string;
+      variations: { plural: Record<string, VariationUnit> };
+    }
+  >;
+  variations?: {
+    device?: Record<string, VariationUnit>;
+    plural?: Record<string, VariationUnit>;
+  };
+};
+type Catalog = {
+  sourceLanguage: string;
+  strings: Record<
+    string,
+    {
+      extractionState?: string;
+      localizations?: Record<string, Localization>;
+    }
+  >;
+  version: "1.0";
+};
+
+const pluralCategories = new Set([
+  "zero",
+  "one",
+  "two",
+  "few",
+  "many",
+  "other",
+]);
+const deviceCategories = new Set([
+  "applewatch",
+  "ipad",
+  "iphone",
+  "mac",
+  "other",
+  "tv",
+  "vision",
+]);
+
+export const plugin: InlangPlugin<Config> = {
+  key: PLUGIN_KEY,
+  settingsSchema: PluginSettings,
+  toBeImportedFiles: ({ settings }) => [
+    {
+      locale: settings.baseLocale,
+      path: settings[PLUGIN_KEY].pathPattern,
+    },
+  ],
+  importFiles: ({ files, settings }: ImportArgs) =>
+    importCatalogs(files, settings),
+  exportFiles: (args: ExportArgs) => exportCatalog(args),
+};
+
+function importCatalogs(
+  files: ImportArgs["files"],
+  settings: ImportArgs["settings"],
+) {
+  if (files.length !== 1)
+    throw new Error(
+      `Apple .xcstrings expects exactly one catalog, received ${files.length}`,
+    );
+  const catalog = parseCatalog(files[0]!.content);
+  if (catalog.sourceLanguage !== settings.baseLocale)
+    throw new Error(
+      `Apple .xcstrings sourceLanguage "${catalog.sourceLanguage}" must match baseLocale "${settings.baseLocale}"`,
+    );
+  const bundles = new Map<string, Bundle>();
+  const messages: MessageImport[] = [];
+  const variants: VariantImport[] = [];
+  for (const [id, entry] of Object.entries(catalog.strings)) {
+    if (!entry || typeof entry !== "object")
+      throw new Error(`Invalid catalog entry "${id}"`);
+    if (!entry.localizations || Object.keys(entry.localizations).length === 0)
+      throw new Error(
+        `Apple .xcstrings source-only entry "${id}" has no localization value to import`,
+      );
+    for (const [locale, localization] of Object.entries(
+      entry.localizations ?? {},
+    )) {
+      if (!settings.locales.includes(locale))
+        throw new Error(
+          `Apple .xcstrings locale "${locale}" in "${id}" is not declared in project settings`,
+        );
+      const imported = importLocalization(id, localization);
+      const existing = bundles.get(id) ?? { id, declarations: [] };
+      bundles.set(id, mergeDeclarations(existing, imported.declarations));
+      messages.push({ bundleId: id, locale, selectors: imported.selectors });
+      for (const variant of imported.variants)
+        variants.push({
+          messageBundleId: id,
+          messageLocale: locale,
+          ...variant,
+        });
+    }
+  }
+  return { bundles: [...bundles.values()], messages, variants };
+}
+
+function importLocalization(id: string, localization: Localization) {
+  assertObject(localization, `localization for "${id}"`);
+  const hasPlain = localization.stringUnit !== undefined;
+  const substitutions = localization.substitutions ?? {};
+  const hasPlural = Object.keys(substitutions).length > 0;
+  const hasDevice = localization.variations?.device !== undefined;
+  const hasDirectPlural = localization.variations?.plural !== undefined;
+  if (
+    [hasPlain && !hasPlural, hasPlural, hasDevice, hasDirectPlural].filter(
+      Boolean,
+    ).length !== 1
+  )
+    throw new Error(
+      `Apple .xcstrings entry "${id}" must contain exactly one supported localization shape`,
+    );
+  if (hasDevice) {
+    const units = localization.variations!.device!;
+    assertVariationUnits(units, id, "device", deviceCategories);
+    const parsed = Object.entries(units).map(([key, unit]) => ({
+      key,
+      parsed: parsePattern(unit.stringUnit.value),
+    }));
+    return {
+      declarations: [
+        { type: "input-variable", name: "device" } as Declaration,
+        ...inputDeclarations(
+          parsed.flatMap(({ parsed }) => parsed.variables),
+          ["device"],
+        ),
+      ],
+      selectors: [{ type: "variable-reference" as const, name: "device" }],
+      variants: parsed.map(({ key, parsed }) => ({
+        matches: [match("device", key)],
+        pattern: parsed.pattern,
+      })),
+    };
+  }
+  if (hasDirectPlural) {
+    const units = localization.variations!.plural!;
+    assertVariationUnits(units, id, "plural", pluralCategories);
+    const sourcePattern = parsePattern(id);
+    const sourceExpressions = sourcePattern.pattern.filter(
+      (part) => part.type === "expression",
+    );
+    if (sourceExpressions.length !== 1)
+      throw new Error(
+        `Direct Apple plural "${id}" must contain exactly one printf argument in its key`,
+      );
+    const sourceExpression = sourceExpressions[0]!;
+    if (sourceExpression.arg.type !== "variable-reference")
+      throw new Error(`Invalid direct Apple plural argument in "${id}"`);
+    const inputName = sourceExpression.arg.name;
+    const format = printfFormat(
+      sourceExpression.annotation,
+      argumentPosition(inputName),
+    );
+    const selector = "countPlural";
+    const parsed = Object.entries(units).map(([key, unit]) => ({
+      key,
+      parsed: parsePattern(unit.stringUnit.value),
+    }));
+    return {
+      declarations: [
+        { type: "input-variable", name: inputName } as Declaration,
+        pluralDeclaration(selector, inputName, {
+          appleFormatSpecifier: format.specifier,
+          appleArgNum: String(format.position),
+          applePluralStyle: "direct",
+        }),
+        ...inputDeclarations(
+          parsed.flatMap(({ parsed }) => parsed.variables),
+          [inputName, selector],
+        ),
+      ],
+      selectors: [{ type: "variable-reference" as const, name: selector }],
+      variants: parsed.map(({ key, parsed }) => ({
+        matches: [match(selector, key)],
+        pattern: parsed.pattern,
+      })),
+    };
+  }
+  if (hasPlural) {
+    if (Object.keys(substitutions).length !== 1)
+      throw new Error(
+        `Apple .xcstrings entry "${id}" has multiple substitutions, which are not representable by one Inlang selector`,
+      );
+    const [name, substitution] = Object.entries(substitutions)[0]!;
+    if (!substitution?.variations?.plural)
+      throw new Error(
+        `Apple .xcstrings substitution "${name}" in "${id}" must contain plural variations`,
+      );
+    assertPrintfSpecifier(substitution.formatSpecifier, id);
+    assertVariationUnits(
+      substitution.variations.plural,
+      id,
+      "plural",
+      pluralCategories,
+    );
+    const argNum = substitution.argNum ?? 1;
+    if (!Number.isSafeInteger(argNum) || argNum < 1)
+      throw new Error(
+        `Invalid Apple .xcstrings argNum in substitution "${name}" of "${id}"`,
+      );
+    const inputName = `arg${argNum}`;
+    const template = requiredStringUnit(localization.stringUnit, id).value;
+    const token = `%#@${name}@`;
+    if (template.split(token).length !== 2)
+      throw new Error(
+        `Apple .xcstrings substitution template in "${id}" must contain exactly one ${token}`,
+      );
+    const [prefix, suffix] = template.split(token);
+    const parsedPrefix = parsePattern(prefix!);
+    const parsedSuffix = parsePattern(suffix!);
+    const parsed = Object.entries(substitution.variations.plural).map(
+      ([key, unit]) => ({
+        key,
+        parsed: parsePattern(unit.stringUnit.value),
+      }),
+    );
+    return {
+      declarations: [
+        { type: "input-variable", name: inputName } as Declaration,
+        pluralDeclaration(name, inputName, {
+          appleFormatSpecifier: substitution.formatSpecifier,
+          appleArgNum: String(argNum),
+          applePluralStyle: "substitution",
+        }),
+        ...inputDeclarations(
+          [
+            ...parsedPrefix.variables,
+            ...parsed.flatMap(({ parsed }) => parsed.variables),
+            ...parsedSuffix.variables,
+          ],
+          [inputName, name],
+        ),
+      ],
+      selectors: [{ type: "variable-reference" as const, name }],
+      variants: parsed.map(({ key, parsed }) => ({
+        matches: [match(name, key)],
+        pattern: [
+          ...parsedPrefix.pattern,
+          ...parsed.pattern,
+          ...parsedSuffix.pattern,
+        ],
+      })),
+    };
+  }
+  const parsed = parsePattern(
+    requiredStringUnit(localization.stringUnit, id).value,
+  );
+  return {
+    declarations: inputDeclarations(parsed.variables),
+    selectors: [],
+    variants: [{ matches: [], pattern: parsed.pattern }],
+  };
+}
+
+function exportCatalog({ bundles, messages, variants, settings }: ExportArgs) {
+  assertUniqueIds(bundles, "bundle");
+  assertUniqueIds(messages, "message");
+  const messageIds = new Set(messages.map((message) => message.id));
+  for (const variant of variants)
+    if (!messageIds.has(variant.messageId))
+      throw new Error(
+        `Apple .xcstrings variant "${variant.id}" references missing message "${variant.messageId}"`,
+      );
+  const strings: Catalog["strings"] = {};
+  for (const bundle of bundles) {
+    const bundleMessages = messages.filter(
+      (message) => message.bundleId === bundle.id,
+    );
+    if (bundleMessages.length === 0) continue;
+    const localizations: Record<string, Localization> = {};
+    for (const message of bundleMessages) {
+      if (localizations[message.locale])
+        throw new Error(
+          `Duplicate Apple .xcstrings locale "${message.locale}" in "${bundle.id}"`,
+        );
+      localizations[message.locale] = exportLocalization(
+        bundle,
+        message,
+        variants,
+      );
+    }
+    strings[bundle.id] = { extractionState: "manual", localizations };
+  }
+  const catalog: Catalog = {
+    sourceLanguage: settings.baseLocale,
+    strings: Object.fromEntries(
+      Object.entries(strings).sort(([a], [b]) => a.localeCompare(b)),
+    ),
+    version: "1.0",
+  };
+  return [
+    {
+      locale: settings.baseLocale,
+      name: settings[PLUGIN_KEY]?.pathPattern ?? "Localizable.xcstrings",
+      content: new TextEncoder().encode(
+        `${JSON.stringify(catalog, null, 2)}\n`,
+      ),
+    },
+  ];
+}
+
+function exportLocalization(
+  bundle: Bundle,
+  message: Message,
+  variants: Variant[],
+): Localization {
+  const messageVariants = variants.filter(
+    (variant) => variant.messageId === message.id,
+  );
+  if (message.selectors.length === 0) {
+    if (
+      messageVariants.length !== 1 ||
+      messageVariants[0]!.matches.length !== 0
+    )
+      throw new Error(
+        `Apple .xcstrings requires one unconditional variant in "${bundle.id}"`,
+      );
+    return {
+      stringUnit: translated(
+        serializePattern(messageVariants[0]!.pattern, bundle),
+      ),
+    };
+  }
+  if (message.selectors.length !== 1)
+    throw new Error(
+      `Apple .xcstrings currently supports one selector per message (bundle "${bundle.id}")`,
+    );
+  const selector = message.selectors[0]!.name;
+  const plural = pluralInput(bundle, selector);
+  const units = variationUnits(bundle, messageVariants, selector);
+  if (plural) {
+    for (const key of Object.keys(units))
+      if (!pluralCategories.has(key))
+        throw new Error(
+          `Unsupported Apple plural category "${key}" in "${bundle.id}"`,
+        );
+    const pluralDeclaration = bundle.declarations.find(
+      (declaration) => declaration.name === selector,
+    );
+    const annotation =
+      pluralDeclaration?.type === "local-variable"
+        ? pluralDeclaration.value.annotation
+        : undefined;
+    const storedSpecifier = literalOption(annotation, "appleFormatSpecifier");
+    const storedArgNum = literalOption(annotation, "appleArgNum");
+    const pluralStyle = literalOption(annotation, "applePluralStyle");
+    const argNum = storedArgNum
+      ? Number(storedArgNum)
+      : inputPosition(bundle, plural);
+    const formatSpecifier = storedSpecifier ?? "lld";
+    if (!Number.isSafeInteger(argNum) || argNum < 1)
+      throw new Error(
+        `Invalid Apple plural argument position in "${bundle.id}"`,
+      );
+    assertPrintfSpecifier(formatSpecifier, bundle.id);
+    if (pluralStyle === "direct") {
+      return { variations: { plural: units } };
+    }
+    return {
+      stringUnit: translated(`%#@${selector}@`),
+      substitutions: {
+        [selector]: {
+          argNum,
+          formatSpecifier,
+          variations: { plural: units },
+        },
+      },
+    };
+  }
+  if (selector === "device") return { variations: { device: units } };
+  throw new Error(
+    `Apple .xcstrings cannot represent selector "${selector}" in "${bundle.id}"`,
+  );
+}
+
+function variationUnits(bundle: Bundle, variants: Variant[], selector: string) {
+  const units: Record<string, VariationUnit> = {};
+  let catchalls = 0;
+  for (const variant of variants) {
+    if (variant.matches.length !== 1 || variant.matches[0]!.key !== selector)
+      throw new Error(`Invalid Apple .xcstrings matches in "${bundle.id}"`);
+    const matchValue =
+      variant.matches[0]!.type === "catchall-match"
+        ? "other"
+        : variant.matches[0]!.value;
+    if (variant.matches[0]!.type === "catchall-match") catchalls++;
+    if (units[matchValue])
+      throw new Error(
+        `Duplicate Apple variation "${matchValue}" in "${bundle.id}"`,
+      );
+    units[matchValue] = {
+      stringUnit: translated(
+        serializePattern(variant.pattern, bundle, {
+          variableName: pluralInput(bundle, selector),
+          specifier: pluralSpecifier(bundle, selector),
+        }),
+      ),
+    };
+  }
+  if (catchalls !== 1 || !units.other)
+    throw new Error(
+      `Apple variations in "${bundle.id}" require exactly one catchall/other variant`,
+    );
+  return units;
+}
+
+function wrapPattern(
+  prefix: string,
+  pattern: Pattern,
+  suffix: string,
+): Pattern {
+  return [
+    ...(prefix ? [{ type: "text" as const, value: prefix }] : []),
+    ...pattern,
+    ...(suffix ? [{ type: "text" as const, value: suffix }] : []),
+  ];
+}
+
+function parseCatalog(content: Uint8Array): Catalog {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(new TextDecoder().decode(content));
+  } catch (error) {
+    throw new Error(
+      `Invalid Apple .xcstrings JSON: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  assertObject(parsed, "Apple .xcstrings catalog");
+  if (parsed.version !== "1.0" || typeof parsed.sourceLanguage !== "string")
+    throw new Error(
+      "Apple .xcstrings requires version 1.0 and a sourceLanguage",
+    );
+  assertObject(parsed.strings, "Apple .xcstrings strings");
+  return parsed as Catalog;
+}
+
+function parsePattern(value: string) {
+  const pattern: Pattern = [];
+  const variables: string[] = [];
+  const regex =
+    /^%(?:(\d+)\$([-+# 0,(]*\d*(?:\.\d+)?(?:hh|h|ll|l|q|z|t|j)?[diuoxXfFeEgGaAcCsSp@])|((?:hh|h|ll|l|q|z|t|j)?[diuoxXfFeEgGaAcCsSp@]))/;
+  if (!hasPrintfExpression(value, regex))
+    return { pattern: [{ type: "text", value }] as Pattern, variables };
+  let cursor = 0;
+  let implicit = 0;
+  let sawImplicit = false;
+  let sawExplicit = false;
+  const specifiersByPosition = new Map<number, string>();
+  let text = "";
+  while (cursor < value.length) {
+    if (value.startsWith("%%", cursor)) {
+      text += "%";
+      cursor += 2;
+      continue;
+    }
+    const found = value.slice(cursor).match(regex);
+    if (!found) {
+      if (value[cursor] === "%")
+        throw new Error(
+          `Unsupported Apple format specifier near "${value.slice(cursor, cursor + 12)}"`,
+        );
+      text += value[cursor++];
+      continue;
+    }
+    if (text) {
+      pattern.push({ type: "text", value: text });
+      text = "";
+    }
+    if (found[1]) sawExplicit = true;
+    else sawImplicit = true;
+    if (sawExplicit && sawImplicit)
+      throw new Error(
+        `Apple format strings cannot mix positional and implicit specifiers in "${value}"`,
+      );
+    const position = found[1] ? Number(found[1]) : ++implicit;
+    const specifier = found[2] ?? found[3]!;
+    const previousSpecifier = specifiersByPosition.get(position);
+    if (previousSpecifier && previousSpecifier !== specifier)
+      throw new Error(
+        `Apple argument ${position} uses incompatible specifiers "${previousSpecifier}" and "${specifier}"`,
+      );
+    specifiersByPosition.set(position, specifier);
+    const name = `arg${position}`;
+    variables.push(name);
+    pattern.push({
+      type: "expression",
+      arg: { type: "variable-reference", name },
+      annotation: {
+        type: "function-reference",
+        name: "apple-printf",
+        options: [
+          { name: "specifier", value: { type: "literal", value: specifier } },
+          {
+            name: "position",
+            value: { type: "literal", value: String(position) },
+          },
+        ],
+      },
+    });
+    cursor += found[0].length;
+  }
+  if (text) pattern.push({ type: "text", value: text });
+  return { pattern, variables };
+}
+
+function serializePattern(
+  pattern: Pattern,
+  bundle: Bundle,
+  numericDefault?: {
+    variableName: string | undefined;
+    specifier: string | undefined;
+  },
+) {
+  const formatted = pattern.some((part) => part.type === "expression");
+  return pattern
+    .map((part) => {
+      if (part.type === "text")
+        return formatted ? part.value.replace(/%/g, "%%") : part.value;
+      if (part.type !== "expression" || part.arg.type !== "variable-reference")
+        throw new Error(
+          `Apple .xcstrings only supports plain variable expressions (bundle "${bundle.id}")`,
+        );
+      const fallback = inputPosition(bundle, part.arg.name);
+      const format =
+        !part.annotation &&
+        numericDefault?.variableName === part.arg.name &&
+        numericDefault.specifier
+          ? { position: fallback, specifier: numericDefault.specifier }
+          : printfFormat(part.annotation, fallback);
+      return `%${format.position}$${format.specifier}`;
+    })
+    .join("");
+}
+
+function printfFormat(
+  annotation: Extract<Pattern[number], { type: "expression" }>["annotation"],
+  fallback: number,
+) {
+  if (!annotation) return { position: fallback, specifier: "@" };
+  if (
+    annotation.type !== "function-reference" ||
+    annotation.name !== "apple-printf"
+  )
+    throw new Error(
+      `Apple .xcstrings does not support the ${annotation.type} annotation`,
+    );
+  const option = (name: string) =>
+    annotation.options.find((candidate) => candidate.name === name)?.value;
+  const specifier = option("specifier");
+  const position = option("position");
+  if (
+    specifier?.type !== "literal" ||
+    position?.type !== "literal" ||
+    !/^\d+$/.test(position.value)
+  )
+    throw new Error("Invalid Apple printf annotation");
+  assertPrintfSpecifier(specifier.value, "pattern");
+  return { specifier: specifier.value, position: Number(position.value) };
+}
+
+function literalOption(
+  annotation: Extract<Pattern[number], { type: "expression" }>["annotation"],
+  name: string,
+) {
+  if (annotation?.type !== "function-reference") return undefined;
+  const value = annotation.options.find(
+    (option) => option.name === name,
+  )?.value;
+  return value?.type === "literal" ? value.value : undefined;
+}
+
+function assertUniqueIds(rows: Array<{ id: string }>, kind: string) {
+  const seen = new Set<string>();
+  for (const row of rows) {
+    if (seen.has(row.id))
+      throw new Error(`Duplicate Apple .xcstrings ${kind} id "${row.id}"`);
+    seen.add(row.id);
+  }
+}
+
+function pluralInput(bundle: Bundle, selector: string) {
+  const declaration = bundle.declarations.find(
+    (candidate) => candidate.name === selector,
+  );
+  if (
+    declaration?.type !== "local-variable" ||
+    declaration.value.annotation?.type !== "function-reference" ||
+    declaration.value.annotation.name !== "plural" ||
+    declaration.value.arg.type !== "variable-reference"
+  )
+    return undefined;
+  for (const option of declaration.value.annotation.options) {
+    if (!option.name.startsWith("apple"))
+      throw new Error(
+        `Apple .xcstrings does not support plural option "${option.name}" in "${bundle.id}"`,
+      );
+  }
+  return declaration.value.arg.name;
+}
+
+function pluralSpecifier(bundle: Bundle, selector: string) {
+  const declaration = bundle.declarations.find(
+    (candidate) => candidate.name === selector,
+  );
+  if (declaration?.type !== "local-variable") return undefined;
+  return (
+    literalOption(declaration.value.annotation, "appleFormatSpecifier") ?? "lld"
+  );
+}
+
+function pluralDeclaration(
+  name: string,
+  inputName: string,
+  options: Record<string, string>,
+) {
+  return {
+    type: "local-variable",
+    name,
+    value: {
+      type: "expression",
+      arg: { type: "variable-reference", name: inputName },
+      annotation: {
+        type: "function-reference",
+        name: "plural",
+        options: Object.entries(options).map(([optionName, value]) => ({
+          name: optionName,
+          value: { type: "literal", value },
+        })),
+      },
+    },
+  } as Declaration;
+}
+
+function inputPosition(bundle: Bundle, name: string) {
+  const inputs = bundle.declarations.filter(
+    (declaration) => declaration.type === "input-variable",
+  );
+  const position =
+    inputs.findIndex((declaration) => declaration.name === name) + 1;
+  if (position === 0)
+    throw new Error(`Variable "${name}" is not declared in "${bundle.id}"`);
+  return position;
+}
+
+function mergeDeclarations(bundle: Bundle, declarations: Declaration[]) {
+  const byName = new Map(
+    bundle.declarations.map((declaration) => [declaration.name, declaration]),
+  );
+  for (const declaration of declarations) {
+    const current = byName.get(declaration.name);
+    if (current && JSON.stringify(current) !== JSON.stringify(declaration))
+      throw new Error(
+        `Inconsistent declaration "${declaration.name}" across Apple catalog locales in "${bundle.id}"`,
+      );
+    byName.set(declaration.name, declaration);
+  }
+  return { ...bundle, declarations: [...byName.values()] };
+}
+
+function inputDeclarations(names: string[], excluded: string[] = []) {
+  return [...new Set(names)]
+    .filter((name) => !excluded.includes(name))
+    .sort(
+      (a, b) => argumentPosition(a) - argumentPosition(b) || a.localeCompare(b),
+    )
+    .map((name) => ({ type: "input-variable", name }) as Declaration);
+}
+function argumentPosition(name: string) {
+  const match = /^arg(\d+)$/.exec(name);
+  return match ? Number(match[1]) : Number.MAX_SAFE_INTEGER;
+}
+function translated(value: string): StringUnit {
+  return { state: "translated", value };
+}
+function match(key: string, value: string) {
+  return value === "other"
+    ? { type: "catchall-match" as const, key }
+    : { type: "literal-match" as const, key, value };
+}
+function requiredStringUnit(unit: StringUnit | undefined, id: string) {
+  if (!unit || typeof unit.value !== "string")
+    throw new Error(`Missing stringUnit value in "${id}"`);
+  return unit;
+}
+function assertVariationUnits(
+  units: Record<string, VariationUnit>,
+  id: string,
+  kind: string,
+  allowed: Set<string> | undefined,
+) {
+  assertObject(units, `${kind} variations in "${id}"`);
+  if (Object.keys(units).length === 0 || !units.other)
+    throw new Error(`Apple ${kind} variations in "${id}" require "other"`);
+  for (const [key, unit] of Object.entries(units)) {
+    if (allowed && !allowed.has(key))
+      throw new Error(`Unsupported Apple ${kind} value "${key}" in "${id}"`);
+    requiredStringUnit(unit?.stringUnit, id);
+  }
+}
+function assertPrintfSpecifier(value: string, id: string) {
+  if (
+    !/^[-+# 0,(]*\d*(?:\.\d+)?(?:hh|h|ll|l|q|z|t|j)?[diuoxXfFeEgGaAcCsSp@]$/.test(
+      value,
+    )
+  )
+    throw new Error(`Invalid Apple printf specifier "${value}" in "${id}"`);
+}
+function assertObject(
+  value: unknown,
+  label: string,
+): asserts value is Record<string, any> {
+  if (!value || typeof value !== "object" || Array.isArray(value))
+    throw new Error(`Invalid ${label}`);
+}
+function hasPrintfExpression(source: string, regex: RegExp) {
+  for (let cursor = 0; cursor < source.length; cursor++) {
+    if (source.startsWith("%%", cursor)) {
+      cursor++;
+      continue;
+    }
+    if (source[cursor] === "%" && regex.test(source.slice(cursor))) return true;
+  }
+  return false;
+}

--- a/packages/plugins/apple-xcstrings/src/plugin.ts
+++ b/packages/plugins/apple-xcstrings/src/plugin.ts
@@ -224,7 +224,10 @@ function importLocalization(id: string, localization: Localization) {
       );
     const [prefix, suffix] = template.split(token);
     const parsedPrefix = parsePattern(prefix!);
-    const parsedSuffix = parsePattern(suffix!);
+    const parsedSuffix = parsePattern(
+      suffix!,
+      Math.max(argNum + 1, parsedPrefix.nextImplicit),
+    );
     const parsed = Object.entries(substitution.variations.plural).map(
       ([key, unit]) => ({
         key,
@@ -467,10 +470,13 @@ function inferDirectPluralFormat(
       argumentPosition(expression.arg.name),
     );
   });
-  const first = formats[0]!;
+  const numericFormats = formats.filter((format) =>
+    /(?:hh|h|ll|l|q|z|t|j)?[diuoxXfFeEgGaA]$/.test(format.specifier),
+  );
+  const first = numericFormats[0]!;
   if (
-    !/(?:hh|h|ll|l|q|z|t|j)?[diuoxXfFeEgGaA]$/.test(first.specifier) ||
-    formats.some(
+    !first ||
+    numericFormats.some(
       (format) =>
         format.position !== first.position ||
         format.specifier !== first.specifier,
@@ -506,7 +512,11 @@ function parsePattern(value: string, implicitStart = 1) {
   const regex =
     /^%(?:(\d+)\$([-+# 0,(]*\d*(?:\.\d+)?(?:hh|h|ll|l|q|z|t|j)?[diuoxXfFeEgGaAcCsSp@])|((?:hh|h|ll|l|q|z|t|j)?[diuoxXfFeEgGaAcCsSp@]))/;
   if (!hasPrintfExpression(value, regex))
-    return { pattern: [{ type: "text", value }] as Pattern, variables };
+    return {
+      pattern: [{ type: "text", value }] as Pattern,
+      variables,
+      nextImplicit: implicitStart,
+    };
   let cursor = 0;
   let implicit = implicitStart - 1;
   let sawImplicit = false;
@@ -566,7 +576,7 @@ function parsePattern(value: string, implicitStart = 1) {
     cursor += found[0].length;
   }
   if (text) pattern.push({ type: "text", value: text });
-  return { pattern, variables };
+  return { pattern, variables, nextImplicit: implicit + 1 };
 }
 
 function serializePattern(

--- a/packages/plugins/apple-xcstrings/src/plugin.ts
+++ b/packages/plugins/apple-xcstrings/src/plugin.ts
@@ -460,11 +460,13 @@ function inferDirectPluralFormat(
   const sourceExpressions = sourcePattern.filter(
     (part) => part.type === "expression",
   );
-  const candidates = sourceExpressions.length
+  const variantExpressions = variants.flatMap(({ parsed }) =>
+    parsed.pattern.filter((part) => part.type === "expression"),
+  );
+  const sourceNumeric = numericExpressionFormats(sourceExpressions);
+  const candidates = sourceNumeric.length
     ? sourceExpressions
-    : variants.flatMap(({ parsed }) =>
-        parsed.pattern.filter((part) => part.type === "expression"),
-      );
+    : variantExpressions;
   if (!candidates.length)
     throw new Error(
       `Direct Apple plural "${id}" must contain a numeric printf argument in its key or variants`,
@@ -493,6 +495,19 @@ function inferDirectPluralFormat(
       `Direct Apple plural "${id}" must use one consistent numeric argument`,
     );
   return first;
+}
+
+function numericExpressionFormats(
+  expressions: Array<Extract<Pattern[number], { type: "expression" }>>,
+) {
+  return expressions.filter((expression) => {
+    if (expression.arg.type !== "variable-reference") return false;
+    const format = printfFormat(
+      expression.annotation,
+      argumentPosition(expression.arg.name),
+    );
+    return /(?:hh|h|ll|l|q|z|t|j)?[diuoxXfFeEgGaA]$/.test(format.specifier);
+  });
 }
 
 function parseCatalog(content: Uint8Array): Catalog {

--- a/packages/plugins/apple-xcstrings/src/plugin.ts
+++ b/packages/plugins/apple-xcstrings/src/plugin.ts
@@ -698,11 +698,16 @@ function pluralDeclaration(
 }
 
 function inputPosition(bundle: Bundle, name: string) {
-  const namedPosition = argumentPosition(name);
-  if (namedPosition !== Number.MAX_SAFE_INTEGER) return namedPosition;
   const inputs = bundle.declarations.filter(
     (declaration) => declaration.type === "input-variable",
   );
+  if (!inputs.some((declaration) => declaration.name === name))
+    throw new Error(`Variable "${name}" is not declared in "${bundle.id}"`);
+  const namedMatch = /^arg([1-9]\d*)$/.exec(name);
+  if (namedMatch) {
+    const namedPosition = Number(namedMatch[1]);
+    if (Number.isSafeInteger(namedPosition)) return namedPosition;
+  }
   const position =
     inputs.findIndex((declaration) => declaration.name === name) + 1;
   if (position === 0)

--- a/packages/plugins/apple-xcstrings/src/settings.ts
+++ b/packages/plugins/apple-xcstrings/src/settings.ts
@@ -1,0 +1,9 @@
+import { Type, type Static } from "@sinclair/typebox";
+
+export type PluginSettings = Static<typeof PluginSettings>;
+export const PluginSettings = Type.Object({
+  pathPattern: Type.String({
+    pattern: ".*\\.xcstrings$",
+    examples: ["./Localizations/Localizable.xcstrings"],
+  }),
+});

--- a/packages/plugins/apple-xcstrings/tsconfig.build.json
+++ b/packages/plugins/apple-xcstrings/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"],
+  "compilerOptions": { "rootDir": "src" }
+}

--- a/packages/plugins/apple-xcstrings/tsconfig.json
+++ b/packages/plugins/apple-xcstrings/tsconfig.json
@@ -1,0 +1,1 @@
+{ "extends": "@inlang/tsconfig/default", "include": ["src/**/*"] }

--- a/packages/plugins/i18next/build.js
+++ b/packages/plugins/i18next/build.js
@@ -1,4 +1,5 @@
 import { context } from "esbuild";
+import { execFileSync } from "node:child_process";
 
 // eslint-disable-next-line no-undef
 const isProduction = process.env.NODE_ENV === "production";
@@ -21,10 +22,24 @@ const ctx = await context({
 });
 
 if (isProduction === false) {
-  await ctx.watch();
-  // eslint-disable-next-line no-undef
-  console.info("Watching for changes...");
+	await ctx.watch();
+	// eslint-disable-next-line no-undef
+	console.info("Watching for changes...");
 } else {
-  await ctx.rebuild();
-  await ctx.dispose();
+	await ctx.rebuild();
+	await ctx.dispose();
+	execFileSync(
+		"tsc",
+		[
+			"--emitDeclarationOnly",
+			"--declaration",
+			"--declarationMap",
+			"false",
+			"--outDir",
+			"dist",
+			"--noEmit",
+			"false",
+		],
+		{ stdio: "inherit" }
+	);
 }

--- a/packages/plugins/i18next/src/import-export/exportFiles.ts
+++ b/packages/plugins/i18next/src/import-export/exportFiles.ts
@@ -85,6 +85,20 @@ function serializeMessage(
 	variants: Variant[],
 	settings?: PluginSettings
 ): Array<{ key: string; value: string; locale: string }> {
+	const supportedSelectors = new Set([
+		"context",
+		"count",
+		"countPlural",
+		"countOrdinal",
+	]);
+	const unsupportedSelector = message.selectors.find(
+		(selector) => !supportedSelectors.has(selector.name)
+	);
+	if (unsupportedSelector) {
+		throw new Error(
+			`i18next export cannot represent selector "${unsupportedSelector.name}" in bundle "${bundle.id}"`
+		);
+	}
 	const result = [];
 
 	// emit base keys first and the most specific keys last, mirroring how

--- a/packages/plugins/i18next/src/import-export/selector-validation.test.ts
+++ b/packages/plugins/i18next/src/import-export/selector-validation.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "vitest";
+import { plugin } from "../plugin.js";
+
+test("rejects unsupported selectors rather than silently dropping variants", async () => {
+	await expect(
+		plugin.exportFiles!({
+			settings: {
+				baseLocale: "en",
+				locales: ["en"],
+				modules: [],
+				"plugin.inlang.i18next": { pathPattern: "./{locale}.json" },
+			},
+			bundles: [{ id: "greeting", declarations: [] }],
+			messages: [
+				{
+					id: "message",
+					bundleId: "greeting",
+					locale: "en",
+					selectors: [{ type: "variable-reference", name: "audience" }],
+				},
+			],
+			variants: [
+				{
+					id: "formal",
+					messageId: "message",
+					matches: [
+						{ type: "literal-match", key: "audience", value: "formal" },
+					],
+					pattern: [{ type: "text", value: "Welcome" }],
+				},
+				{
+					id: "fallback",
+					messageId: "message",
+					matches: [{ type: "catchall-match", key: "audience" }],
+					pattern: [{ type: "text", value: "Hi" }],
+				},
+			],
+		})
+	).rejects.toThrow('cannot represent selector "audience"');
+});

--- a/packages/plugins/inlang-message-format/CHANGELOG.md
+++ b/packages/plugins/inlang-message-format/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @inlang/plugin-message-format
 
+## 4.4.2
+
+### Patch Changes
+
+- 9c719b3: Speed up importing large message-format projects by indexing bundles by id.
+
 ## 4.4.1
 
 ### Patch Changes

--- a/packages/plugins/inlang-message-format/package.json
+++ b/packages/plugins/inlang-message-format/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@inlang/plugin-message-format",
-	"version": "4.4.1",
+	"version": "4.4.2",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/plugins/inlang-message-format/src/import-export/importFiles.bench.ts
+++ b/packages/plugins/inlang-message-format/src/import-export/importFiles.bench.ts
@@ -1,0 +1,50 @@
+import { bench, describe } from "vitest";
+import { importFiles } from "./importFiles.js";
+
+function makeFiles(locales: number, keys: number) {
+	const encoder = new TextEncoder();
+	const files = [];
+
+	for (let localeIndex = 0; localeIndex < locales; localeIndex++) {
+		const locale = `locale_${localeIndex}`;
+		const json: Record<string, string> = {};
+
+		for (let keyIndex = 0; keyIndex < keys; keyIndex++) {
+			const key = `message_${keyIndex}`;
+			if (keyIndex % 5 === 0) {
+				json[key] = `Hello {name} from ${locale} (#${keyIndex})`;
+			} else if (keyIndex % 5 === 1) {
+				json[key] = `Count is {count} in ${locale}`;
+			} else {
+				json[key] = `Static text ${locale} ${keyIndex}`;
+			}
+		}
+
+		files.push({
+			locale,
+			content: encoder.encode(JSON.stringify(json)),
+		});
+	}
+
+	return files;
+}
+
+for (const [locales, keys] of [
+	[30, 5000],
+	[10, 1000],
+	[1, 200],
+]) {
+	const files = makeFiles(locales, keys);
+	describe(`importFiles (${locales} locales × ${keys} keys)`, () => {
+		bench(
+			"Import files",
+			async () => {
+				await importFiles({
+					settings: {} as any,
+					files,
+				});
+			},
+			{ time: 1000 }
+		);
+	});
+}

--- a/packages/plugins/inlang-message-format/src/import-export/importFiles.bench.ts
+++ b/packages/plugins/inlang-message-format/src/import-export/importFiles.bench.ts
@@ -29,11 +29,13 @@ function makeFiles(locales: number, keys: number) {
 	return files;
 }
 
-for (const [locales, keys] of [
+const benchmarks: [number, number][] = [
 	[30, 5000],
 	[10, 1000],
 	[1, 200],
-]) {
+];
+
+for (const [locales, keys] of benchmarks) {
 	const files = makeFiles(locales, keys);
 	describe(`importFiles (${locales} locales × ${keys} keys)`, () => {
 		bench(

--- a/packages/plugins/inlang-message-format/src/import-export/importFiles.ts
+++ b/packages/plugins/inlang-message-format/src/import-export/importFiles.ts
@@ -23,6 +23,7 @@ export const importFiles: NonNullable<(typeof plugin)["importFiles"]> = async ({
 	files,
 }) => {
 	const bundles: Bundle[] = [];
+	const bundlesById = new Map<string, Bundle>();
 	const messages: MessageImport[] = [];
 	const variants: VariantImport[] = [];
 
@@ -38,9 +39,10 @@ export const importFiles: NonNullable<(typeof plugin)["importFiles"]> = async ({
 			messages.push(result.message);
 			variants.push(...result.variants);
 
-			const existingBundle = bundles.find((b) => b.id === result.bundle.id);
+			const existingBundle = bundlesById.get(result.bundle.id);
 			if (existingBundle === undefined) {
 				bundles.push(result.bundle);
+				bundlesById.set(result.bundle.id, result.bundle);
 			} else {
 				// merge declarations without duplicates
 				existingBundle.declarations = unique([

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -40,7 +40,7 @@
 		"node": ">=20.0.0"
 	},
 	"dependencies": {
-		"@lix-js/sdk": "0.11.0",
+		"@lix-js/sdk": "0.12.0",
 		"@sinclair/typebox": "^0.31.17",
 		"kysely": "^0.28.12",
 		"sqlite-wasm-kysely": "0.3.0",

--- a/packages/sdk/src/database/lixDialect.ts
+++ b/packages/sdk/src/database/lixDialect.ts
@@ -153,7 +153,9 @@ function prepareLixQuery(compiledSql: string): {
 	sql: string;
 	parameterPositions: number[];
 } {
-	const sql = rewriteTableNames(omitPrimaryKeyAssignments(compiledSql));
+	const sql = ensureGeneratedPrimaryKey(
+		rewriteTableNames(omitPrimaryKeyAssignments(compiledSql))
+	);
 	const compacted = compactSqlParameters(sql);
 	return {
 		sql: compacted.sql,
@@ -161,12 +163,36 @@ function prepareLixQuery(compiledSql: string): {
 	};
 }
 
+function ensureGeneratedPrimaryKey(sql: string): string {
+	const tables = "(?:inlang_bundle|inlang_message|inlang_variant)";
+	const insertWithColumns = new RegExp(
+		`^(insert\\s+into\\s+"${tables}"\\s*)\\(([^)]*)\\)(\\s+values\\s*)\\(([^)]*)\\)(.*)$`,
+		"i"
+	);
+	const withColumns = sql.match(insertWithColumns);
+	if (withColumns && !/(?:^|,)\s*"id"\s*(?:,|$)/i.test(withColumns[2] ?? "")) {
+		return `${withColumns[1]}("id", ${withColumns[2]})${withColumns[3]}(CAST(uuidv7() AS TEXT), ${withColumns[4]})${withColumns[5]}`;
+	}
+
+	const insertDefaultValues = new RegExp(
+		`^(insert\\s+into\\s+"${tables}"\\s*)default\\s+values(.*)$`,
+		"i"
+	);
+	const defaultValues = sql.match(insertDefaultValues);
+	if (defaultValues) {
+		return `${defaultValues[1]}("id") VALUES (CAST(uuidv7() AS TEXT))${defaultValues[2]}`;
+	}
+	return sql;
+}
+
 function rewriteTableNames(sql: string): string {
 	return sql
 		.replaceAll('"file"', '"lix_file"')
 		.replaceAll('"bundle"', '"inlang_bundle"')
 		.replaceAll('"message"', '"inlang_message"')
-		.replaceAll('"variant"', '"inlang_variant"');
+		.replaceAll('"variant"', '"inlang_variant"')
+		.replaceAll('"bundleId"', '"bundle_id"')
+		.replaceAll('"messageId"', '"message_id"');
 }
 
 function omitPrimaryKeyAssignments(sql: string): string {
@@ -199,7 +225,16 @@ function omitPrimaryKeyAssignments(sql: string): string {
 
 function publicRow(row: Record<string, unknown>): Record<string, unknown> {
 	return Object.fromEntries(
-		Object.entries(row).filter(([column]) => !column.startsWith("lixcol_"))
+		Object.entries(row)
+			.filter(([column]) => !column.startsWith("lixcol_"))
+			.map(([column, value]) => [
+				column === "bundle_id"
+					? "bundleId"
+					: column === "message_id"
+						? "messageId"
+						: column,
+				value,
+			])
 	);
 }
 

--- a/packages/sdk/src/database/lixDialect.ts
+++ b/packages/sdk/src/database/lixDialect.ts
@@ -109,12 +109,14 @@ class LixConnection implements DatabaseConnection {
 		const executor = this.#transaction ?? this.#lix;
 		let prepared = this.#preparedQueries.get(compiledQuery.sql);
 		if (!prepared) {
-			prepared = prepareLixQuery(compiledQuery.sql);
+			const nextPrepared = prepareLixQuery(compiledQuery.sql);
+			prepared = nextPrepared;
 			this.#preparedQueries.set(compiledQuery.sql, prepared);
 		}
 		const parameters = prepared.parameterPositions.map(
 			(position) => compiledQuery.parameters[position - 1]
 		);
+		encodeIdentityParameters(parameters, prepared.identityParameterPositions);
 		const result = await executor.execute(
 			prepared.sql,
 			parameters as SqlParam[]
@@ -133,6 +135,7 @@ class LixConnection implements DatabaseConnection {
 type PreparedLixQuery = {
 	sql: string;
 	parameterPositions: number[];
+	identityParameterPositions: number[];
 };
 
 /** Convert Kysely's compiled query to the one Lix SQL/parameter contract. */
@@ -143,16 +146,14 @@ export function compileLixQuery(
 	const parameters = prepared.parameterPositions.map(
 		(position) => compiledQuery.parameters[position - 1]
 	);
+	encodeIdentityParameters(parameters, prepared.identityParameterPositions);
 	return {
 		sql: prepared.sql,
 		params: parameters as SqlParam[],
 	};
 }
 
-function prepareLixQuery(compiledSql: string): {
-	sql: string;
-	parameterPositions: number[];
-} {
+function prepareLixQuery(compiledSql: string): PreparedLixQuery {
 	const sql = ensureGeneratedPrimaryKey(
 		rewriteTableNames(omitPrimaryKeyAssignments(compiledSql))
 	);
@@ -160,18 +161,30 @@ function prepareLixQuery(compiledSql: string): {
 	return {
 		sql: compacted.sql,
 		parameterPositions: compacted.positions,
+		identityParameterPositions: findIdentityParameterPositions(compacted.sql),
 	};
 }
 
 function ensureGeneratedPrimaryKey(sql: string): string {
 	const tables = "(?:inlang_bundle|inlang_message|inlang_variant)";
 	const insertWithColumns = new RegExp(
-		`^(insert\\s+into\\s+"${tables}"\\s*)\\(([^)]*)\\)(\\s+values\\s*)\\(([^)]*)\\)(.*)$`,
+		`^(insert\\s+into\\s+"${tables}"\\s*)\\(([^)]*)\\)(\\s+values\\s+)(.*)$`,
 		"i"
 	);
 	const withColumns = sql.match(insertWithColumns);
 	if (withColumns && !/(?:^|,)\s*"id"\s*(?:,|$)/i.test(withColumns[2] ?? "")) {
-		return `${withColumns[1]}("id", ${withColumns[2]})${withColumns[3]}(CAST(uuidv7() AS TEXT), ${withColumns[4]})${withColumns[5]}`;
+		const valuesAndTail = withColumns[4] ?? "";
+		const tailStart = valuesAndTail.search(/\s+(?:on\s+conflict|returning)\b/i);
+		const values =
+			tailStart === -1 ? valuesAndTail : valuesAndTail.slice(0, tailStart);
+		const tail = tailStart === -1 ? "" : valuesAndTail.slice(tailStart);
+		const generatedValues = values.replace(
+			/\(([^()]*)\)/g,
+			(_, row: string) => {
+				return `(CAST(uuidv7() AS TEXT), ${row})`;
+			}
+		);
+		return `${withColumns[1]}("id", ${withColumns[2]})${withColumns[3]}${generatedValues}${tail}`;
 	}
 
 	const insertDefaultValues = new RegExp(
@@ -233,9 +246,95 @@ function publicRow(row: Record<string, unknown>): Record<string, unknown> {
 					: column === "message_id"
 						? "messageId"
 						: column,
-				value,
+				isIdentityColumn(column) && typeof value === "string"
+					? decodeIdentity(value)
+					: value,
 			])
 	);
+}
+
+function isIdentityColumn(column: string): boolean {
+	return column === "id" || column === "bundle_id" || column === "message_id";
+}
+
+const encodedIdentityPrefix = "lixid1:";
+
+function encodeIdentity(value: string): string {
+	if (!value.includes("\0") && !value.startsWith(encodedIdentityPrefix)) {
+		return value;
+	}
+	const bytes = new TextEncoder().encode(value);
+	let binary = "";
+	for (const byte of bytes) binary += String.fromCharCode(byte);
+	return `${encodedIdentityPrefix}${btoa(binary)
+		.replaceAll("+", "-")
+		.replaceAll("/", "_")
+		.replace(/=+$/, "")}`;
+}
+
+function decodeIdentity(value: string): string {
+	if (!value.startsWith(encodedIdentityPrefix)) return value;
+	try {
+		const encoded = value
+			.slice(encodedIdentityPrefix.length)
+			.replaceAll("-", "+")
+			.replaceAll("_", "/");
+		const binary = atob(encoded + "=".repeat((4 - (encoded.length % 4)) % 4));
+		return new TextDecoder().decode(
+			Uint8Array.from(binary, (character) => character.charCodeAt(0))
+		);
+	} catch {
+		return value;
+	}
+}
+
+function encodeIdentityParameters(
+	parameters: unknown[],
+	positions: number[]
+): void {
+	for (const position of positions) {
+		const value = parameters[position - 1];
+		if (typeof value === "string")
+			parameters[position - 1] = encodeIdentity(value);
+	}
+}
+
+function findIdentityParameterPositions(sql: string): number[] {
+	const positions = new Set<number>();
+	const identityColumns = "(?:id|bundle_id|message_id)";
+	for (const match of sql.matchAll(
+		new RegExp(`"${identityColumns}"\\s*=\\s*\\$(\\d+)`, "gi")
+	)) {
+		positions.add(Number(match[1]));
+	}
+	for (const match of sql.matchAll(
+		new RegExp(`"${identityColumns}"\\s+in\\s*\\(([^)]*)\\)`, "gi")
+	)) {
+		for (const parameter of match[1]?.matchAll(/\$(\d+)/g) ?? []) {
+			positions.add(Number(parameter[1]));
+		}
+	}
+	const insert = sql.match(
+		/insert\s+into\s+"(?:inlang_bundle|inlang_message|inlang_variant)"\s*\(([^)]*)\)\s+values\s+([\s\S]*)/i
+	);
+	if (insert) {
+		const columns = [...(insert[1] ?? "").matchAll(/"([^"]+)"/g)]
+			.map((match) => match[1])
+			.filter((column): column is string => column !== undefined);
+		const identityIndexes = columns.flatMap((column, index) =>
+			isIdentityColumn(column) ? [index] : []
+		);
+		for (const row of (insert[2] ?? "").matchAll(/\(([^()]*)\)/g)) {
+			const values = [...(row[1] ?? "").matchAll(/\$(\d+)/g)].map((match) =>
+				Number(match[1])
+			);
+			for (const index of identityIndexes) {
+				const position = values[index];
+				if (position !== undefined) positions.add(position);
+			}
+		}
+	}
+	return [...positions].sort((left, right) => left - right);
 }
 
 function compactSqlParameters(sql: string): {

--- a/packages/sdk/src/database/registerSchemas.ts
+++ b/packages/sdk/src/database/registerSchemas.ts
@@ -1,4 +1,4 @@
-import type { Lix } from "@lix-js/sdk";
+import { Value, type Lix } from "@lix-js/sdk";
 import {
 	InlangBundleSchema,
 	InlangMessageSchema,
@@ -13,7 +13,7 @@ const schemas = [
 
 export async function registerInlangSchemas(lix: Lix): Promise<void> {
 	const registered = await lix.execute(
-		"SELECT lix_json_get_text(value, 'x-lix-key') AS schema_key FROM lix_registered_schema"
+		"SELECT value ->> 'key' AS schema_key FROM lix_registered_schema"
 	);
 	const registeredKeys = new Set(
 		registered.rows
@@ -22,10 +22,9 @@ export async function registerInlangSchemas(lix: Lix): Promise<void> {
 	);
 
 	for (const schema of schemas) {
-		if (registeredKeys.has(schema["x-lix-key"])) continue;
-		await lix.execute(
-			"INSERT INTO lix_registered_schema (value) VALUES (lix_json($1))",
-			[JSON.stringify(schema)]
-		);
+		if (registeredKeys.has(schema.key)) continue;
+		await lix.execute("INSERT INTO lix_registered_schema (value) VALUES ($1)", [
+			Value.jsonb(schema),
+		]);
 	}
 }

--- a/packages/sdk/src/import-export/importFiles.test.ts
+++ b/packages/sdk/src/import-export/importFiles.test.ts
@@ -4,6 +4,42 @@ import { loadProjectInMemory } from "../project/loadProjectInMemory.js";
 import { newProject } from "../project/newProject.js";
 import type { InlangPlugin } from "../plugin/schema.js";
 
+test("batch imports an unambiguous fresh project", async () => {
+	const project = await loadProjectInMemory({ blob: await newProject() });
+
+	const mockPlugin: InlangPlugin = {
+		key: "mock",
+		importFiles: async () => ({
+			bundles: [{ id: "mock-bundle" }],
+			messages: [
+				{ bundleId: "mock-bundle", locale: "en" },
+				{ bundleId: "mock-bundle", locale: "de" },
+			],
+			variants: [
+				{ messageBundleId: "mock-bundle", messageLocale: "en" },
+				{ messageBundleId: "mock-bundle", messageLocale: "de" },
+			],
+		}),
+	};
+
+	await importFiles({
+		db: project.db,
+		files: [{ content: new Uint8Array(), locale: "mock" }],
+		pluginKey: "mock",
+		plugins: [mockPlugin],
+		settings: {} as any,
+	});
+
+	const messages = await project.db.selectFrom("message").selectAll().execute();
+	const variants = await project.db.selectFrom("variant").selectAll().execute();
+
+	expect(messages).toHaveLength(2);
+	expect(variants).toHaveLength(2);
+	expect(new Set(variants.map((variant) => variant.messageId))).toEqual(
+		new Set(messages.map((message) => message.id))
+	);
+});
+
 test("it should insert a message as is if the id is provided", async () => {
 	const project = await loadProjectInMemory({ blob: await newProject() });
 

--- a/packages/sdk/src/import-export/importFiles.test.ts
+++ b/packages/sdk/src/import-export/importFiles.test.ts
@@ -40,6 +40,66 @@ test("batch imports an unambiguous fresh project", async () => {
 	);
 });
 
+test("batches rows with mixed optional columns", async () => {
+	const project = await loadProjectInMemory({ blob: await newProject() });
+
+	const mockPlugin: InlangPlugin = {
+		key: "mock",
+		importFiles: async () => ({
+			bundles: [{ id: "plain-bundle" }, { id: "rich-bundle" }],
+			messages: [
+				{ bundleId: "plain-bundle", locale: "en" },
+				{
+					bundleId: "rich-bundle",
+					locale: "de",
+					selectors: [{ type: "variable-reference", name: "platform" }],
+				},
+			],
+			variants: [
+				{ messageBundleId: "plain-bundle", messageLocale: "en" },
+				{
+					messageBundleId: "rich-bundle",
+					messageLocale: "de",
+					matches: [
+						{
+							type: "literal-match",
+							key: "platform",
+							value: "web",
+						},
+					],
+					pattern: [{ type: "text", value: "Hello web" }],
+				},
+			],
+		}),
+	};
+
+	await importFiles({
+		db: project.db,
+		files: [{ content: new Uint8Array(), locale: "mock" }],
+		pluginKey: "mock",
+		plugins: [mockPlugin],
+		settings: {} as any,
+	});
+
+	const messages = await project.db.selectFrom("message").selectAll().execute();
+	const variants = await project.db.selectFrom("variant").selectAll().execute();
+
+	expect(messages).toHaveLength(2);
+	expect(
+		messages.find((message) => message.locale === "en")?.selectors
+	).toStrictEqual([]);
+	expect(
+		messages.find((message) => message.locale === "de")?.selectors
+	).toStrictEqual([{ type: "variable-reference", name: "platform" }]);
+	expect(variants).toHaveLength(2);
+	expect(
+		variants.find((variant) => variant.matches.length === 0)?.pattern
+	).toStrictEqual([]);
+	expect(
+		variants.find((variant) => variant.matches.length > 0)?.pattern
+	).toStrictEqual([{ type: "text", value: "Hello web" }]);
+});
+
 test("preserves variant upsert semantics for duplicate matches", async () => {
 	const project = await loadProjectInMemory({ blob: await newProject() });
 

--- a/packages/sdk/src/import-export/importFiles.test.ts
+++ b/packages/sdk/src/import-export/importFiles.test.ts
@@ -40,6 +40,87 @@ test("batch imports an unambiguous fresh project", async () => {
 	);
 });
 
+test("preserves variant upsert semantics for duplicate matches", async () => {
+	const project = await loadProjectInMemory({ blob: await newProject() });
+
+	const mockPlugin: InlangPlugin = {
+		key: "mock",
+		importFiles: async () => ({
+			bundles: [{ id: "mock-bundle" }],
+			messages: [{ bundleId: "mock-bundle", locale: "en" }],
+			variants: [
+				{
+					messageBundleId: "mock-bundle",
+					messageLocale: "en",
+					matches: [],
+					pattern: [{ type: "text", value: "first" }],
+				},
+				{
+					messageBundleId: "mock-bundle",
+					messageLocale: "en",
+					matches: [],
+					pattern: [{ type: "text", value: "last" }],
+				},
+			],
+		}),
+	};
+
+	await importFiles({
+		db: project.db,
+		files: [{ content: new Uint8Array(), locale: "mock" }],
+		pluginKey: "mock",
+		plugins: [mockPlugin],
+		settings: {} as any,
+	});
+
+	const variants = await project.db.selectFrom("variant").selectAll().execute();
+
+	expect(variants).toHaveLength(1);
+	expect(variants[0]?.pattern).toStrictEqual([{ type: "text", value: "last" }]);
+});
+
+test("does not alias message references containing NUL characters", async () => {
+	const project = await loadProjectInMemory({ blob: await newProject() });
+
+	const mockPlugin: InlangPlugin = {
+		key: "mock",
+		importFiles: async () => ({
+			bundles: [{ id: "a" }, { id: "a\u0000b" }],
+			messages: [
+				{ bundleId: "a", locale: "b\u0000c" },
+				{ bundleId: "a\u0000b", locale: "c" },
+			],
+			variants: [
+				{
+					messageBundleId: "a",
+					messageLocale: "b\u0000c",
+					pattern: [{ type: "text", value: "first" }],
+				},
+				{
+					messageBundleId: "a\u0000b",
+					messageLocale: "c",
+					pattern: [{ type: "text", value: "second" }],
+				},
+			],
+		}),
+	};
+
+	await importFiles({
+		db: project.db,
+		files: [{ content: new Uint8Array(), locale: "mock" }],
+		pluginKey: "mock",
+		plugins: [mockPlugin],
+		settings: {} as any,
+	});
+
+	const messages = await project.db.selectFrom("message").selectAll().execute();
+	const variants = await project.db.selectFrom("variant").selectAll().execute();
+
+	expect(variants).toHaveLength(2);
+	expect(new Set(variants.map((variant) => variant.messageId))).toHaveLength(2);
+	expect(messages).toHaveLength(2);
+});
+
 test("it should insert a message as is if the id is provided", async () => {
 	const project = await loadProjectInMemory({ blob: await newProject() });
 

--- a/packages/sdk/src/import-export/importFiles.ts
+++ b/packages/sdk/src/import-export/importFiles.ts
@@ -20,6 +20,43 @@ const variantReferenceKey = (
 
 const INSERT_BATCH_SIZE = 500;
 
+/**
+ * Kysely uses one column list for every row in a multi-row insert. SQLite's
+ * default-value handling for omitted NOT NULL JSON columns is not reliable
+ * when rows with different optional-column shapes are mixed, so keep each
+ * shape in its own insert statement.
+ */
+async function insertInBatchesByShape<T extends object>(args: {
+	rows: readonly T[];
+	optionalColumns: readonly string[];
+	insert: (rows: T[]) => Promise<void>;
+}) {
+	const rowsByShape = new Map<string, T[]>();
+	for (const row of args.rows) {
+		const shape = args.optionalColumns
+			.map((column) =>
+				(row as Record<string, unknown>)[column] === undefined ? "0" : "1"
+			)
+			.join("");
+		const rowsForShape = rowsByShape.get(shape);
+		if (rowsForShape) {
+			rowsForShape.push(row);
+		} else {
+			rowsByShape.set(shape, [row]);
+		}
+	}
+
+	for (const rowsForShape of rowsByShape.values()) {
+		for (
+			let offset = 0;
+			offset < rowsForShape.length;
+			offset += INSERT_BATCH_SIZE
+		) {
+			await args.insert(rowsForShape.slice(offset, offset + INSERT_BATCH_SIZE));
+		}
+	}
+}
+
 export async function importFiles(args: {
 	files: ImportFile[];
 	readonly pluginKey: string;
@@ -110,31 +147,25 @@ export async function importFiles(args: {
 			);
 
 		if (canBatchImportFreshProject) {
-			for (
-				let offset = 0;
-				offset < imported.bundles.length;
-				offset += INSERT_BATCH_SIZE
-			) {
-				await trx
-					.insertInto("bundle")
-					.values(imported.bundles.slice(offset, offset + INSERT_BATCH_SIZE))
-					.execute();
-			}
+			await insertInBatchesByShape({
+				rows: imported.bundles,
+				optionalColumns: ["declarations"],
+				insert: async (rows) => {
+					await trx.insertInto("bundle").values(rows).execute();
+				},
+			});
 
 			const messagesWithIds = imported.messages.map((message) => ({
 				...message,
 				id: v7(),
 			}));
-			for (
-				let offset = 0;
-				offset < messagesWithIds.length;
-				offset += INSERT_BATCH_SIZE
-			) {
-				await trx
-					.insertInto("message")
-					.values(messagesWithIds.slice(offset, offset + INSERT_BATCH_SIZE))
-					.execute();
-			}
+			await insertInBatchesByShape({
+				rows: messagesWithIds,
+				optionalColumns: ["selectors"],
+				insert: async (rows) => {
+					await trx.insertInto("message").values(rows).execute();
+				},
+			});
 
 			const messageIds = new Map(
 				messagesWithIds.map((message) => [
@@ -160,18 +191,13 @@ export async function importFiles(args: {
 					};
 				}
 			);
-			for (
-				let offset = 0;
-				offset < variantsWithMessageIds.length;
-				offset += INSERT_BATCH_SIZE
-			) {
-				await trx
-					.insertInto("variant")
-					.values(
-						variantsWithMessageIds.slice(offset, offset + INSERT_BATCH_SIZE)
-					)
-					.execute();
-			}
+			await insertInBatchesByShape({
+				rows: variantsWithMessageIds,
+				optionalColumns: ["matches", "pattern"],
+				insert: async (rows) => {
+					await trx.insertInto("variant").values(rows).execute();
+				},
+			});
 			return;
 		}
 

--- a/packages/sdk/src/import-export/importFiles.ts
+++ b/packages/sdk/src/import-export/importFiles.ts
@@ -9,6 +9,17 @@ import type { InlangPlugin, VariantImport } from "../plugin/schema.js";
 import type { ImportFile } from "../project/api.js";
 import { v7 } from "uuid";
 
+const messageReferenceKey = (bundleId: string, locale: string) =>
+	JSON.stringify([bundleId, locale]);
+
+const variantReferenceKey = (
+	bundleId: string,
+	locale: string,
+	matches: unknown
+) => JSON.stringify([bundleId, locale, matches]);
+
+const INSERT_BATCH_SIZE = 500;
+
 export async function importFiles(args: {
 	files: ImportFile[];
 	readonly pluginKey: string;
@@ -50,17 +61,39 @@ export async function importFiles(args: {
 		const messageKeys = new Set<string>();
 		let messagesHaveUniqueKeys = true;
 		for (const message of imported.messages) {
-			const key = `${message.bundleId}\u0000${message.locale}`;
+			const key = messageReferenceKey(message.bundleId, message.locale);
 			if (messageKeys.has(key)) {
 				messagesHaveUniqueKeys = false;
 				break;
 			}
 			messageKeys.add(key);
 		}
+		const variantKeys = new Set<string>();
+		let variantsHaveUniqueKeys = true;
+		for (const variant of imported.variants) {
+			if (
+				variant.messageBundleId === undefined ||
+				variant.messageLocale === undefined
+			) {
+				variantsHaveUniqueKeys = false;
+				break;
+			}
+			const key = variantReferenceKey(
+				variant.messageBundleId,
+				variant.messageLocale,
+				variant.matches
+			);
+			if (variantKeys.has(key)) {
+				variantsHaveUniqueKeys = false;
+				break;
+			}
+			variantKeys.add(key);
+		}
 		const canBatchImportFreshProject =
 			hasExistingBundles === undefined &&
 			bundlesHaveUniqueIds &&
 			messagesHaveUniqueKeys &&
+			variantsHaveUniqueKeys &&
 			imported.messages.every((message) => message.id === undefined) &&
 			imported.variants.every(
 				(variant) =>
@@ -72,36 +105,50 @@ export async function importFiles(args: {
 			imported.messages.every((message) => bundleIds.has(message.bundleId)) &&
 			imported.variants.every((variant) =>
 				messageKeys.has(
-					`${variant.messageBundleId}\u0000${variant.messageLocale}`
+					messageReferenceKey(variant.messageBundleId!, variant.messageLocale!)
 				)
 			);
 
 		if (canBatchImportFreshProject) {
-			if (imported.bundles.length > 0) {
-				await trx.insertInto("bundle").values(imported.bundles).execute();
+			for (
+				let offset = 0;
+				offset < imported.bundles.length;
+				offset += INSERT_BATCH_SIZE
+			) {
+				await trx
+					.insertInto("bundle")
+					.values(imported.bundles.slice(offset, offset + INSERT_BATCH_SIZE))
+					.execute();
 			}
 
 			const messagesWithIds = imported.messages.map((message) => ({
 				...message,
 				id: v7(),
 			}));
-			for (let offset = 0; offset < messagesWithIds.length; offset += 500) {
+			for (
+				let offset = 0;
+				offset < messagesWithIds.length;
+				offset += INSERT_BATCH_SIZE
+			) {
 				await trx
 					.insertInto("message")
-					.values(messagesWithIds.slice(offset, offset + 500))
+					.values(messagesWithIds.slice(offset, offset + INSERT_BATCH_SIZE))
 					.execute();
 			}
 
 			const messageIds = new Map(
 				messagesWithIds.map((message) => [
-					`${message.bundleId}\u0000${message.locale}`,
+					messageReferenceKey(message.bundleId, message.locale),
 					message.id,
 				])
 			);
 			const variantsWithMessageIds: NewVariant[] = imported.variants.map(
 				(variant) => {
 					const messageId = messageIds.get(
-						`${variant.messageBundleId}\u0000${variant.messageLocale}`
+						messageReferenceKey(
+							variant.messageBundleId!,
+							variant.messageLocale!
+						)
 					);
 					if (messageId === undefined) {
 						throw new Error("Imported variant does not reference a message");
@@ -113,10 +160,16 @@ export async function importFiles(args: {
 					};
 				}
 			);
-			for (let offset = 0; offset < variantsWithMessageIds.length; offset += 500) {
+			for (
+				let offset = 0;
+				offset < variantsWithMessageIds.length;
+				offset += INSERT_BATCH_SIZE
+			) {
 				await trx
 					.insertInto("variant")
-					.values(variantsWithMessageIds.slice(offset, offset + 500))
+					.values(
+						variantsWithMessageIds.slice(offset, offset + INSERT_BATCH_SIZE)
+					)
 					.execute();
 			}
 			return;

--- a/packages/sdk/src/import-export/importFiles.ts
+++ b/packages/sdk/src/import-export/importFiles.ts
@@ -7,6 +7,7 @@ import type { ProjectSettings } from "../json-schema/settings.js";
 import type { InlangDatabaseSchema, NewVariant } from "../database/schema.js";
 import type { InlangPlugin, VariantImport } from "../plugin/schema.js";
 import type { ImportFile } from "../project/api.js";
+import { v7 } from "uuid";
 
 export async function importFiles(args: {
 	files: ImportFile[];
@@ -32,6 +33,95 @@ export async function importFiles(args: {
 	});
 
 	await args.db.transaction().execute(async (trx) => {
+		const hasExistingBundles = await trx
+			.selectFrom("bundle")
+			.select("id")
+			.limit(1)
+			.executeTakeFirst();
+		const bundleIds = new Set<string>();
+		let bundlesHaveUniqueIds = true;
+		for (const bundle of imported.bundles) {
+			if (bundle.id === undefined || bundleIds.has(bundle.id)) {
+				bundlesHaveUniqueIds = false;
+				break;
+			}
+			bundleIds.add(bundle.id);
+		}
+		const messageKeys = new Set<string>();
+		let messagesHaveUniqueKeys = true;
+		for (const message of imported.messages) {
+			const key = `${message.bundleId}\u0000${message.locale}`;
+			if (messageKeys.has(key)) {
+				messagesHaveUniqueKeys = false;
+				break;
+			}
+			messageKeys.add(key);
+		}
+		const canBatchImportFreshProject =
+			hasExistingBundles === undefined &&
+			bundlesHaveUniqueIds &&
+			messagesHaveUniqueKeys &&
+			imported.messages.every((message) => message.id === undefined) &&
+			imported.variants.every(
+				(variant) =>
+					variant.id === undefined &&
+					variant.messageId === undefined &&
+					variant.messageBundleId !== undefined &&
+					variant.messageLocale !== undefined
+			) &&
+			imported.messages.every((message) => bundleIds.has(message.bundleId)) &&
+			imported.variants.every((variant) =>
+				messageKeys.has(
+					`${variant.messageBundleId}\u0000${variant.messageLocale}`
+				)
+			);
+
+		if (canBatchImportFreshProject) {
+			if (imported.bundles.length > 0) {
+				await trx.insertInto("bundle").values(imported.bundles).execute();
+			}
+
+			const messagesWithIds = imported.messages.map((message) => ({
+				...message,
+				id: v7(),
+			}));
+			for (let offset = 0; offset < messagesWithIds.length; offset += 500) {
+				await trx
+					.insertInto("message")
+					.values(messagesWithIds.slice(offset, offset + 500))
+					.execute();
+			}
+
+			const messageIds = new Map(
+				messagesWithIds.map((message) => [
+					`${message.bundleId}\u0000${message.locale}`,
+					message.id,
+				])
+			);
+			const variantsWithMessageIds: NewVariant[] = imported.variants.map(
+				(variant) => {
+					const messageId = messageIds.get(
+						`${variant.messageBundleId}\u0000${variant.messageLocale}`
+					);
+					if (messageId === undefined) {
+						throw new Error("Imported variant does not reference a message");
+					}
+					return {
+						messageId,
+						matches: variant.matches,
+						pattern: variant.pattern,
+					};
+				}
+			);
+			for (let offset = 0; offset < variantsWithMessageIds.length; offset += 500) {
+				await trx
+					.insertInto("variant")
+					.values(variantsWithMessageIds.slice(offset, offset + 500))
+					.execute();
+			}
+			return;
+		}
+
 		// upsert every bundle
 		for (const bundle of imported.bundles) {
 			await trx

--- a/packages/sdk/src/project/loadProjectFromDirectory.bench.ts
+++ b/packages/sdk/src/project/loadProjectFromDirectory.bench.ts
@@ -1,0 +1,34 @@
+import { bench } from "vitest";
+import nodeFs from "node:fs";
+import nodePath from "node:path";
+import { memfs } from "memfs";
+import { loadProjectFromDirectory } from "./loadProjectFromDirectory.js";
+
+const pluginAsText = nodeFs.readFileSync(
+	nodePath.join(
+		process.cwd(),
+		"packages/plugins/inlang-message-format/dist/index.js"
+	),
+	"utf8"
+);
+const messageData = Object.fromEntries(
+	Array.from({ length: 1000 }, (_, i) => [`message_${i}`, `Hello {username} #${i}`])
+);
+const localeNames = Array.from({ length: 10 }, (_, i) => `locale_${i}`);
+const fs = memfs({
+	"/plugin.js": pluginAsText,
+	"/project.inlang/settings.json": JSON.stringify({
+		baseLocale: localeNames[0],
+		locales: localeNames,
+		modules: ["/plugin.js"],
+		"plugin.inlang.messageFormat": { pathPattern: "/{locale}.json" },
+	}),
+	...Object.fromEntries(
+		localeNames.map((locale) => [`/${locale}.json`, JSON.stringify(messageData)])
+	),
+}).fs as unknown as typeof import("node:fs");
+
+bench("load project from directory", async () => {
+	const project = await loadProjectFromDirectory({ path: "/project.inlang", fs });
+	await project.close();
+}, { iterations: 1, time: 100 });

--- a/packages/sdk/src/project/openProject.test.ts
+++ b/packages/sdk/src/project/openProject.test.ts
@@ -16,7 +16,7 @@ test("opens a project on a caller-owned Lix", async () => {
 		locales: ["fr", "en"],
 	});
 	const registeredSchemas = await lix.execute(
-		"SELECT lix_json_get_text(value, 'x-lix-key') AS schema_key FROM lix_registered_schema"
+		"SELECT value ->> 'key' AS schema_key FROM lix_registered_schema"
 	);
 	expect(
 		registeredSchemas.rows

--- a/packages/sdk/src/project/snapshot.ts
+++ b/packages/sdk/src/project/snapshot.ts
@@ -116,12 +116,12 @@ export async function restoreProjectBlob(lix: Lix, blob: Blob): Promise<void> {
 		});
 		for (const message of bundle.messages) {
 			statements.push({
-				sql: 'INSERT INTO inlang_message (id, "bundleId", locale, selectors) VALUES ($1, $2, $3, $4)',
+				sql: "INSERT INTO inlang_message (id, bundle_id, locale, selectors) VALUES ($1, $2, $3, $4)",
 				params: [message.id, bundle.id, message.locale, message.selectors],
 			});
 			for (const variant of message.variants) {
 				statements.push({
-					sql: 'INSERT INTO inlang_variant (id, "messageId", matches, pattern) VALUES ($1, $2, $3, $4)',
+					sql: "INSERT INTO inlang_variant (id, message_id, matches, pattern) VALUES ($1, $2, $3, $4)",
 					params: [variant.id, message.id, variant.matches, variant.pattern],
 				});
 			}

--- a/packages/sdk/src/schema-definitions/bundle.ts
+++ b/packages/sdk/src/schema-definitions/bundle.ts
@@ -1,11 +1,18 @@
 export const InlangBundleSchema = {
-	"x-lix-key": "inlang_bundle",
-	"x-lix-primary-key": ["/id"],
-	type: "object",
-	properties: {
-		id: { type: "string", "x-lix-default": "lix_uuid_v7()" },
-		declarations: { type: "array", items: { type: "object" }, default: [] },
-	},
-	required: ["id", "declarations"],
-	additionalProperties: false,
+	$schema: "https://lix.dev/schema-v1.json",
+	key: "inlang_bundle",
+	columns: [
+		{
+			name: "id",
+			type: "text",
+			nullable: false,
+		},
+		{
+			name: "declarations",
+			type: "jsonb",
+			nullable: false,
+			default_value: [],
+		},
+	],
+	primary_key: ["id"],
 } as const;

--- a/packages/sdk/src/schema-definitions/message.ts
+++ b/packages/sdk/src/schema-definitions/message.ts
@@ -1,19 +1,34 @@
 export const InlangMessageSchema = {
-	"x-lix-key": "inlang_message",
-	"x-lix-primary-key": ["/id"],
-	"x-lix-foreign-keys": [
+	$schema: "https://lix.dev/schema-v1.json",
+	key: "inlang_message",
+	columns: [
 		{
-			properties: ["/bundleId"],
-			references: { schemaKey: "inlang_bundle", properties: ["/id"] },
+			name: "id",
+			type: "text",
+			nullable: false,
+		},
+		{
+			name: "bundle_id",
+			type: "text",
+			nullable: false,
+		},
+		{
+			name: "locale",
+			type: "text",
+			nullable: false,
+		},
+		{
+			name: "selectors",
+			type: "jsonb",
+			nullable: false,
+			default_value: [],
 		},
 	],
-	type: "object",
-	properties: {
-		id: { type: "string", "x-lix-default": "lix_uuid_v7()" },
-		bundleId: { type: "string" },
-		locale: { type: "string" },
-		selectors: { type: "array", items: { type: "object" }, default: [] },
-	},
-	required: ["id", "bundleId", "locale", "selectors"],
-	additionalProperties: false,
+	primary_key: ["id"],
+	foreign_keys: [
+		{
+			columns: ["bundle_id"],
+			references: { schema_key: "inlang_bundle", columns: ["id"] },
+		},
+	],
 } as const;

--- a/packages/sdk/src/schema-definitions/variant.ts
+++ b/packages/sdk/src/schema-definitions/variant.ts
@@ -1,19 +1,35 @@
 export const InlangVariantSchema = {
-	"x-lix-key": "inlang_variant",
-	"x-lix-primary-key": ["/id"],
-	"x-lix-foreign-keys": [
+	$schema: "https://lix.dev/schema-v1.json",
+	key: "inlang_variant",
+	columns: [
 		{
-			properties: ["/messageId"],
-			references: { schemaKey: "inlang_message", properties: ["/id"] },
+			name: "id",
+			type: "text",
+			nullable: false,
+		},
+		{
+			name: "message_id",
+			type: "text",
+			nullable: false,
+		},
+		{
+			name: "matches",
+			type: "jsonb",
+			nullable: false,
+			default_value: [],
+		},
+		{
+			name: "pattern",
+			type: "jsonb",
+			nullable: false,
+			default_value: [],
 		},
 	],
-	type: "object",
-	properties: {
-		id: { type: "string", "x-lix-default": "lix_uuid_v7()" },
-		messageId: { type: "string" },
-		matches: { type: "array", items: { type: "object" }, default: [] },
-		pattern: { type: "array", items: { type: "object" }, default: [] },
-	},
-	required: ["id", "messageId", "matches", "pattern"],
-	additionalProperties: false,
+	primary_key: ["id"],
+	foreign_keys: [
+		{
+			columns: ["message_id"],
+			references: { schema_key: "inlang_message", columns: ["id"] },
+		},
+	],
 } as const;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -238,10 +238,10 @@ importers:
         version: 0.15.2
       '@inlang/message':
         specifier: 2.1.0
-        version: 2.1.0(@sinclair/typebox@0.34.40)
+        version: 2.1.0(@sinclair/typebox@0.34.52)
       '@inlang/plugin':
         specifier: 2.0.0
-        version: 2.0.0(@sinclair/typebox@0.34.40)
+        version: 2.0.0(@sinclair/typebox@0.34.52)
       '@inlang/sdk':
         specifier: ^0.9.0
         version: 0.9.0(babel-plugin-macros@3.1.0)
@@ -545,6 +545,28 @@ importers:
       vitest:
         specifier: ^4.0.6
         version: 4.0.16(@types/node@24.10.2)(happy-dom@18.0.1)(jiti@2.6.1)(jsdom@27.3.0(postcss@8.5.6))(lightningcss@1.30.2)(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1)
+
+  packages/plugins/apple-xcstrings:
+    dependencies:
+      '@inlang/sdk':
+        specifier: workspace:*
+        version: link:../../sdk
+      '@sinclair/typebox':
+        specifier: ^0.31.17
+        version: 0.31.28
+    devDependencies:
+      '@inlang/tsconfig':
+        specifier: workspace:*
+        version: link:../../tsconfig
+      esbuild:
+        specifier: ^0.25.9
+        version: 0.25.12
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.2)(@vitest/browser@3.2.4)(happy-dom@18.0.1)(jiti@2.6.1)(jsdom@27.3.0(postcss@8.5.6))(lightningcss@1.30.2)(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1)
 
   packages/plugins/i18next:
     dependencies:
@@ -4036,8 +4058,8 @@ packages:
   '@sinclair/typebox@0.31.28':
     resolution: {integrity: sha512-/s55Jujywdw/Jpan+vsy6JZs1z2ZTGxTmbZTPiuSL2wz9mfzA2gN1zzaqmvfi4pq+uOt7Du85fkiwv5ymW84aQ==}
 
-  '@sinclair/typebox@0.34.40':
-    resolution: {integrity: sha512-gwBNIP8ZAYev/ORDWW0QvxdwPXwxBtLsdsJgSc7eDIRt8ubP+rxUBzPsrwnu16fgEF8Bx4lh/+mvQvJzcTM6Kw==}
+  '@sinclair/typebox@0.34.52':
+    resolution: {integrity: sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==}
 
   '@sindresorhus/is@7.2.0':
     resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
@@ -13383,9 +13405,9 @@ snapshots:
     dependencies:
       '@sinclair/typebox': 0.31.28
 
-  '@inlang/json-types@1.1.0(@sinclair/typebox@0.34.40)':
+  '@inlang/json-types@1.1.0(@sinclair/typebox@0.34.52)':
     dependencies:
-      '@sinclair/typebox': 0.34.40
+      '@sinclair/typebox': 0.34.52
 
   '@inlang/language-tag@1.5.1':
     dependencies:
@@ -13405,10 +13427,10 @@ snapshots:
       '@inlang/language-tag': 1.5.1
       '@sinclair/typebox': 0.31.28
 
-  '@inlang/message@2.1.0(@sinclair/typebox@0.34.40)':
+  '@inlang/message@2.1.0(@sinclair/typebox@0.34.52)':
     dependencies:
       '@inlang/language-tag': 1.5.1
-      '@sinclair/typebox': 0.34.40
+      '@sinclair/typebox': 0.34.52
 
   '@inlang/module@1.2.14(@sinclair/typebox@0.31.28)':
     dependencies:
@@ -13416,15 +13438,15 @@ snapshots:
       '@inlang/plugin': 2.4.14(@sinclair/typebox@0.31.28)
       '@sinclair/typebox': 0.31.28
 
-  '@inlang/plugin@2.0.0(@sinclair/typebox@0.34.40)':
+  '@inlang/plugin@2.0.0(@sinclair/typebox@0.34.52)':
     dependencies:
-      '@inlang/json-types': 1.1.0(@sinclair/typebox@0.34.40)
+      '@inlang/json-types': 1.1.0(@sinclair/typebox@0.34.52)
       '@inlang/language-tag': 1.5.1
-      '@inlang/message': 2.1.0(@sinclair/typebox@0.34.40)
-      '@inlang/project-settings': 2.4.2(@sinclair/typebox@0.34.40)
+      '@inlang/message': 2.1.0(@sinclair/typebox@0.34.52)
+      '@inlang/project-settings': 2.4.2(@sinclair/typebox@0.34.52)
       '@inlang/translatable': 1.3.1
       '@lix-js/fs': 2.2.0
-      '@sinclair/typebox': 0.34.40
+      '@sinclair/typebox': 0.34.52
 
   '@inlang/plugin@2.4.14(@sinclair/typebox@0.31.28)':
     dependencies:
@@ -13442,11 +13464,11 @@ snapshots:
       '@inlang/language-tag': 1.5.1
       '@sinclair/typebox': 0.31.28
 
-  '@inlang/project-settings@2.4.2(@sinclair/typebox@0.34.40)':
+  '@inlang/project-settings@2.4.2(@sinclair/typebox@0.34.52)':
     dependencies:
-      '@inlang/json-types': 1.1.0(@sinclair/typebox@0.34.40)
+      '@inlang/json-types': 1.1.0(@sinclair/typebox@0.34.52)
       '@inlang/language-tag': 1.5.1
-      '@sinclair/typebox': 0.34.40
+      '@sinclair/typebox': 0.34.52
 
   '@inlang/result@1.1.0': {}
 
@@ -13589,7 +13611,7 @@ snapshots:
 
   '@jest/schemas@30.0.5':
     dependencies:
-      '@sinclair/typebox': 0.34.40
+      '@sinclair/typebox': 0.34.52
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -14781,7 +14803,7 @@ snapshots:
 
   '@sinclair/typebox@0.31.28': {}
 
-  '@sinclair/typebox@0.34.40': {}
+  '@sinclair/typebox@0.34.52': {}
 
   '@sindresorhus/is@7.2.0': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -692,7 +692,7 @@ importers:
         version: 1.10.6
       '@vitest/coverage-v8':
         specifier: 3.1.1
-        version: 3.1.1(@vitest/browser@3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(playwright@1.55.0)(vite@6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1))(vitest@3.1.1(@types/debug@4.1.12)(@types/node@24.10.2)(@vitest/browser@3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(playwright@1.55.0)(vite@6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1))(happy-dom@18.0.1)(jsdom@27.3.0(postcss@8.5.6))(lightningcss@1.30.2)(msw@2.10.2(@types/node@24.10.2)(typescript@5.7.3))(sass-embedded@1.89.2)(terser@5.36.0))
+        version: 3.1.1(@vitest/browser@3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(playwright@1.55.0)(vite@7.2.7(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1))(vitest@3.1.1(@types/debug@4.1.12)(@types/node@24.10.2)(@vitest/browser@3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(playwright@1.55.0)(vite@7.2.7(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1))(happy-dom@18.0.1)(jsdom@27.3.0(postcss@8.5.6))(lightningcss@1.30.2)(msw@2.10.2(@types/node@24.10.2)(typescript@5.7.3))(sass-embedded@1.89.2)(terser@5.36.0))
       esbuild:
         specifier: ^0.24.2
         version: 0.24.2
@@ -707,7 +707,7 @@ importers:
         version: 5.7.3
       vitest:
         specifier: 3.1.1
-        version: 3.1.1(@types/debug@4.1.12)(@types/node@24.10.2)(@vitest/browser@3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(playwright@1.55.0)(vite@6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1))(happy-dom@18.0.1)(jsdom@27.3.0(postcss@8.5.6))(lightningcss@1.30.2)(msw@2.10.2(@types/node@24.10.2)(typescript@5.7.3))(sass-embedded@1.89.2)(terser@5.36.0)
+        version: 3.1.1(@types/debug@4.1.12)(@types/node@24.10.2)(@vitest/browser@3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(playwright@1.55.0)(vite@7.2.7(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1))(happy-dom@18.0.1)(jsdom@27.3.0(postcss@8.5.6))(lightningcss@1.30.2)(msw@2.10.2(@types/node@24.10.2)(typescript@5.7.3))(sass-embedded@1.89.2)(terser@5.36.0)
 
   packages/plugins/t-function-matcher:
     dependencies:
@@ -765,8 +765,8 @@ importers:
   packages/sdk:
     dependencies:
       '@lix-js/sdk':
-        specifier: 0.11.0
-        version: 0.11.0
+        specifier: 0.12.0
+        version: 0.12.0
       '@sinclair/typebox':
         specifier: ^0.31.17
         version: 0.31.28
@@ -1954,15 +1954,15 @@ packages:
 
   '@esbuild-kit/cjs-loader@2.4.4':
     resolution: {integrity: sha512-NfsJX4PdzhwSkfJukczyUiZGc7zNNWZcEAyqeISpDnn0PTfzMJR1aR8xAIPskBejIxBJbIgCCMzbaYa9SXepIg==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild-kit/esm-loader@2.6.5':
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild/aix-ppc64@0.19.12':
     resolution: {integrity: sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==}
@@ -3232,28 +3232,28 @@ packages:
     resolution: {integrity: sha512-B9X3FjD8WmdG7tbA44JuniSO0KdKBWnjfxl8zpgrDCkavrp/GP7U0xxBkc0WgeeoHjQ/pkqq9VqtWB2kS9jIUg==}
     deprecated: use the lix sdk instead https://www.npmjs.com/package/@lix-js/sdk
 
-  '@lix-js/sdk-darwin-arm64@0.11.0':
-    resolution: {integrity: sha512-+VBH3NZ1ecXdLzIPm4GDuyGLboYqwbPGAkeNaHrFF9G+vkeDV/rol6Yo3POhUVXhdhY7YAgh1D49AtHk6WWsaw==}
+  '@lix-js/sdk-darwin-arm64@0.12.0':
+    resolution: {integrity: sha512-Pt6Q17kpvoTJCBaUdo5SfXuDFf1Fx2vODvnWlFILBmwV7xzUh9g2ALRF8nZr2jDWSeAi6g8PnjXDvryp2ug81g==}
     cpu: [arm64]
     os: [darwin]
 
-  '@lix-js/sdk-linux-arm64@0.11.0':
-    resolution: {integrity: sha512-ew+n15rxXK6OOPwoF7DYo64txwedo6Gk355Q1X5oeLlTQkpkpkmP90W10LBI/4uZYF1ifsXllOufkHmu6Lor1Q==}
+  '@lix-js/sdk-linux-arm64@0.12.0':
+    resolution: {integrity: sha512-tI+yZ6DOHIZhsblXMdMhFlq1k5m0Jc+/MF7im5MWzHk7KtYzdInW40uzg5NdjXkqlkFPsnugiNJzuCHCaW2XBg==}
     cpu: [arm64]
     os: [linux]
 
-  '@lix-js/sdk-linux-x64@0.11.0':
-    resolution: {integrity: sha512-WtM2Zqz3JgXEv3uNYJbeC15iqYl+rRUegxG98UH+Kc/3cCHheFFgWtjOhIPYeXmkSsYEaer99hdbEkl4uyEErw==}
+  '@lix-js/sdk-linux-x64@0.12.0':
+    resolution: {integrity: sha512-OTvkeZ3LNp3b1uHWBHGYPpeSQAv7NLj/kXbaUY1CMCyvZCFoWRvvz9Fmojv0mdWJV0j5qenJZF42XCiXVtcbrQ==}
     cpu: [x64]
     os: [linux]
 
-  '@lix-js/sdk-win32-x64@0.11.0':
-    resolution: {integrity: sha512-QJA2H1LWnkCa1pbogJehWmRAJ9e4w5JWXHKoXz7fy2+8CbHtfP4EwVl1x7OreV4zwwrM/Hb6LL8Bf0GoWYpB7A==}
+  '@lix-js/sdk-win32-x64@0.12.0':
+    resolution: {integrity: sha512-5THoK6ZEvYveHPmD23hEdxhElZw1OxunWof/ZCR6OlX2scfvCadEQ/snDAg1vXeelAh3VrZTh3fzPCO8rF/Rew==}
     cpu: [x64]
     os: [win32]
 
-  '@lix-js/sdk@0.11.0':
-    resolution: {integrity: sha512-0P2FN7N5b2WBH4DArAExXlnBAU9HG/KVY7rZ2GC1y+FTT+np2UwhYT1alp5xKCHnsOAwBrBUjHfNDxlUKYjsPA==}
+  '@lix-js/sdk@0.12.0':
+    resolution: {integrity: sha512-Vn4IYLmQyvqrVM+wcpzK6yDAZoK2Q4Hi9wRSsslfr1CcLQanRV1Tfheb5Kh2xy5NBLLbzFmFLsl7ElIKo8wVuA==}
 
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -13636,26 +13636,26 @@ snapshots:
     dependencies:
       typescript: 5.2.2
 
-  '@lix-js/sdk-darwin-arm64@0.11.0':
+  '@lix-js/sdk-darwin-arm64@0.12.0':
     optional: true
 
-  '@lix-js/sdk-linux-arm64@0.11.0':
+  '@lix-js/sdk-linux-arm64@0.12.0':
     optional: true
 
-  '@lix-js/sdk-linux-x64@0.11.0':
+  '@lix-js/sdk-linux-x64@0.12.0':
     optional: true
 
-  '@lix-js/sdk-win32-x64@0.11.0':
+  '@lix-js/sdk-win32-x64@0.12.0':
     optional: true
 
-  '@lix-js/sdk@0.11.0':
+  '@lix-js/sdk@0.12.0':
     dependencies:
       fflate: 0.8.3
     optionalDependencies:
-      '@lix-js/sdk-darwin-arm64': 0.11.0
-      '@lix-js/sdk-linux-arm64': 0.11.0
-      '@lix-js/sdk-linux-x64': 0.11.0
-      '@lix-js/sdk-win32-x64': 0.11.0
+      '@lix-js/sdk-darwin-arm64': 0.12.0
+      '@lix-js/sdk-linux-arm64': 0.12.0
+      '@lix-js/sdk-linux-x64': 0.12.0
+      '@lix-js/sdk-win32-x64': 0.12.0
 
   '@manypkg/find-root@1.1.0':
     dependencies:
@@ -16091,11 +16091,11 @@ snapshots:
       - vite
     optional: true
 
-  '@vitest/browser@3.2.4(msw@2.10.2(@types/node@22.15.33)(typescript@5.7.3))(playwright@1.55.0)(vite@7.2.7(@types/node@22.15.33)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1)':
+  '@vitest/browser@3.2.4(msw@2.10.2(@types/node@22.15.33)(typescript@5.7.3))(playwright@1.55.0)(vite@6.3.5(@types/node@22.15.33)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1)':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
-      '@vitest/mocker': 3.2.4(msw@2.10.2(@types/node@22.15.33)(typescript@5.7.3))(vite@7.2.7(@types/node@22.15.33)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))
+      '@vitest/mocker': 3.2.4(msw@2.10.2(@types/node@22.15.33)(typescript@5.7.3))(vite@6.3.5(@types/node@22.15.33)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))
       '@vitest/utils': 3.2.4
       magic-string: 0.30.21
       sirv: 3.0.2
@@ -16133,11 +16133,11 @@ snapshots:
       - vite
     optional: true
 
-  '@vitest/browser@3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(playwright@1.55.0)(vite@6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1)':
+  '@vitest/browser@3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(playwright@1.55.0)(vite@7.2.7(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1)':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
-      '@vitest/mocker': 3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(vite@6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))
+      '@vitest/mocker': 3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(vite@7.2.7(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))
       '@vitest/utils': 3.2.4
       magic-string: 0.30.21
       sirv: 3.0.2
@@ -16192,7 +16192,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@3.1.1(@vitest/browser@3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(playwright@1.55.0)(vite@6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1))(vitest@3.1.1(@types/debug@4.1.12)(@types/node@24.10.2)(@vitest/browser@3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(playwright@1.55.0)(vite@6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1))(happy-dom@18.0.1)(jsdom@27.3.0(postcss@8.5.6))(lightningcss@1.30.2)(msw@2.10.2(@types/node@24.10.2)(typescript@5.7.3))(sass-embedded@1.89.2)(terser@5.36.0))':
+  '@vitest/coverage-v8@3.1.1(@vitest/browser@3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(playwright@1.55.0)(vite@7.2.7(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1))(vitest@3.1.1(@types/debug@4.1.12)(@types/node@24.10.2)(@vitest/browser@3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(playwright@1.55.0)(vite@7.2.7(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1))(happy-dom@18.0.1)(jsdom@27.3.0(postcss@8.5.6))(lightningcss@1.30.2)(msw@2.10.2(@types/node@24.10.2)(typescript@5.7.3))(sass-embedded@1.89.2)(terser@5.36.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -16206,9 +16206,9 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.1.1(@types/debug@4.1.12)(@types/node@24.10.2)(@vitest/browser@3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(playwright@1.55.0)(vite@6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1))(happy-dom@18.0.1)(jsdom@27.3.0(postcss@8.5.6))(lightningcss@1.30.2)(msw@2.10.2(@types/node@24.10.2)(typescript@5.7.3))(sass-embedded@1.89.2)(terser@5.36.0)
+      vitest: 3.1.1(@types/debug@4.1.12)(@types/node@24.10.2)(@vitest/browser@3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(playwright@1.55.0)(vite@7.2.7(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1))(happy-dom@18.0.1)(jsdom@27.3.0(postcss@8.5.6))(lightningcss@1.30.2)(msw@2.10.2(@types/node@24.10.2)(typescript@5.7.3))(sass-embedded@1.89.2)(terser@5.36.0)
     optionalDependencies:
-      '@vitest/browser': 3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(playwright@1.55.0)(vite@6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1)
+      '@vitest/browser': 3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(playwright@1.55.0)(vite@7.2.7(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -16227,9 +16227,9 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.2)(@vitest/browser@3.2.4)(happy-dom@18.0.1)(jiti@2.6.1)(jsdom@27.3.0(postcss@8.5.6))(lightningcss@1.30.2)(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.15.33)(@vitest/browser@3.2.4)(happy-dom@18.0.1)(jiti@2.6.1)(jsdom@27.3.0(postcss@8.5.6))(lightningcss@1.30.2)(msw@2.10.2(@types/node@22.15.33)(typescript@5.7.3))(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1)
     optionalDependencies:
-      '@vitest/browser': 3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(playwright@1.55.0)(vite@6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1)
+      '@vitest/browser': 3.2.4(msw@2.10.2(@types/node@22.15.33)(typescript@5.7.3))(playwright@1.55.0)(vite@6.3.5(@types/node@22.15.33)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -16325,16 +16325,6 @@ snapshots:
       msw: 2.10.2(@types/node@22.15.33)(typescript@5.7.3)
       vite: 6.3.5(@types/node@22.15.33)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1)
 
-  '@vitest/mocker@3.2.4(msw@2.10.2(@types/node@22.15.33)(typescript@5.7.3))(vite@7.2.7(@types/node@22.15.33)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      msw: 2.10.2(@types/node@22.15.33)(typescript@5.7.3)
-      vite: 7.2.7(@types/node@22.15.33)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1)
-    optional: true
-
   '@vitest/mocker@3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.7.3))(vite@6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))':
     dependencies:
       '@vitest/spy': 3.2.4
@@ -16362,6 +16352,16 @@ snapshots:
     optionalDependencies:
       msw: 2.10.2(@types/node@24.10.2)(typescript@5.9.3)
       vite: 6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1)
+
+  '@vitest/mocker@3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(vite@7.2.7(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.10.2(@types/node@24.10.2)(typescript@5.9.3)
+      vite: 7.2.7(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1)
+    optional: true
 
   '@vitest/mocker@4.0.16(msw@2.10.2(@types/node@22.15.33)(typescript@5.7.3))(vite@7.2.7(@types/node@22.15.33)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))':
     dependencies:
@@ -23900,7 +23900,7 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@3.1.1(@types/debug@4.1.12)(@types/node@24.10.2)(@vitest/browser@3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(playwright@1.55.0)(vite@6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1))(happy-dom@18.0.1)(jsdom@27.3.0(postcss@8.5.6))(lightningcss@1.30.2)(msw@2.10.2(@types/node@24.10.2)(typescript@5.7.3))(sass-embedded@1.89.2)(terser@5.36.0):
+  vitest@3.1.1(@types/debug@4.1.12)(@types/node@24.10.2)(@vitest/browser@3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(playwright@1.55.0)(vite@7.2.7(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1))(happy-dom@18.0.1)(jsdom@27.3.0(postcss@8.5.6))(lightningcss@1.30.2)(msw@2.10.2(@types/node@24.10.2)(typescript@5.7.3))(sass-embedded@1.89.2)(terser@5.36.0):
     dependencies:
       '@vitest/expect': 3.1.1
       '@vitest/mocker': 3.1.1(msw@2.10.2(@types/node@24.10.2)(typescript@5.7.3))(vite@5.4.19(@types/node@24.10.2)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0))
@@ -23925,7 +23925,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 24.10.2
-      '@vitest/browser': 3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(playwright@1.55.0)(vite@6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1)
+      '@vitest/browser': 3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(playwright@1.55.0)(vite@7.2.7(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1)
       happy-dom: 18.0.1
       jsdom: 27.3.0(postcss@8.5.6)
     transitivePeerDependencies:
@@ -23967,7 +23967,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 22.15.33
-      '@vitest/browser': 3.2.4(msw@2.10.2(@types/node@22.15.33)(typescript@5.7.3))(playwright@1.55.0)(vite@7.2.7(@types/node@22.15.33)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1)
+      '@vitest/browser': 3.2.4(msw@2.10.2(@types/node@22.15.33)(typescript@5.7.3))(playwright@1.55.0)(vite@6.3.5(@types/node@22.15.33)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1)
       happy-dom: 18.0.1
       jsdom: 27.3.0(postcss@8.5.6)
     transitivePeerDependencies:
@@ -24057,7 +24057,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 24.10.2
-      '@vitest/browser': 3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(playwright@1.55.0)(vite@6.3.5(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1)
+      '@vitest/browser': 3.2.4(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(playwright@1.55.0)(vite@7.2.7(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))(vitest@3.2.4)(webdriverio@9.2.1)
       happy-dom: 18.0.1
       jsdom: 27.3.0(postcss@8.5.6)
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -493,6 +493,59 @@ importers:
         specifier: ^4.8.0
         version: 4.10.0(webpack@5.99.9)
 
+  packages/plugins/android:
+    dependencies:
+      '@inlang/sdk':
+        specifier: workspace:*
+        version: link:../../sdk
+      '@sinclair/typebox':
+        specifier: ^0.31.17
+        version: 0.31.28
+      fast-xml-parser:
+        specifier: ^4.5.3
+        version: 4.5.3
+    devDependencies:
+      '@inlang/tsconfig':
+        specifier: workspace:*
+        version: link:../../tsconfig
+      esbuild:
+        specifier: ^0.25.9
+        version: 0.25.12
+      prettier:
+        specifier: 3.3.3
+        version: 3.3.3
+      typescript:
+        specifier: ^5.5.2
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.6
+        version: 4.0.16(@types/node@24.10.2)(happy-dom@18.0.1)(jiti@2.6.1)(jsdom@27.3.0(postcss@8.5.6))(lightningcss@1.30.2)(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1)
+
+  packages/plugins/apple-strings:
+    dependencies:
+      '@inlang/sdk':
+        specifier: workspace:*
+        version: link:../../sdk
+      '@sinclair/typebox':
+        specifier: ^0.31.17
+        version: 0.31.28
+    devDependencies:
+      '@inlang/tsconfig':
+        specifier: workspace:*
+        version: link:../../tsconfig
+      esbuild:
+        specifier: ^0.25.9
+        version: 0.25.12
+      prettier:
+        specifier: 3.3.3
+        version: 3.3.3
+      typescript:
+        specifier: ^5.5.2
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.6
+        version: 4.0.16(@types/node@24.10.2)(happy-dom@18.0.1)(jiti@2.6.1)(jsdom@27.3.0(postcss@8.5.6))(lightningcss@1.30.2)(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1)
+
   packages/plugins/i18next:
     dependencies:
       '@inlang/sdk':
@@ -16381,6 +16434,15 @@ snapshots:
       msw: 2.10.2(@types/node@24.10.2)(typescript@5.7.3)
       vite: 7.2.7(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1)
 
+  '@vitest/mocker@4.0.16(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(vite@7.2.7(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))':
+    dependencies:
+      '@vitest/spy': 4.0.16
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.10.2(@types/node@24.10.2)(typescript@5.9.3)
+      vite: 7.2.7(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1)
+
   '@vitest/mocker@4.0.6(msw@2.10.2(@types/node@22.15.33)(typescript@5.7.3))(vite@7.2.7(@types/node@22.15.33)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))':
     dependencies:
       '@vitest/spy': 4.0.6
@@ -18918,7 +18980,6 @@ snapshots:
   fast-xml-parser@4.5.3:
     dependencies:
       strnum: 1.1.2
-    optional: true
 
   fastest-levenshtein@1.0.16: {}
 
@@ -22841,8 +22902,7 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
-  strnum@1.1.2:
-    optional: true
+  strnum@1.1.2: {}
 
   strong-log-transformer@2.1.0:
     dependencies:
@@ -23241,8 +23301,7 @@ snapshots:
 
   typescript@5.7.3: {}
 
-  typescript@5.9.3:
-    optional: true
+  typescript@5.9.3: {}
 
   ufo@1.6.1: {}
 
@@ -24117,6 +24176,45 @@ snapshots:
     dependencies:
       '@vitest/expect': 4.0.16
       '@vitest/mocker': 4.0.16(msw@2.10.2(@types/node@24.10.2)(typescript@5.7.3))(vite@7.2.7(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))
+      '@vitest/pretty-format': 4.0.16
+      '@vitest/runner': 4.0.16
+      '@vitest/snapshot': 4.0.16
+      '@vitest/spy': 4.0.16
+      '@vitest/utils': 4.0.16
+      es-module-lexer: 1.7.0
+      expect-type: 1.2.2
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 7.2.7(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.10.2
+      happy-dom: 18.0.1
+      jsdom: 27.3.0(postcss@8.5.6)
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
+
+  vitest@4.0.16(@types/node@24.10.2)(happy-dom@18.0.1)(jiti@2.6.1)(jsdom@27.3.0(postcss@8.5.6))(lightningcss@1.30.2)(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1):
+    dependencies:
+      '@vitest/expect': 4.0.16
+      '@vitest/mocker': 4.0.16(msw@2.10.2(@types/node@24.10.2)(typescript@5.9.3))(vite@7.2.7(@types/node@24.10.2)(jiti@2.6.1)(lightningcss@1.30.2)(sass-embedded@1.89.2)(terser@5.36.0)(tsx@4.20.5)(yaml@2.8.1))
       '@vitest/pretty-format': 4.0.16
       '@vitest/runner': 4.0.16
       '@vitest/snapshot': 4.0.16


### PR DESCRIPTION
## Summary

- Upgrade `@inlang/sdk` to exact Lix `0.12.0` and migrate SDK schemas/database bridge to the native Schema-v1 SQL contract.
- Fold the changes from #4394, #4399, and #4400 into the v3 line.
- Include the release/version delta from #4395 without importing unrelated main history.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter @inlang/sdk build`
- `pnpm --filter @inlang/sdk test` — 22 files, 123 passed, 19 skipped, 4 todo
- `pnpm --filter @inlang/plugin-android test` — 15/15
- `pnpm --filter @inlang/plugin-apple-strings test` — 9/9
- `pnpm --filter @inlang/plugin-apple-xcstrings test` — 9/9
- `pnpm --filter @inlang/plugin-message-format test` — 58 passed, 1 skipped
- `git diff --check`

The branch is based on the exact `origin/v3` snapshot and does not modify the existing v3 branch directly.
