### PR TITLE
fix(sdk): upgrade Lix SDK to 0.15.1

### DIFF
--- a/.changeset/fresh-lix-rows.md
+++ b/.changeset/fresh-lix-rows.md
@@ -2,4 +2,4 @@
 "@inlang/sdk": patch
 ---
 
-Upgrade to Lix SDK 0.15.0 and migrate query results to plain JavaScript rows. Preserve transaction-local message and variant lookups, including CTE reads. Safely encode locales containing NUL characters or the reserved identity prefix during writes and snapshot restoration.
+Upgrade to Lix SDK 0.15.1 and migrate query results to plain JavaScript rows. Use the engine fix for transaction-local message and variant lookups, including CTE reads, without rewriting their SQL predicates. Safely encode locales containing NUL characters or the reserved identity prefix during writes and snapshot restoration.

--- a/.changeset/fresh-lix-rows.md
+++ b/.changeset/fresh-lix-rows.md
@@ -1,0 +1,5 @@
+---
+"@inlang/sdk": patch
+---
+
+Upgrade to Lix SDK 0.15.0 and migrate query results to plain JavaScript rows. Preserve transaction-local message and variant lookups and safely encode locales containing NUL characters.

--- a/.changeset/fresh-lix-rows.md
+++ b/.changeset/fresh-lix-rows.md
@@ -2,4 +2,4 @@
 "@inlang/sdk": patch
 ---
 
-Upgrade to Lix SDK 0.15.0 and migrate query results to plain JavaScript rows. Preserve transaction-local message and variant lookups and safely encode locales containing NUL characters.
+Upgrade to Lix SDK 0.15.0 and migrate query results to plain JavaScript rows. Preserve transaction-local message and variant lookups, including CTE reads. Safely encode locales containing NUL characters or the reserved identity prefix during writes and snapshot restoration.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -39,7 +39,7 @@
 		"node": ">=20.0.0"
 	},
 	"dependencies": {
-		"@lix-js/sdk": "0.15.0",
+		"@lix-js/sdk": "0.15.1",
 		"@sinclair/typebox": "^0.31.17",
 		"kysely": "^0.28.12",
 		"uuid": "^14.0.0"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -39,7 +39,7 @@
 		"node": ">=20.0.0"
 	},
 	"dependencies": {
-		"@lix-js/sdk": "0.12.3",
+		"@lix-js/sdk": "0.15.0",
 		"@sinclair/typebox": "^0.31.17",
 		"kysely": "^0.28.12",
 		"uuid": "^14.0.0"

--- a/packages/sdk/src/database/lixDialect.test.ts
+++ b/packages/sdk/src/database/lixDialect.test.ts
@@ -124,8 +124,50 @@ test("preserves encoded identities and locales in direct and nested reads", asyn
 		const nested = await selectBundleNested(db)
 			.where("bundle.id", "=", bundleId)
 			.executeTakeFirstOrThrow();
+		expect(nested.id).toBe(bundleId);
 		expect(nested.messages[0]).toMatchObject({ id: messageId, locale });
 		expect(nested.messages[0]?.variants[0]?.id).toBe(variantId);
+	} finally {
+		await db.destroy();
+		await lix.close();
+	}
+});
+
+test("CTE transaction reads find newly written messages and variants", async () => {
+	const lix = await openLix();
+	await registerInlangSchemas(lix);
+	const db = initDb({ lix });
+	try {
+		await db.transaction().execute(async (trx) => {
+			await trx.insertInto("bundle").values({ id: "bundle" }).execute();
+			await trx
+				.insertInto("message")
+				.values({ id: "message", bundleId: "bundle", locale: "en" })
+				.execute();
+			await trx
+				.insertInto("variant")
+				.values({ id: "variant", messageId: "message" })
+				.execute();
+			const query = trx
+				.with("matching_messages", (qb) =>
+					qb.selectFrom("message").select("id").where("locale", "=", "en")
+				)
+				.with("matching_variants", (qb) =>
+					qb
+						.selectFrom("variant")
+						.select("id")
+						.where("messageId", "=", "message")
+				)
+				.selectFrom("matching_messages")
+				.crossJoin("matching_variants")
+				.select([
+					"matching_messages.id as foundMessage",
+					"matching_variants.id as foundVariant",
+				]);
+			expect(await query.execute()).toEqual([
+				{ foundMessage: "message", foundVariant: "variant" },
+			]);
+		});
 	} finally {
 		await db.destroy();
 		await lix.close();

--- a/packages/sdk/src/database/lixDialect.test.ts
+++ b/packages/sdk/src/database/lixDialect.test.ts
@@ -14,9 +14,7 @@ test("compiles Kysely parameters with PostgreSQL placeholders", async () => {
 		.where("id", "=", "example")
 		.compile();
 
-	expect(compiled.sql).toBe(
-		'select "id" from "bundle" where "id" = $1'
-	);
+	expect(compiled.sql).toBe('select "id" from "bundle" where "id" = $1');
 	expect(compiled.parameters).toEqual(["example"]);
 
 	await db.destroy();
@@ -52,4 +50,84 @@ test("executes Kysely reads, writes, defaults, and transactions on Lix", async (
 
 	await db.destroy();
 	await lix.close();
+});
+
+test("transaction reads find newly written messages and variants by text columns", async () => {
+	const lix = await openLix();
+	await registerInlangSchemas(lix);
+	const db = initDb({ lix });
+	try {
+		await db.transaction().execute(async (trx) => {
+			await trx.insertInto("bundle").values({ id: "bundle" }).execute();
+			await trx
+				.insertInto("message")
+				.values({ id: "message", bundleId: "bundle", locale: "en" })
+				.execute();
+			await trx
+				.insertInto("variant")
+				.values({ id: "variant", messageId: "message" })
+				.execute();
+			expect(
+				await trx
+					.selectFrom("message")
+					.select("id")
+					.where("bundleId", "=", "bundle")
+					.where("locale", "=", "en")
+					.execute()
+			).toEqual([{ id: "message" }]);
+			expect(
+				await trx
+					.selectFrom("variant")
+					.select("id")
+					.where("messageId", "in", ["message"])
+					.execute()
+			).toEqual([{ id: "variant" }]);
+			expect(
+				await trx
+					.selectFrom("message")
+					.select("id")
+					.where("locale", "=", "de")
+					.execute()
+			).toEqual([]);
+		});
+	} finally {
+		await db.destroy();
+		await lix.close();
+	}
+});
+
+test("preserves encoded identities and locales in direct and nested reads", async () => {
+	const lix = await openLix();
+	await registerInlangSchemas(lix);
+	const db = initDb({ lix });
+	try {
+		const bundleId = "bundle\0id";
+		const messageId = "lixid1:message";
+		const variantId = "variant\0id";
+		const locale = "en\0US";
+		await db.insertInto("bundle").values({ id: bundleId }).execute();
+		await db
+			.insertInto("message")
+			.values({ id: messageId, bundleId, locale })
+			.execute();
+		await db
+			.insertInto("variant")
+			.values({ id: variantId, messageId })
+			.execute();
+		expect(
+			await db
+				.selectFrom("message")
+				.selectAll()
+				.where("locale", "=", locale)
+				.executeTakeFirstOrThrow()
+		).toMatchObject({ id: messageId, bundleId, locale });
+		const nested = await selectBundleNested(db)
+			.where("bundle.id", "=", bundleId)
+			.executeTakeFirstOrThrow();
+		expect(nested.messages[0]).toMatchObject({ id: messageId, locale });
+		expect(nested.messages[0]?.variants[0]?.id).toBe(variantId);
+	} finally {
+		await db.destroy();
+		await lix.close();
+	}
 });

--- a/packages/sdk/src/database/lixDialect.ts
+++ b/packages/sdk/src/database/lixDialect.ts
@@ -118,7 +118,9 @@ class LixConnection implements DatabaseConnection {
 		);
 		encodeIdentityParameters(parameters, prepared.identityParameterPositions);
 		const result = await executor.execute(
-			this.#transaction ? transactionReadSql(prepared.sql) : prepared.sql,
+			this.#transaction
+				? transactionReadSql(prepared.sql, compiledQuery.query)
+				: prepared.sql,
 			parameters as SqlParam[]
 		);
 		return {
@@ -137,8 +139,13 @@ class LixConnection implements DatabaseConnection {
  * Keep these predicates in the SQL evaluator until the engine fixes its overlay.
  * Kysely parameterizes values, so only compiled column references are rewritten.
  */
-function transactionReadSql(sql: string): string {
-	if (!/^select\s/i.test(sql)) return sql;
+function transactionReadSql(
+	sql: string,
+	query: CompiledQuery["query"]
+): string {
+	// Kysely represents WITH-prefixed reads as SelectQueryNode too. Using the
+	// query kind avoids treating WITH-prefixed mutations as read statements.
+	if (query.kind !== "SelectQueryNode" && !/^select\s/i.test(sql)) return sql;
 	return sql.replace(
 		/((?:"[^"]+"\.)?"(?:bundle_id|message_id|locale)")(?=\s*(?:=|in\s*\())/gi,
 		"($1 || '')"

--- a/packages/sdk/src/database/lixDialect.ts
+++ b/packages/sdk/src/database/lixDialect.ts
@@ -118,9 +118,7 @@ class LixConnection implements DatabaseConnection {
 		);
 		encodeIdentityParameters(parameters, prepared.identityParameterPositions);
 		const result = await executor.execute(
-			this.#transaction
-				? transactionReadSql(prepared.sql, compiledQuery.query)
-				: prepared.sql,
+			prepared.sql,
 			parameters as SqlParam[]
 		);
 		return {
@@ -132,24 +130,6 @@ class LixConnection implements DatabaseConnection {
 	async *streamQuery<R>(compiledQuery: CompiledQuery) {
 		yield await this.executeQuery<R>(compiledQuery);
 	}
-}
-
-/**
- * Lix 0.15's secondary text equality pushdown misses transaction-local rows.
- * Keep these predicates in the SQL evaluator until the engine fixes its overlay.
- * Kysely parameterizes values, so only compiled column references are rewritten.
- */
-function transactionReadSql(
-	sql: string,
-	query: CompiledQuery["query"]
-): string {
-	// Kysely represents WITH-prefixed reads as SelectQueryNode too. Using the
-	// query kind avoids treating WITH-prefixed mutations as read statements.
-	if (query.kind !== "SelectQueryNode" && !/^select\s/i.test(sql)) return sql;
-	return sql.replace(
-		/((?:"[^"]+"\.)?"(?:bundle_id|message_id|locale)")(?=\s*(?:=|in\s*\())/gi,
-		"($1 || '')"
-	);
 }
 
 type PreparedLixQuery = {

--- a/packages/sdk/src/database/lixDialect.ts
+++ b/packages/sdk/src/database/lixDialect.ts
@@ -118,11 +118,11 @@ class LixConnection implements DatabaseConnection {
 		);
 		encodeIdentityParameters(parameters, prepared.identityParameterPositions);
 		const result = await executor.execute(
-			prepared.sql,
+			this.#transaction ? transactionReadSql(prepared.sql) : prepared.sql,
 			parameters as SqlParam[]
 		);
 		return {
-			rows: result.rows.map((row) => publicRow(row.toObject())) as R[],
+			rows: result.rows.map((row) => publicRow(row)) as R[],
 			numAffectedRows: BigInt(result.rowsAffected),
 		};
 	}
@@ -130,6 +130,19 @@ class LixConnection implements DatabaseConnection {
 	async *streamQuery<R>(compiledQuery: CompiledQuery) {
 		yield await this.executeQuery<R>(compiledQuery);
 	}
+}
+
+/**
+ * Lix 0.15's secondary text equality pushdown misses transaction-local rows.
+ * Keep these predicates in the SQL evaluator until the engine fixes its overlay.
+ * Kysely parameterizes values, so only compiled column references are rewritten.
+ */
+function transactionReadSql(sql: string): string {
+	if (!/^select\s/i.test(sql)) return sql;
+	return sql.replace(
+		/((?:"[^"]+"\.)?"(?:bundle_id|message_id|locale)")(?=\s*(?:=|in\s*\())/gi,
+		"($1 || '')"
+	);
 }
 
 type PreparedLixQuery = {
@@ -246,7 +259,10 @@ function publicRow(row: Record<string, unknown>): Record<string, unknown> {
 					: column === "message_id"
 						? "messageId"
 						: column,
-				isIdentityColumn(column) && typeof value === "string"
+				(isIdentityColumn(column) ||
+					column === "messageLocale" ||
+					column === "variantId") &&
+				typeof value === "string"
 					? decodeIdentity(value)
 					: value,
 			])
@@ -254,7 +270,12 @@ function publicRow(row: Record<string, unknown>): Record<string, unknown> {
 }
 
 function isIdentityColumn(column: string): boolean {
-	return column === "id" || column === "bundle_id" || column === "message_id";
+	return (
+		column === "id" ||
+		column === "bundle_id" ||
+		column === "message_id" ||
+		column === "locale"
+	);
 }
 
 const encodedIdentityPrefix = "lixid1:";
@@ -301,7 +322,7 @@ function encodeIdentityParameters(
 
 function findIdentityParameterPositions(sql: string): number[] {
 	const positions = new Set<number>();
-	const identityColumns = "(?:id|bundle_id|message_id)";
+	const identityColumns = "(?:id|bundle_id|message_id|locale)";
 	for (const match of sql.matchAll(
 		new RegExp(`"${identityColumns}"\\s*=\\s*\\$(\\d+)`, "gi")
 	)) {

--- a/packages/sdk/src/database/registerSchemas.ts
+++ b/packages/sdk/src/database/registerSchemas.ts
@@ -17,7 +17,7 @@ export async function registerInlangSchemas(lix: Lix): Promise<void> {
 	);
 	const registeredKeys = new Set(
 		registered.rows
-			.map((row) => row.value("schema_key").toJS())
+			.map((row) => row.schema_key)
 			.filter((key): key is string => typeof key === "string")
 	);
 

--- a/packages/sdk/src/plugin/cache.test.ts
+++ b/packages/sdk/src/plugin/cache.test.ts
@@ -26,7 +26,7 @@ test("it should be network-first", async () => {
 	expect(cachedPlugins.length).toBe(1);
 
 	const parsed = new TextDecoder().decode(
-		cachedPlugins[0]!.value("content").asBytes()
+		cachedPlugins[0]!.content as Uint8Array
 	);
 
 	expect(parsed).toBe("module content 1");
@@ -45,7 +45,7 @@ test("it should be network-first", async () => {
 	expect(cachedPlugins2.length).toBe(1);
 
 	const parsed2 = new TextDecoder().decode(
-		cachedPlugins2[0]!.value("content").asBytes()
+		cachedPlugins2[0]!.content as Uint8Array
 	);
 
 	expect(parsed2).toBe("module content 2");

--- a/packages/sdk/src/plugin/cache.ts
+++ b/packages/sdk/src/plugin/cache.ts
@@ -21,14 +21,14 @@ async function readModuleFromCache(
 	const moduleHash = escape(moduleURI);
 	const filePath = `/cache/plugins/${moduleHash}`;
 
-	const result = await lix.execute(
+	const result = await lix.execute<{ content: Uint8Array }>(
 		"SELECT content FROM lix_file WHERE path = $1",
 		[filePath]
 	);
 	const file = result.rows[0];
 
 	if (file) {
-		return new TextDecoder().decode(file.value("content").asBytes());
+		return new TextDecoder().decode(file.content);
 	}
 	return undefined;
 }

--- a/packages/sdk/src/project/loadProject.test.ts
+++ b/packages/sdk/src/project/loadProject.test.ts
@@ -117,7 +117,7 @@ test("uses the active account owned by Lix", async () => {
 		"SELECT id, kind, status FROM lix_account WHERE id = $1",
 		[activeAccountId]
 	);
-	const activeAccount = result.rows[0]?.toObject();
+	const activeAccount = result.rows[0];
 
 	expect(activeAccount).toMatchObject({
 		id: activeAccountId,

--- a/packages/sdk/src/project/loadProject.ts
+++ b/packages/sdk/src/project/loadProject.ts
@@ -143,17 +143,17 @@ async function readLixId(lix: Lix): Promise<string> {
 	const result = await lix.execute(
 		"SELECT value FROM lix_key_value WHERE key = 'lix_id'"
 	);
-	const id = result.rows[0]?.value("value").toJS();
+	const id = result.rows[0]?.value;
 	if (typeof id !== "string") throw new Error("Missing Lix id");
 	return id;
 }
 
 async function readLixFile(lix: Lix, path: string): Promise<Uint8Array> {
-	const result = await lix.execute(
+	const result = await lix.execute<{ content: Uint8Array }>(
 		"SELECT content FROM lix_file WHERE path = $1",
 		[path]
 	);
-	const data = result.rows[0]?.value("content").asBytes();
+	const data = result.rows[0]?.content;
 	if (!data) throw new Error(`Missing project file: ${path}`);
 	return data;
 }

--- a/packages/sdk/src/project/loadProjectFromDirectory.test.ts
+++ b/packages/sdk/src/project/loadProjectFromDirectory.test.ts
@@ -31,8 +31,8 @@ async function selectLixFiles(
 		params
 	);
 	return result.rows.map((row) => ({
-		path: row.get("path") as string,
-		content: row.value("content").asBytes() ?? new Uint8Array(),
+		path: row.path as string,
+		content: (row.content as Uint8Array | null) ?? new Uint8Array(),
 	}));
 }
 
@@ -40,7 +40,7 @@ async function selectLixId(lix: Lix) {
 	const result = await lix.execute(
 		"SELECT value FROM lix_key_value WHERE key = 'lix_id'"
 	);
-	return result.rows[0]?.value("value").toJS();
+	return result.rows[0]?.value;
 }
 
 async function selectLixFile(lix: Lix, path: string) {

--- a/packages/sdk/src/project/loadProjectFromDirectory.ts
+++ b/packages/sdk/src/project/loadProjectFromDirectory.ts
@@ -328,8 +328,8 @@ async function syncLixFsFiles(args: {
 		const filesInLix = (
 			await args.lix.execute("SELECT path, content FROM lix_file")
 		).rows.map((row) => ({
-			path: row.get("path") as string,
-			content: row.value("content").asBytes()!,
+			path: row.path as string,
+			content: row.content as Uint8Array,
 		}));
 
 		for (const fileInLix of filesInLix) {
@@ -340,7 +340,7 @@ async function syncLixFsFiles(args: {
 			// NOTE we could start with comparing the mdate and skip file read completely...
 			if (!currentStateOfFileInLix) {
 				currentLixState[fileInLix.path] = {
-				content: new Uint8Array(fileInLix.content).buffer,
+					content: new Uint8Array(fileInLix.content).buffer,
 					state: "unknown",
 				};
 			} else {

--- a/packages/sdk/src/project/loadProjectInMemory.test.ts
+++ b/packages/sdk/src/project/loadProjectInMemory.test.ts
@@ -149,3 +149,63 @@ test("serializes bundles with nested messages and variants", async () => {
 	).toBe("welcome_en_admin");
 	await reopenedLegacy.close();
 });
+
+test.each([
+	{ locale: "en\0US", encodedIds: false },
+	{ locale: "lixid1:en", encodedIds: false },
+	{ locale: "en\0US", encodedIds: true },
+	{ locale: "lixid1:en", encodedIds: true },
+])(
+	"snapshot roundtrip preserves locales and identities: $locale, encodedIds=$encodedIds",
+	async ({ locale, encodedIds }) => {
+		const project = await loadProjectInMemory({ blob: await newProject() });
+		let blob: Blob;
+		const bundleId = encodedIds ? "bundle\0id" : "bundle";
+		const messageId = encodedIds ? "lixid1:message" : "message";
+		const variantId = encodedIds ? "variant\0id" : "variant";
+		try {
+			await insertBundleNested(project.db, {
+				id: bundleId,
+				messages: [
+					{
+						id: messageId,
+						bundleId,
+						locale,
+						variants: [{ id: variantId, messageId, matches: [], pattern: [] }],
+					},
+				],
+			});
+			blob = await project.toBlob();
+			const snapshot = JSON.parse(await blob.text());
+			expect(snapshot.bundles[0]).toMatchObject({
+				id: bundleId,
+				messages: [{ id: messageId, locale, variants: [{ id: variantId }] }],
+			});
+		} finally {
+			await project.close();
+		}
+		const reopened = await loadProjectInMemory({ blob });
+		try {
+			expect(
+				await reopened.db
+					.selectFrom("message")
+					.selectAll()
+					.where("locale", "=", locale)
+					.executeTakeFirstOrThrow()
+			).toMatchObject({ id: messageId, bundleId, locale });
+			const nested = await selectBundleNested(reopened.db)
+				.where("bundle.id", "=", bundleId)
+				.executeTakeFirstOrThrow();
+			expect(nested.messages[0]).toMatchObject({
+				id: messageId,
+				locale,
+				variants: [{ id: variantId, messageId }],
+			});
+			expect(
+				JSON.parse(await (await reopened.toBlob()).text()).bundles
+			).toEqual(JSON.parse(await blob.text()).bundles);
+		} finally {
+			await reopened.close();
+		}
+	}
+);

--- a/packages/sdk/src/project/newProject.test.ts
+++ b/packages/sdk/src/project/newProject.test.ts
@@ -35,7 +35,7 @@ test("it should have the lix id as project id", async () => {
 	const lixIdResult = await project.lix.execute(
 		"SELECT value FROM lix_key_value WHERE key = 'lix_id'"
 	);
-	const lixId = lixIdResult.rows[0]?.value("value").toJS();
+	const lixId = lixIdResult.rows[0]?.value;
 
 	const projectId = await project.id.get();
 	expect(projectId).toBeDefined();

--- a/packages/sdk/src/project/openProject.test.ts
+++ b/packages/sdk/src/project/openProject.test.ts
@@ -20,7 +20,7 @@ test("opens a project on a caller-owned Lix", async () => {
 	);
 	expect(
 		registeredSchemas.rows
-			.map((row) => row.value("schema_key").toJS())
+			.map((row) => row.schema_key)
 			.filter((key) => typeof key === "string" && key.startsWith("inlang_"))
 			.sort()
 	).toEqual(["inlang_bundle", "inlang_message", "inlang_variant"]);

--- a/packages/sdk/src/project/saveProjectToDirectory.ts
+++ b/packages/sdk/src/project/saveProjectToDirectory.ts
@@ -93,8 +93,8 @@ export async function saveProjectToDirectory(args: {
 	const files = (
 		await args.project.lix.execute("SELECT path, content FROM lix_file")
 	).rows.map((row) => ({
-		path: row.get("path") as string,
-		content: row.value("content").asBytes()!,
+		path: row.path as string,
+		content: row.content as Uint8Array,
 	}));
 
 	const gitignoreContent = new TextEncoder().encode(

--- a/packages/sdk/src/project/snapshot.ts
+++ b/packages/sdk/src/project/snapshot.ts
@@ -1,4 +1,4 @@
-import type { Lix, LixBatchStatement } from "@lix-js/sdk";
+import type { Lix, LixBatchStatement, ExecuteResult } from "@lix-js/sdk";
 import { initDb } from "../database/initDb.js";
 import type {
 	Bundle,
@@ -35,29 +35,31 @@ type LegacySnapshot = {
 
 export async function projectToBlob(lix: Lix): Promise<Blob> {
 	const db = initDb({ lix });
-	let lixIdResult: Awaited<ReturnType<Lix["execute"]>>;
-	let files: Awaited<ReturnType<Lix["execute"]>>;
+	let lixIdResult: ExecuteResult;
+	let files: ExecuteResult<{ path: string; content: Uint8Array | null }>;
 	let bundles: BundleNested[];
 	try {
 		[lixIdResult, files, bundles] = await Promise.all([
 			lix.execute("SELECT value FROM lix_key_value WHERE key = 'lix_id'"),
-			lix.execute("SELECT path, content FROM lix_file ORDER BY path"),
+			lix.execute<{ path: string; content: Uint8Array | null }>(
+				"SELECT path, content FROM lix_file ORDER BY path"
+			),
 			selectBundleNested(db).execute(),
 		]);
 	} finally {
 		await db.destroy();
 	}
-	const lixId = lixIdResult.rows[0]?.value("value").toJS();
+	const lixId = lixIdResult.rows[0]?.value;
 	if (typeof lixId !== "string") throw new Error("Missing Lix id");
 
 	const snapshot: Snapshot = {
 		format: FORMAT,
 		lixId,
 		files: files.rows
-			.filter((row) => row.get("path") !== "/project_id")
+			.filter((row) => row.path !== "/project_id")
 			.map((row) => ({
-				path: row.get("path") as string,
-				data: bytesToBase64(row.value("content").asBytes() ?? new Uint8Array()),
+				path: row.path,
+				data: bytesToBase64(row.content ?? new Uint8Array()),
 			})),
 		bundles,
 	};

--- a/packages/sdk/src/project/snapshot.ts
+++ b/packages/sdk/src/project/snapshot.ts
@@ -1,4 +1,6 @@
 import type { Lix, LixBatchStatement, ExecuteResult } from "@lix-js/sdk";
+import { compileBundleNestedBatch } from "../query-utilities/compileBundleNestedBatch.js";
+import { compileLixQuery } from "../database/lixDialect.js";
 import { initDb } from "../database/initDb.js";
 import type {
 	Bundle,
@@ -111,24 +113,18 @@ export async function restoreProjectBlob(lix: Lix, blob: Blob): Promise<void> {
 		snapshot.format === LEGACY_FORMAT
 			? nestLegacyBundles(snapshot)
 			: snapshot.bundles;
-	for (const bundle of bundles) {
-		statements.push({
-			sql: "INSERT INTO inlang_bundle (id, declarations) VALUES ($1, $2)",
-			params: [bundle.id, bundle.declarations],
-		});
-		for (const message of bundle.messages) {
-			statements.push({
-				sql: "INSERT INTO inlang_message (id, bundle_id, locale, selectors) VALUES ($1, $2, $3, $4)",
-				params: [message.id, bundle.id, message.locale, message.selectors],
-			});
-			for (const variant of message.variants) {
-				statements.push({
-					sql: "INSERT INTO inlang_variant (id, message_id, matches, pattern) VALUES ($1, $2, $3, $4)",
-					params: [variant.id, message.id, variant.matches, variant.pattern],
-				});
-			}
+	const db = initDb({ lix });
+	try {
+		// Use the same compilation and text encoding as ordinary nested writes.
+		for (const bundle of bundles) {
+			statements.push(
+				...compileBundleNestedBatch(db, bundle, "insert").map(compileLixQuery)
+			);
 		}
+	} finally {
+		await db.destroy();
 	}
+
 	if (statements.length > 0) await lix.executeBatch(statements);
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -840,8 +840,8 @@ importers:
   packages/sdk:
     dependencies:
       '@lix-js/sdk':
-        specifier: 0.12.3
-        version: 0.12.3
+        specifier: 0.15.0
+        version: 0.15.0
       '@sinclair/typebox':
         specifier: ^0.31.17
         version: 0.31.28
@@ -3304,28 +3304,28 @@ packages:
     resolution: {integrity: sha512-B9X3FjD8WmdG7tbA44JuniSO0KdKBWnjfxl8zpgrDCkavrp/GP7U0xxBkc0WgeeoHjQ/pkqq9VqtWB2kS9jIUg==}
     deprecated: use the lix sdk instead https://www.npmjs.com/package/@lix-js/sdk
 
-  '@lix-js/sdk-darwin-arm64@0.12.3':
-    resolution: {integrity: sha512-YeMJyYGk+QwvQe8O4AAcBMgfNm68IjAGDvuvZHr1U1rIb3GC2kYFStajqf4mT4BGc+cN65/P/2kkqEo+Igu/sA==}
+  '@lix-js/sdk-darwin-arm64@0.15.0':
+    resolution: {integrity: sha512-r4eZNPhojKSqXId6ODvQUezkzk4cKtSxG7hqALz3feHfIOtzMmsDQosFza+T7OQP1to5xU5SBzK0ibR/ZFD4Ew==}
     cpu: [arm64]
     os: [darwin]
 
-  '@lix-js/sdk-linux-arm64@0.12.3':
-    resolution: {integrity: sha512-jtmfNg6jLW61l1QvsU3W184l3hGtYUyPGzZrQyekk0vsMF1hxsP++7ONEGNI19PE7ldwSnGCB8Q6OzRKX87abQ==}
+  '@lix-js/sdk-linux-arm64@0.15.0':
+    resolution: {integrity: sha512-Fv+zKzYvuwqNvrKpBRo5RKSSK+InK9XAqTV0aaWaQSDXgP48LSySshOoWn9Oh6bvJeslg7q0POAJKL4oTJjZPg==}
     cpu: [arm64]
     os: [linux]
 
-  '@lix-js/sdk-linux-x64@0.12.3':
-    resolution: {integrity: sha512-PiQL4h1FJXbxnZx/PgenI5grgpFtYlS/ZtPtTYh638YHVu+6J0cqGY/pLVqP8CKv1dWAKsZ2YgftLd+1j2+WKA==}
+  '@lix-js/sdk-linux-x64@0.15.0':
+    resolution: {integrity: sha512-ZDLbTrBXADFybZzc4RNkDGtUwz1SVk0zv4AebmC3R/gNZgJ3r56aOukPLKW8CEeimLmEewt5ce2N09T9w4ynGA==}
     cpu: [x64]
     os: [linux]
 
-  '@lix-js/sdk-win32-x64@0.12.3':
-    resolution: {integrity: sha512-hnxMI7kPS4ngXs0ZVnOve5CmtC4+vaNIyNDi/yWU0rSvxj7mqw/1RCegTrCB7LjxlX4DG+eg9HruXurk9NDjGg==}
+  '@lix-js/sdk-win32-x64@0.15.0':
+    resolution: {integrity: sha512-ZAs43Ra0gT/Jgu0NdnCPfxCK8qMI9h1isKEqhE5ry9yHpY5TUaZiZxP3dH0eFHCoL8nkLL748H8m9SzkxF0rkQ==}
     cpu: [x64]
     os: [win32]
 
-  '@lix-js/sdk@0.12.3':
-    resolution: {integrity: sha512-T2194yoZsM2S9kyRmI8UtEJL0fgXYAkeY9jZ/PVyC0K78/wmBvrqOSt9SdvgYxM5qnZ57re3NLOjVlV+X5hWxQ==}
+  '@lix-js/sdk@0.15.0':
+    resolution: {integrity: sha512-kYu4TcGPcKl4G6TJWo9uTT0sGwsPiP6gMHEazCOyOL9cwoHr3H64MCftIuUpyiVsNWR9dK6eIwRFTxOD137iXQ==}
 
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -7030,7 +7030,6 @@ packages:
   eslint@8.57.1:
     resolution: {integrity: sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
 
   eslint@9.29.0:
@@ -13699,26 +13698,26 @@ snapshots:
     dependencies:
       typescript: 5.2.2
 
-  '@lix-js/sdk-darwin-arm64@0.12.3':
+  '@lix-js/sdk-darwin-arm64@0.15.0':
     optional: true
 
-  '@lix-js/sdk-linux-arm64@0.12.3':
+  '@lix-js/sdk-linux-arm64@0.15.0':
     optional: true
 
-  '@lix-js/sdk-linux-x64@0.12.3':
+  '@lix-js/sdk-linux-x64@0.15.0':
     optional: true
 
-  '@lix-js/sdk-win32-x64@0.12.3':
+  '@lix-js/sdk-win32-x64@0.15.0':
     optional: true
 
-  '@lix-js/sdk@0.12.3':
+  '@lix-js/sdk@0.15.0':
     dependencies:
       fflate: 0.8.3
     optionalDependencies:
-      '@lix-js/sdk-darwin-arm64': 0.12.3
-      '@lix-js/sdk-linux-arm64': 0.12.3
-      '@lix-js/sdk-linux-x64': 0.12.3
-      '@lix-js/sdk-win32-x64': 0.12.3
+      '@lix-js/sdk-darwin-arm64': 0.15.0
+      '@lix-js/sdk-linux-arm64': 0.15.0
+      '@lix-js/sdk-linux-x64': 0.15.0
+      '@lix-js/sdk-win32-x64': 0.15.0
 
   '@manypkg/find-root@1.1.0':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -840,8 +840,8 @@ importers:
   packages/sdk:
     dependencies:
       '@lix-js/sdk':
-        specifier: 0.15.0
-        version: 0.15.0
+        specifier: 0.15.1
+        version: 0.15.1
       '@sinclair/typebox':
         specifier: ^0.31.17
         version: 0.31.28
@@ -3304,28 +3304,23 @@ packages:
     resolution: {integrity: sha512-B9X3FjD8WmdG7tbA44JuniSO0KdKBWnjfxl8zpgrDCkavrp/GP7U0xxBkc0WgeeoHjQ/pkqq9VqtWB2kS9jIUg==}
     deprecated: use the lix sdk instead https://www.npmjs.com/package/@lix-js/sdk
 
-  '@lix-js/sdk-darwin-arm64@0.15.0':
-    resolution: {integrity: sha512-r4eZNPhojKSqXId6ODvQUezkzk4cKtSxG7hqALz3feHfIOtzMmsDQosFza+T7OQP1to5xU5SBzK0ibR/ZFD4Ew==}
+  '@lix-js/sdk-darwin-arm64@0.15.1':
+    resolution: {integrity: sha512-RTe5hNe8lkF4uZ/ktKQFaXbFtowf617XTLs8Q/lPbAvCN/87A7KkmGyWV2mO8uZyposn/UO8q2NnD2yns8bPPA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@lix-js/sdk-linux-arm64@0.15.0':
-    resolution: {integrity: sha512-Fv+zKzYvuwqNvrKpBRo5RKSSK+InK9XAqTV0aaWaQSDXgP48LSySshOoWn9Oh6bvJeslg7q0POAJKL4oTJjZPg==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@lix-js/sdk-linux-x64@0.15.0':
-    resolution: {integrity: sha512-ZDLbTrBXADFybZzc4RNkDGtUwz1SVk0zv4AebmC3R/gNZgJ3r56aOukPLKW8CEeimLmEewt5ce2N09T9w4ynGA==}
+  '@lix-js/sdk-linux-x64@0.15.1':
+    resolution: {integrity: sha512-gCEN5Ql2JvQn4MpwiILpmFxxO3AHAfmoa4mMvBWFwdKUICaJf5Yzr0zUfHEeLYtvcKpXbpu6dxyZ+AOc8I18ng==}
     cpu: [x64]
     os: [linux]
 
-  '@lix-js/sdk-win32-x64@0.15.0':
-    resolution: {integrity: sha512-ZAs43Ra0gT/Jgu0NdnCPfxCK8qMI9h1isKEqhE5ry9yHpY5TUaZiZxP3dH0eFHCoL8nkLL748H8m9SzkxF0rkQ==}
+  '@lix-js/sdk-win32-x64@0.15.1':
+    resolution: {integrity: sha512-hyo2Sj67mBwhMZ2DFO1UgN4barByYiHojUnVQI9WGue5Slva5vBusbecQG1XSXrYv6HkVxLpS2zwUrr7DTjWQg==}
     cpu: [x64]
     os: [win32]
 
-  '@lix-js/sdk@0.15.0':
-    resolution: {integrity: sha512-kYu4TcGPcKl4G6TJWo9uTT0sGwsPiP6gMHEazCOyOL9cwoHr3H64MCftIuUpyiVsNWR9dK6eIwRFTxOD137iXQ==}
+  '@lix-js/sdk@0.15.1':
+    resolution: {integrity: sha512-mgtPwKg1Etx4NLGADesa+0DNkwVYOrSsIFVhv+VaBGJTisFYMVMucgzYXZQ1XHRpA1jxdFaKhheK3x3tArvv8Q==}
 
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -13698,26 +13693,22 @@ snapshots:
     dependencies:
       typescript: 5.2.2
 
-  '@lix-js/sdk-darwin-arm64@0.15.0':
+  '@lix-js/sdk-darwin-arm64@0.15.1':
     optional: true
 
-  '@lix-js/sdk-linux-arm64@0.15.0':
+  '@lix-js/sdk-linux-x64@0.15.1':
     optional: true
 
-  '@lix-js/sdk-linux-x64@0.15.0':
+  '@lix-js/sdk-win32-x64@0.15.1':
     optional: true
 
-  '@lix-js/sdk-win32-x64@0.15.0':
-    optional: true
-
-  '@lix-js/sdk@0.15.0':
+  '@lix-js/sdk@0.15.1':
     dependencies:
       fflate: 0.8.3
     optionalDependencies:
-      '@lix-js/sdk-darwin-arm64': 0.15.0
-      '@lix-js/sdk-linux-arm64': 0.15.0
-      '@lix-js/sdk-linux-x64': 0.15.0
-      '@lix-js/sdk-win32-x64': 0.15.0
+      '@lix-js/sdk-darwin-arm64': 0.15.1
+      '@lix-js/sdk-linux-x64': 0.15.1
+      '@lix-js/sdk-win32-x64': 0.15.1
 
   '@manypkg/find-root@1.1.0':
     dependencies:


### PR DESCRIPTION
Upgrade `@inlang/sdk` from Lix 0.12.3 to 0.15.1 and migrate database, file, cache, and snapshot reads to its plain JavaScript row API.

Transaction-local message and variant lookups, including CTE-backed reads, now use the engine fix released in Lix 0.15.1 (opral/lix#1696). The SQL predicate workaround has been removed. Encode locales containing NUL characters or the reserved identity prefix, and restore snapshots through the same compilation and encoding path as normal nested writes.

Regression coverage checks transaction-local CTE lookups, nested identity decoding, and snapshot roundtrips with encoded locales and IDs. Includes a patch changeset for `@inlang/sdk` and the updated lockfile.

Validation against the published Lix 0.15.1 package:
- All 5 dialect tests passed with the SQL workaround removed, including direct and CTE transaction reads.
- Full `pnpm run ci` passed: builds for 20 projects, lint for 3 projects, and 728 passing tests across 19 test targets. Existing skips and todos remain. All test commands ran; Nx reused some dependency build tasks.
- `pnpm exec changeset status` and `git diff --check` passed.
