### PR TITLE
chore(sdk): upgrade Lix to 0.12.2

### DIFF
--- a/.changeset/fresh-lixes-upgrade.md
+++ b/.changeset/fresh-lixes-upgrade.md
@@ -1,0 +1,5 @@
+---
+"@inlang/sdk": patch
+---
+
+Update the SDK's Lix engine dependency to 0.12.2, including the Node.js WASM fallback for musl-based environments.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -40,7 +40,7 @@
 		"node": ">=20.0.0"
 	},
 	"dependencies": {
-		"@lix-js/sdk": "0.12.0",
+		"@lix-js/sdk": "0.12.2",
 		"@sinclair/typebox": "^0.31.17",
 		"kysely": "^0.28.12",
 		"sqlite-wasm-kysely": "0.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -840,8 +840,8 @@ importers:
   packages/sdk:
     dependencies:
       '@lix-js/sdk':
-        specifier: 0.12.0
-        version: 0.12.0
+        specifier: 0.12.2
+        version: 0.12.2
       '@sinclair/typebox':
         specifier: ^0.31.17
         version: 0.31.28
@@ -3307,28 +3307,28 @@ packages:
     resolution: {integrity: sha512-B9X3FjD8WmdG7tbA44JuniSO0KdKBWnjfxl8zpgrDCkavrp/GP7U0xxBkc0WgeeoHjQ/pkqq9VqtWB2kS9jIUg==}
     deprecated: use the lix sdk instead https://www.npmjs.com/package/@lix-js/sdk
 
-  '@lix-js/sdk-darwin-arm64@0.12.0':
-    resolution: {integrity: sha512-Pt6Q17kpvoTJCBaUdo5SfXuDFf1Fx2vODvnWlFILBmwV7xzUh9g2ALRF8nZr2jDWSeAi6g8PnjXDvryp2ug81g==}
+  '@lix-js/sdk-darwin-arm64@0.12.2':
+    resolution: {integrity: sha512-0mBRIfgZfaey1/d0mijv7fBIGPeaTIMCDOPr3s4RUlHy/j+llNmAyDS2iNlalFh9nQGys7JNzo2Hv3FQbdKmug==}
     cpu: [arm64]
     os: [darwin]
 
-  '@lix-js/sdk-linux-arm64@0.12.0':
-    resolution: {integrity: sha512-tI+yZ6DOHIZhsblXMdMhFlq1k5m0Jc+/MF7im5MWzHk7KtYzdInW40uzg5NdjXkqlkFPsnugiNJzuCHCaW2XBg==}
+  '@lix-js/sdk-linux-arm64@0.12.2':
+    resolution: {integrity: sha512-817uJlC2KTIKDaqQvALTu03hEJpNxEA+9d33FNs8sOm9pAguOWiAK1zGA2SD0IgS9Q8NqQeABLb84OesW5/NCA==}
     cpu: [arm64]
     os: [linux]
 
-  '@lix-js/sdk-linux-x64@0.12.0':
-    resolution: {integrity: sha512-OTvkeZ3LNp3b1uHWBHGYPpeSQAv7NLj/kXbaUY1CMCyvZCFoWRvvz9Fmojv0mdWJV0j5qenJZF42XCiXVtcbrQ==}
+  '@lix-js/sdk-linux-x64@0.12.2':
+    resolution: {integrity: sha512-rA7lw1jBr6azBHR5Sh/RzOKSAlRcmVea7VeI4VQqpy0PZs+5tWoK9iVC41V4oCIKssRv2wrkbvyP3CqInhoknQ==}
     cpu: [x64]
     os: [linux]
 
-  '@lix-js/sdk-win32-x64@0.12.0':
-    resolution: {integrity: sha512-5THoK6ZEvYveHPmD23hEdxhElZw1OxunWof/ZCR6OlX2scfvCadEQ/snDAg1vXeelAh3VrZTh3fzPCO8rF/Rew==}
+  '@lix-js/sdk-win32-x64@0.12.2':
+    resolution: {integrity: sha512-y9IikCdrYx6cFnfqeUvYKPw6KBY016U2F2wYDILYZDZndccK2xw7lJChX163w9PewMwY3GsC/UqRBi5yqFAJ2w==}
     cpu: [x64]
     os: [win32]
 
-  '@lix-js/sdk@0.12.0':
-    resolution: {integrity: sha512-Vn4IYLmQyvqrVM+wcpzK6yDAZoK2Q4Hi9wRSsslfr1CcLQanRV1Tfheb5Kh2xy5NBLLbzFmFLsl7ElIKo8wVuA==}
+  '@lix-js/sdk@0.12.2':
+    resolution: {integrity: sha512-sKGOPdVKdChS5q60F4VQE4ZTcf0B7ZJM3KGCVQFN2suVNKhHcllbsCiwRYuM5WL7Yu1ql7YexltJ2FCsDqKePg==}
 
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -13711,26 +13711,26 @@ snapshots:
     dependencies:
       typescript: 5.2.2
 
-  '@lix-js/sdk-darwin-arm64@0.12.0':
+  '@lix-js/sdk-darwin-arm64@0.12.2':
     optional: true
 
-  '@lix-js/sdk-linux-arm64@0.12.0':
+  '@lix-js/sdk-linux-arm64@0.12.2':
     optional: true
 
-  '@lix-js/sdk-linux-x64@0.12.0':
+  '@lix-js/sdk-linux-x64@0.12.2':
     optional: true
 
-  '@lix-js/sdk-win32-x64@0.12.0':
+  '@lix-js/sdk-win32-x64@0.12.2':
     optional: true
 
-  '@lix-js/sdk@0.12.0':
+  '@lix-js/sdk@0.12.2':
     dependencies:
       fflate: 0.8.3
     optionalDependencies:
-      '@lix-js/sdk-darwin-arm64': 0.12.0
-      '@lix-js/sdk-linux-arm64': 0.12.0
-      '@lix-js/sdk-linux-x64': 0.12.0
-      '@lix-js/sdk-win32-x64': 0.12.0
+      '@lix-js/sdk-darwin-arm64': 0.12.2
+      '@lix-js/sdk-linux-arm64': 0.12.2
+      '@lix-js/sdk-linux-x64': 0.12.2
+      '@lix-js/sdk-win32-x64': 0.12.2
 
   '@manypkg/find-root@1.1.0':
     dependencies:


### PR DESCRIPTION
## Summary

- upgrade `@inlang/sdk`'s exact `@lix-js/sdk` dependency from 0.12.0 to 0.12.2
- update the pnpm lockfile and native optional package resolutions
- add a patch changeset for `@inlang/sdk`

The 0.12.2 release contains the Node.js WASM fallback for memory-backed Lix consumers on musl-based environments.

## Validation

- `pnpm install --frozen-lockfile --ignore-scripts --filter @inlang/sdk...`
- `pnpm --filter @inlang/sdk test` — 123 passed, 19 skipped, 4 todo
- `pnpm --filter @inlang/sdk build`
- `pnpm --filter @inlang/sdk lint`
