### PR TITLE
fix(message-format): preserve selectors, inputs, and local ordering

### DIFF
--- a/.changeset/tidy-selector-roundtrips.md
+++ b/.changeset/tidy-selector-roundtrips.md
@@ -1,0 +1,5 @@
+---
+"@inlang/plugin-message-format": patch
+---
+
+Fix message-format round trips by trimming whitespace around every selector match, preserving placeholder inputs that follow existing declarations, and exporting without mutating declaration or variant-match order.

--- a/packages/plugins/inlang-message-format/src/import-export/exportFiles.test.ts
+++ b/packages/plugins/inlang-message-format/src/import-export/exportFiles.test.ts
@@ -1,0 +1,168 @@
+import type { Bundle, Message, Variant } from "@inlang/sdk";
+import { expect, test } from "vitest";
+import { exportFiles } from "./exportFiles.js";
+
+test("exporting does not mutate declaration or match ordering", async () => {
+	const bundle: Bundle = {
+		id: "example",
+		declarations: [
+			{ type: "input-variable", name: "zebra" },
+			{ type: "input-variable", name: "alpha" },
+		],
+	};
+	const message: Message = {
+		id: "example-en",
+		bundleId: bundle.id,
+		locale: "en",
+		selectors: [
+			{ type: "variable-reference", name: "zebra" },
+			{ type: "variable-reference", name: "alpha" },
+		],
+	};
+	const variant: Variant = {
+		id: "example-en-variant",
+		messageId: message.id,
+		matches: [
+			{ type: "literal-match", key: "zebra", value: "yes" },
+			{ type: "catchall-match", key: "alpha" },
+		],
+		pattern: [{ type: "text", value: "Example" }],
+	};
+	const originalBundle = structuredClone(bundle);
+	const originalMessage = structuredClone(message);
+	const originalVariant = structuredClone(variant);
+
+	const exported = await runExportFiles(bundle, message, variant);
+
+	expect(exported.example[0]).toMatchObject({
+		declarations: ["input alpha", "input zebra"],
+		selectors: ["alpha", "zebra"],
+		match: { "alpha=*, zebra=yes": "Example" },
+	});
+	expect(bundle).toStrictEqual(originalBundle);
+	expect(message).toStrictEqual(originalMessage);
+	expect(variant).toStrictEqual(originalVariant);
+});
+
+test("inferring catchall matches does not mutate an empty match array", async () => {
+	const bundle: Bundle = {
+		id: "example",
+		declarations: [
+			{ type: "input-variable", name: "count" },
+			{
+				type: "local-variable",
+				name: "formatted",
+				value: {
+					type: "expression",
+					arg: { type: "variable-reference", name: "count" },
+					annotation: {
+						type: "function-reference",
+						name: "number",
+						options: [],
+					},
+				},
+			},
+		],
+	};
+	const message: Message = {
+		id: "example-en",
+		bundleId: bundle.id,
+		locale: "en",
+		selectors: [],
+	};
+	const variant: Variant = {
+		id: "example-en-variant",
+		messageId: message.id,
+		matches: [],
+		pattern: [
+			{
+				type: "expression",
+				arg: { type: "variable-reference", name: "formatted" },
+			},
+		],
+	};
+
+	const exported = await runExportFiles(bundle, message, variant);
+
+	expect(exported.example[0].match).toStrictEqual({
+		"formatted=*": "{formatted}",
+	});
+	expect(variant.matches).toStrictEqual([]);
+});
+
+test("local declarations retain their dependency-safe ordering", async () => {
+	const bundle: Bundle = {
+		id: "example",
+		declarations: [
+			{
+				type: "local-variable",
+				name: "zebra",
+				value: {
+					type: "expression",
+					arg: { type: "variable-reference", name: "count" },
+					annotation: {
+						type: "function-reference",
+						name: "number",
+						options: [],
+					},
+				},
+			},
+			{
+				type: "local-variable",
+				name: "alpha",
+				value: {
+					type: "expression",
+					arg: { type: "variable-reference", name: "zebra" },
+					annotation: {
+						type: "function-reference",
+						name: "number",
+						options: [],
+					},
+				},
+			},
+			{ type: "input-variable", name: "count" },
+		],
+	};
+	const message: Message = {
+		id: "example-en",
+		bundleId: bundle.id,
+		locale: "en",
+		selectors: [],
+	};
+	const variant: Variant = {
+		id: "example-en-variant",
+		messageId: message.id,
+		matches: [],
+		pattern: [
+			{
+				type: "expression",
+				arg: { type: "variable-reference", name: "alpha" },
+			},
+		],
+	};
+	const originalDeclarations = structuredClone(bundle.declarations);
+
+	const exported = await runExportFiles(bundle, message, variant);
+
+	expect(exported.example[0].declarations).toStrictEqual([
+		"input count",
+		"local zebra = count: number",
+		"local alpha = zebra: number",
+	]);
+	expect(bundle.declarations).toStrictEqual(originalDeclarations);
+});
+
+async function runExportFiles(
+	bundle: Bundle,
+	message: Message,
+	variant: Variant
+) {
+	const exported = await exportFiles({
+		settings: {} as any,
+		bundles: [bundle],
+		messages: [message],
+		variants: [variant],
+	});
+
+	return JSON.parse(new TextDecoder().decode(exported[0]?.content));
+}

--- a/packages/plugins/inlang-message-format/src/import-export/exportFiles.ts
+++ b/packages/plugins/inlang-message-format/src/import-export/exportFiles.ts
@@ -98,19 +98,20 @@ function serializeVariants(
 
 	const entries = [];
 	for (const variant of variants) {
-		if (variant.matches.length === 0) {
+		const matches = [...variant.matches];
+		if (matches.length === 0) {
 			for (const part of variant.pattern) {
 				if (
 					part.type === "expression" &&
 					part.arg.type === "variable-reference"
 				) {
-					variant.matches.push({ key: part.arg.name, type: "catchall-match" });
+					matches.push({ key: part.arg.name, type: "catchall-match" });
 				}
 			}
 		}
 
 		const pattern = serializePattern(variant.pattern);
-		const match = serializeMatcher(variant.matches);
+		const match = serializeMatcher(matches);
 		entries.push([match, pattern]);
 	}
 
@@ -118,10 +119,15 @@ function serializeVariants(
 		{
 			// naively adding all declarations, even if unused in the variants
 			// can be optimized later.
-			declarations: bundle.declarations
-				.sort((a, b) => a.name.localeCompare(b.name))
-				.map(serializeDeclaration)
-				.sort(),
+			declarations: [
+				...bundle.declarations
+					.filter((declaration) => declaration.type === "input-variable")
+					.map(serializeDeclaration)
+					.sort(),
+				...bundle.declarations
+					.filter((declaration) => declaration.type === "local-variable")
+					.map(serializeDeclaration),
+			],
 			selectors: message.selectors.map((s) => s.name).sort(),
 			match: Object.fromEntries(entries),
 		},
@@ -186,7 +192,9 @@ function serializeMarkup(
 	options:
 		| Array<{
 				name: string;
-				value: { type: "literal"; value: string } | { type: "variable-reference"; name: string };
+				value:
+					| { type: "literal"; value: string }
+					| { type: "variable-reference"; name: string };
 		  }>
 		| undefined,
 	attributes:
@@ -222,13 +230,16 @@ function serializeMarkup(
 }
 
 function escapeMarkupLiteral(value: string): string {
-	return value.replace(/\\/g, "\\\\").replace(/\|/g, "\\|").replace(/}/g, "\\}");
+	return value
+		.replace(/\\/g, "\\\\")
+		.replace(/\|/g, "\\|")
+		.replace(/}/g, "\\}");
 }
 
 // input: { platform: "android", userGender: "male" }
 // output: `platform=android,userGender=male`
 function serializeMatcher(matches: Match[]): string {
-	const parts = matches
+	const parts = [...matches]
 		.sort((a, b) => a.key.localeCompare(b.key))
 		.map((match) =>
 			match.type === "literal-match"

--- a/packages/plugins/inlang-message-format/src/import-export/importFiles.ts
+++ b/packages/plugins/inlang-message-format/src/import-export/importFiles.ts
@@ -190,7 +190,7 @@ function parseVariants(
 				}
 			}
 			if (isDuplicate) {
-				break;
+				continue;
 			}
 			declarations.add(declaration);
 		}
@@ -293,7 +293,10 @@ function parsePattern(value: string): {
 	};
 }
 
-function findPlaceholderClosingIndex(value: string, openingIndex: number): number {
+function findPlaceholderClosingIndex(
+	value: string,
+	openingIndex: number
+): number {
 	let inQuotedLiteral = false;
 
 	for (let cursor = openingIndex + 1; cursor < value.length; cursor += 1) {
@@ -480,14 +483,14 @@ function parseMarkupValue(
 		let cursor = index + 1;
 		let literal = "";
 		while (cursor < value.length) {
-				const char = value[cursor]!;
-				if (char === "\\") {
-					const next = value[cursor + 1];
-					if (next === "|" || next === "\\" || next === "}") {
-						literal += next;
-						cursor += 2;
-						continue;
-					}
+			const char = value[cursor]!;
+			if (char === "\\") {
+				const next = value[cursor + 1];
+				if (next === "|" || next === "\\" || next === "}") {
+					literal += next;
+					cursor += 2;
+					continue;
+				}
 				literal += char;
 				cursor += 1;
 				continue;
@@ -527,14 +530,12 @@ function parseMatches(value: string): {
 	matches: Match[];
 	selectors: Message["selectors"];
 } {
-	const stripped = value.replace(" ", "");
-
 	const matches: Match[] = [];
 	const selectors: Message["selectors"] = [];
 
-	const parts = stripped.split(",");
+	const parts = value.split(",");
 	for (const part of parts) {
-		const [key, value] = part.split("=");
+		const [key, value] = part.split("=").map((segment) => segment.trim());
 		if (!key || !value) {
 			continue;
 		}

--- a/packages/plugins/inlang-message-format/src/import-export/roundtrip.test.ts
+++ b/packages/plugins/inlang-message-format/src/import-export/roundtrip.test.ts
@@ -3,6 +3,7 @@ import { importFiles } from "./importFiles.js";
 import {
 	Declaration,
 	type Bundle,
+	type Match,
 	type Message,
 	type Pattern,
 	type Variant,
@@ -355,6 +356,93 @@ test("it handles detecting and adding selectors and declarations for complex mes
 			pattern: [{ type: "text", value: "The person has to download the app." }],
 		} satisfies Partial<Variant>)
 	);
+});
+
+test("it preserves three selector names across export and reimport", async () => {
+	const imported = await runImportFiles({
+		journal_write: [
+			{
+				declarations: ["input duration", "input every", "input type"],
+				selectors: ["duration", "every", "type"],
+				match: {
+					"duration=1,every=week,type=custom": "Write a custom entry",
+					"duration=*,every=*,type=*": "Write an entry",
+				},
+			},
+		],
+	});
+
+	const exported = await runExportFilesParsed(imported);
+	expect(exported.journal_write[0].match).toHaveProperty(
+		"duration=1, every=week, type=custom",
+		"Write a custom entry"
+	);
+
+	const reimported = await runImportFiles(exported);
+	expect(reimported.bundles[0]?.declarations).toStrictEqual([
+		{ type: "input-variable", name: "duration" },
+		{ type: "input-variable", name: "every" },
+		{ type: "input-variable", name: "type" },
+	] satisfies Declaration[]);
+	expect(reimported.messages[0]?.selectors).toStrictEqual([
+		{ type: "variable-reference", name: "duration" },
+		{ type: "variable-reference", name: "every" },
+		{ type: "variable-reference", name: "type" },
+	] satisfies Message["selectors"]);
+	expect(reimported.variants[0]?.matches).toStrictEqual([
+		{ type: "literal-match", key: "duration", value: "1" },
+		{ type: "literal-match", key: "every", value: "week" },
+		{ type: "literal-match", key: "type", value: "custom" },
+	] satisfies Match[]);
+});
+
+test("it trims whitespace around every selector name and match value", async () => {
+	const imported = await runImportFiles({
+		journal_write: [
+			{
+				match: {
+					" duration = 1 , every = week , type = custom ": "Write an entry",
+					" duration = * , every = * , type = * ": "Write anything",
+				},
+			},
+		],
+	});
+
+	expect(imported.messages[0]?.selectors).toStrictEqual([
+		{ type: "variable-reference", name: "duration" },
+		{ type: "variable-reference", name: "every" },
+		{ type: "variable-reference", name: "type" },
+	] satisfies Message["selectors"]);
+	expect(imported.variants[0]?.matches).toStrictEqual([
+		{ type: "literal-match", key: "duration", value: "1" },
+		{ type: "literal-match", key: "every", value: "week" },
+		{ type: "literal-match", key: "type", value: "custom" },
+	] satisfies Match[]);
+	expect(imported.variants[1]?.matches).toStrictEqual([
+		{ type: "catchall-match", key: "duration" },
+		{ type: "catchall-match", key: "every" },
+		{ type: "catchall-match", key: "type" },
+	] satisfies Match[]);
+});
+
+test("it detects later placeholders after an already declared input", async () => {
+	const imported = await runImportFiles({
+		complex_message: [
+			{
+				declarations: ["input known"],
+				match: {
+					"kind=yes": "{known} {newInput} {anotherInput}",
+				},
+			},
+		],
+	});
+
+	expect(imported.bundles[0]?.declarations).toStrictEqual([
+		{ type: "input-variable", name: "known" },
+		{ type: "input-variable", name: "newInput" },
+		{ type: "input-variable", name: "anotherInput" },
+		{ type: "input-variable", name: "kind" },
+	] satisfies Declaration[]);
 });
 
 test("variants with a plural function are parsed correctly", async () => {


### PR DESCRIPTION
## Summary

- Parse every selector match component independently so exported multi-selector messages reimport without whitespace-corrupted selector names or catchall values.
- Continue discovering placeholders after an already-declared input, preventing missing message inputs and downstream compiler errors.
- Export without mutating caller-owned declarations or variant matches, while preserving dependency order for chained local declarations.
- Add focused regression coverage and a patch changeset for `@inlang/plugin-message-format`.

## Verification

- `pnpm test` in `packages/plugins/inlang-message-format` (64 passed, 1 skipped; includes TypeScript checking).
- `pnpm run build` in `packages/plugins/inlang-message-format`.
- Prettier check for all modified plugin TypeScript files.
- Independent subagent reviews approved the importer and exporter changes.
