### PR TITLE
Fix Lix transaction lifecycle and snapshot restoration

### DIFF
--- a/.changeset/tidy-lix-transactions.md
+++ b/.changeset/tidy-lix-transactions.md
@@ -3,3 +3,5 @@
 ---
 
 Preserve the original error when a Lix transaction commit fails. Serialize Kysely connection leases so unrelated queries cannot join another caller's transaction and concurrent transactions execute independently. Beginning, committing, or rolling back a controlled transaction now releases its connection if it fails. Consumed transactions reject further queries instead of executing outside the transaction.
+
+Restoring an in-memory project snapshot replaces file content at snapshot-owned paths, including files initialized by Lix, while preserving unrelated destination files.

--- a/.changeset/tidy-lix-transactions.md
+++ b/.changeset/tidy-lix-transactions.md
@@ -1,0 +1,5 @@
+---
+"@inlang/sdk": patch
+---
+
+Preserve the original error when a Lix transaction commit fails. Serialize Kysely connection leases so unrelated queries cannot join another caller's transaction and concurrent transactions execute independently. Beginning, committing, or rolling back a controlled transaction now releases its connection if it fails. Consumed transactions reject further queries instead of executing outside the transaction.

--- a/packages/sdk/src/database/lixDialect.test.ts
+++ b/packages/sdk/src/database/lixDialect.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 import { openLix } from "@lix-js/sdk";
 import { initDb } from "./initDb.js";
 import { registerInlangSchemas } from "./registerSchemas.js";
@@ -169,6 +169,252 @@ test("CTE transaction reads find newly written messages and variants", async () 
 			]);
 		});
 	} finally {
+		await db.destroy();
+		await lix.close();
+	}
+});
+
+test("preserves a consumed commit failure and permits a subsequent transaction", async () => {
+	const lix = await openLix();
+	await registerInlangSchemas(lix);
+	const db = initDb({ lix });
+	const commitError = new Error("durable commit failed");
+	const begin = lix.beginTransaction.bind(lix);
+	const beginSpy = vi
+		.spyOn(lix, "beginTransaction")
+		.mockImplementationOnce(async () => {
+			const transaction = await begin();
+			vi.spyOn(transaction, "commit").mockImplementationOnce(async () => {
+				// Match the Lix contract: a failed terminal call consumes its handle.
+				await transaction.rollback();
+				throw commitError;
+			});
+			return transaction;
+		});
+	try {
+		await expect(
+			db.transaction().execute(async (trx) => {
+				await trx.insertInto("bundle").values({ id: "failed" }).execute();
+			})
+		).rejects.toBe(commitError);
+		expect(await db.selectFrom("bundle").selectAll().execute()).toEqual([]);
+		await db.transaction().execute(async (trx) => {
+			await trx.insertInto("bundle").values({ id: "next" }).execute();
+		});
+		expect(await db.selectFrom("bundle").select("id").execute()).toEqual([
+			{ id: "next" },
+		]);
+	} finally {
+		beginSpy.mockRestore();
+		await db.destroy();
+		await lix.close();
+	}
+});
+
+test("unrelated queries wait for the transaction lease and survive its rollback", async () => {
+	const lix = await openLix();
+	await registerInlangSchemas(lix);
+	const db = initDb({ lix });
+	const callbackError = new Error("abort transaction");
+	let entered!: () => void;
+	const transactionEntered = new Promise<void>((resolve) => {
+		entered = resolve;
+	});
+	let abort!: () => void;
+	const mayAbort = new Promise<void>((resolve) => {
+		abort = resolve;
+	});
+	try {
+		const transaction = db.transaction().execute(async (trx) => {
+			await trx.insertInto("bundle").values({ id: "rolled-back" }).execute();
+			entered();
+			await mayAbort;
+			throw callbackError;
+		});
+		const rejected = expect(transaction).rejects.toBe(callbackError);
+		await transactionEntered;
+		// Queue a write outside the transaction before releasing its lease.
+		const independent = db
+			.insertInto("bundle")
+			.values({ id: "independent" })
+			.execute();
+		abort();
+		await rejected;
+		await independent;
+		expect(await db.selectFrom("bundle").select("id").execute()).toEqual([
+			{ id: "independent" },
+		]);
+	} finally {
+		abort?.();
+		await db.destroy();
+		await lix.close();
+	}
+});
+
+test("serializes concurrent transactions without rejecting or mixing their writes", async () => {
+	const lix = await openLix();
+	await registerInlangSchemas(lix);
+	const db = initDb({ lix });
+	try {
+		const results = await Promise.allSettled(
+			["first", "second"].map((id) =>
+				db.transaction().execute(async (trx) => {
+					await trx.insertInto("bundle").values({ id }).execute();
+				})
+			)
+		);
+		expect(
+			await db.selectFrom("bundle").select("id").orderBy("id").execute()
+		).toEqual([{ id: "first" }, { id: "second" }]);
+		expect(results.map((result) => result.status)).toEqual([
+			"fulfilled",
+			"fulfilled",
+		]);
+	} finally {
+		await db.destroy();
+		await lix.close();
+	}
+});
+
+test("releases the connection lease when beginning a transaction fails", async () => {
+	const lix = await openLix();
+	const db = initDb({ lix });
+	const beginError = new Error("cannot begin transaction");
+	const beginSpy = vi
+		.spyOn(lix, "beginTransaction")
+		.mockRejectedValueOnce(beginError);
+	try {
+		await expect(db.transaction().execute(async () => {})).rejects.toBe(
+			beginError
+		);
+		await db.transaction().execute(async () => {});
+	} finally {
+		beginSpy.mockRestore();
+		await db.destroy();
+		await lix.close();
+	}
+});
+
+test("surfaces a rollback failure and releases the consumed transaction", async () => {
+	const lix = await openLix();
+	const db = initDb({ lix });
+	const rollbackError = new Error("rollback failed");
+	const begin = lix.beginTransaction.bind(lix);
+	const beginSpy = vi
+		.spyOn(lix, "beginTransaction")
+		.mockImplementationOnce(async () => {
+			const transaction = await begin();
+			const rollback = transaction.rollback.bind(transaction);
+			vi.spyOn(transaction, "rollback").mockImplementationOnce(async () => {
+				await rollback();
+				throw rollbackError;
+			});
+			return transaction;
+		});
+	try {
+		await expect(
+			db.transaction().execute(async () => {
+				throw new Error("abort");
+			})
+		).rejects.toBe(rollbackError);
+		await db.transaction().execute(async () => {});
+	} finally {
+		beginSpy.mockRestore();
+		await db.destroy();
+		await lix.close();
+	}
+});
+
+test("controlled begin failure releases its lease", async () => {
+	const lix = await openLix();
+	const db = initDb({ lix });
+	const failure = new Error("begin failed");
+	const begin = vi
+		.spyOn(lix, "beginTransaction")
+		.mockRejectedValueOnce(failure);
+	try {
+		await expect(db.startTransaction().execute()).rejects.toBe(failure);
+		const next = await db.startTransaction().execute();
+		await next.rollback().execute();
+	} finally {
+		begin.mockRestore();
+		await db.destroy();
+		await lix.close();
+	}
+});
+
+test.each(["commit", "rollback"] as const)(
+	"controlled %s failure consumes the connection and releases its lease",
+	async (kind) => {
+		const lix = await openLix();
+		await registerInlangSchemas(lix);
+		const db = initDb({ lix });
+		const failure = new Error(`${kind} failed`);
+		const begin = lix.beginTransaction.bind(lix);
+		const beginSpy = vi
+			.spyOn(lix, "beginTransaction")
+			.mockImplementationOnce(async () => {
+				const transaction = await begin();
+				const rollback = transaction.rollback.bind(transaction);
+				vi.spyOn(transaction, kind).mockImplementationOnce(async () => {
+					await rollback();
+					throw failure;
+				});
+				return transaction;
+			});
+		try {
+			const transaction = await db.startTransaction().execute();
+			await transaction
+				.insertInto("bundle")
+				.values({ id: "discarded" })
+				.execute();
+			await expect(transaction[kind]().execute()).rejects.toBe(failure);
+			await expect(
+				transaction.insertInto("bundle").values({ id: "escaped" }).execute()
+			).rejects.toThrow("connection is closed");
+			await db.transaction().execute(async (next) => {
+				await next.insertInto("bundle").values({ id: "next" }).execute();
+			});
+			expect(await db.selectFrom("bundle").select("id").execute()).toEqual([
+				{ id: "next" },
+			]);
+		} finally {
+			beginSpy.mockRestore();
+			await db.destroy();
+			await lix.close();
+		}
+	}
+);
+
+test("cleanup of a failed controlled commit cannot release a later caller's lease", async () => {
+	const lix = await openLix();
+	const db = initDb({ lix });
+	const failure = new Error("commit failed");
+	const begin = lix.beginTransaction.bind(lix);
+	const beginSpy = vi
+		.spyOn(lix, "beginTransaction")
+		.mockImplementationOnce(async () => {
+			const transaction = await begin();
+			vi.spyOn(transaction, "commit").mockImplementationOnce(async () => {
+				await transaction.rollback();
+				throw failure;
+			});
+			return transaction;
+		});
+	try {
+		const first = await db.startTransaction().execute();
+		await expect(first.commit().execute()).rejects.toBe(failure);
+		const second = await db.startTransaction().execute();
+		const third = db.startTransaction().execute();
+		await first.rollback().execute();
+		// Drain the event loop while the second caller still owns the lease.
+		await new Promise<void>((resolve) => setImmediate(resolve));
+		expect(beginSpy).toHaveBeenCalledTimes(2);
+		await second.rollback().execute();
+		await (await third).rollback().execute();
+		expect(beginSpy).toHaveBeenCalledTimes(3);
+	} finally {
+		beginSpy.mockRestore();
 		await db.destroy();
 		await lix.close();
 	}

--- a/packages/sdk/src/database/lixDialect.ts
+++ b/packages/sdk/src/database/lixDialect.ts
@@ -42,16 +42,26 @@ export class LixDialect implements Dialect {
 }
 
 class LixDriver implements Driver {
-	readonly #connection: LixConnection;
+	readonly #lix: Lix;
+	readonly #preparedQueries = new Map<string, PreparedLixQuery>();
+	#lease: Promise<void> = Promise.resolve();
 
 	constructor(lix: Lix) {
-		this.#connection = new LixConnection(lix);
+		this.#lix = lix;
 	}
 
 	async init(): Promise<void> {}
 
 	async acquireConnection(): Promise<DatabaseConnection> {
-		return this.#connection;
+		// Every caller owns its own lease. Terminal failures can release it even
+		// when Kysely's controlled API skips cleanup; later cleanup is idempotent.
+		const previousLease = this.#lease;
+		let release!: () => void;
+		this.#lease = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		await previousLease;
+		return new LixConnection(this.#lix, this.#preparedQueries, release);
 	}
 
 	async beginTransaction(connection: DatabaseConnection): Promise<void> {
@@ -66,52 +76,101 @@ class LixDriver implements Driver {
 		await (connection as LixConnection).rollbackTransaction();
 	}
 
-	async releaseConnection(): Promise<void> {}
-	async destroy(): Promise<void> {
-		await this.#connection.destroy();
-	}
-}
-
-class LixConnection implements DatabaseConnection {
-	readonly #lix: Lix;
-	readonly #preparedQueries = new Map<string, PreparedLixQuery>();
-	#transaction: LixTransaction | undefined;
-
-	constructor(lix: Lix) {
-		this.#lix = lix;
-	}
-
-	async beginTransaction(): Promise<void> {
-		if (this.#transaction)
-			throw new Error("A Lix transaction is already active");
-		this.#transaction = await this.#lix.beginTransaction();
+	async releaseConnection(connection: DatabaseConnection): Promise<void> {
+		(connection as LixConnection).release();
 	}
 
 	async destroy(): Promise<void> {
 		this.#preparedQueries.clear();
 	}
+}
+
+type TransactionState =
+	| { kind: "idle" | "starting" | "finishing" | "commit-failed" | "closed" }
+	| { kind: "active"; transaction: LixTransaction };
+
+class LixConnection implements DatabaseConnection {
+	#state: TransactionState = { kind: "idle" };
+	#released = false;
+
+	constructor(
+		private readonly lix: Lix,
+		private readonly preparedQueries: Map<string, PreparedLixQuery>,
+		readonly releaseLease: () => void
+	) {}
+
+	release(): void {
+		if (this.#released) return;
+		this.#released = true;
+		this.releaseLease();
+	}
+
+	async beginTransaction(): Promise<void> {
+		if (this.#released || this.#state.kind !== "idle")
+			throw new Error("The Lix connection cannot begin a transaction");
+		this.#state = { kind: "starting" };
+		try {
+			this.#state = {
+				kind: "active",
+				transaction: await this.lix.beginTransaction(),
+			};
+		} catch (error) {
+			this.#state = { kind: "closed" };
+			this.release();
+			throw error;
+		}
+	}
 
 	async commitTransaction(): Promise<void> {
-		const transaction = this.#transaction;
-		if (!transaction) throw new Error("No Lix transaction is active");
-		this.#transaction = undefined;
-		await transaction.commit();
+		if (this.#state.kind !== "active")
+			throw new Error("No Lix transaction is active");
+		const { transaction } = this.#state;
+		this.#state = { kind: "finishing" };
+		try {
+			await transaction.commit();
+			this.#state = { kind: "closed" };
+		} catch (error) {
+			// Lix consumes failed commits. Kysely's subsequent rollback only
+			// acknowledges cleanup, preserving the original commit error.
+			this.#state = { kind: "commit-failed" };
+			throw error;
+		} finally {
+			this.release();
+		}
 	}
 
 	async rollbackTransaction(): Promise<void> {
-		const transaction = this.#transaction;
-		if (!transaction) throw new Error("No Lix transaction is active");
-		this.#transaction = undefined;
-		await transaction.rollback();
+		if (this.#state.kind === "commit-failed") {
+			this.#state = { kind: "closed" };
+			return;
+		}
+		if (this.#state.kind !== "active")
+			throw new Error("No Lix transaction is active");
+		const { transaction } = this.#state;
+		this.#state = { kind: "finishing" };
+		try {
+			await transaction.rollback();
+		} finally {
+			this.#state = { kind: "closed" };
+			this.release();
+		}
 	}
 
 	async executeQuery<R>(compiledQuery: CompiledQuery): Promise<QueryResult<R>> {
-		const executor = this.#transaction ?? this.#lix;
-		let prepared = this.#preparedQueries.get(compiledQuery.sql);
+		if (
+			this.#released ||
+			(this.#state.kind !== "idle" && this.#state.kind !== "active")
+		)
+			throw new Error(
+				"The Lix connection is closed or completing a transaction"
+			);
+		const executor =
+			this.#state.kind === "active" ? this.#state.transaction : this.lix;
+		let prepared = this.preparedQueries.get(compiledQuery.sql);
 		if (!prepared) {
 			const nextPrepared = prepareLixQuery(compiledQuery.sql);
 			prepared = nextPrepared;
-			this.#preparedQueries.set(compiledQuery.sql, prepared);
+			this.preparedQueries.set(compiledQuery.sql, prepared);
 		}
 		const parameters = prepared.parameterPositions.map(
 			(position) => compiledQuery.parameters[position - 1]

--- a/packages/sdk/src/project/snapshot.test.ts
+++ b/packages/sdk/src/project/snapshot.test.ts
@@ -1,0 +1,50 @@
+import { openLix } from "@lix-js/sdk";
+import { expect, test } from "vitest";
+import { registerInlangSchemas } from "../database/registerSchemas.js";
+import { projectToBlob, restoreProjectBlob } from "./snapshot.js";
+
+test("restoring snapshot files replaces initialized paths and preserves unrelated files", async () => {
+	const source = await openLix();
+	const destination = await openLix();
+	try {
+		await registerInlangSchemas(source);
+		await registerInlangSchemas(destination);
+		const snapshotContent = new Uint8Array([0, 255, 17]);
+		const initializedContent = new Uint8Array([12, 34]);
+		const unrelatedContent = new Uint8Array([56, 78]);
+		const putFile =
+			"INSERT INTO lix_file (path, content) VALUES ($1, $2) ON CONFLICT (path) DO UPDATE SET content = excluded.content";
+		await source.execute(putFile, ["/.lix/README.md", snapshotContent]);
+		await source.execute(putFile, ["/snapshot-only.txt", snapshotContent]);
+		await destination.execute(putFile, ["/.lix/README.md", initializedContent]);
+		await destination.execute(putFile, [
+			"/destination-only.txt",
+			unrelatedContent,
+		]);
+		const snapshot = await projectToBlob(source);
+
+		await restoreProjectBlob(destination, snapshot);
+		const restoredId = await destination.execute(
+			"SELECT value FROM lix_key_value WHERE key = 'lix_id'"
+		);
+		expect(restoredId.rows[0]?.value).toBe(
+			JSON.parse(await snapshot.text()).lixId
+		);
+
+		const { rows } = await destination.execute<{
+			path: string;
+			content: Uint8Array;
+		}>(
+			"SELECT path, content FROM lix_file WHERE path IN ($1, $2, $3) ORDER BY path",
+			["/.lix/README.md", "/destination-only.txt", "/snapshot-only.txt"]
+		);
+		expect(rows).toEqual([
+			{ path: "/.lix/README.md", content: snapshotContent },
+			{ path: "/destination-only.txt", content: unrelatedContent },
+			{ path: "/snapshot-only.txt", content: snapshotContent },
+		]);
+	} finally {
+		await source.close();
+		await destination.close();
+	}
+});

--- a/packages/sdk/src/project/snapshot.ts
+++ b/packages/sdk/src/project/snapshot.ts
@@ -105,7 +105,7 @@ export async function restoreProjectBlob(lix: Lix, blob: Blob): Promise<void> {
 	for (const file of snapshot.files) {
 		if (file.path === "/project_id") continue;
 		statements.push({
-			sql: "INSERT INTO lix_file (path, content) VALUES ($1, $2)",
+			sql: "INSERT INTO lix_file (path, content) VALUES ($1, $2) ON CONFLICT (path) DO UPDATE SET content = excluded.content",
 			params: [file.path, base64ToBytes(file.data)],
 		});
 	}


### PR DESCRIPTION
A failed Lix commit currently clears the adapter's transaction handle before Kysely requests rollback, so `No Lix transaction is active` replaces the real commit error. Preserve that error by modeling the consumed transaction explicitly and acknowledging its rollback cleanup.

Give each connection acquisition its own idempotent lease and lifecycle. Unrelated queries and concurrent transactions cannot share transaction state; controlled begin/commit/rollback failures release their lease; queries on consumed transactions reject instead of falling through to root autocommit. Delayed cleanup cannot release another caller's lease.

Snapshot restore now upserts content by path, so restoring into an initialized Lix repository replaces seeded files such as `/.lix/README.md` instead of failing on a duplicate path. A regression verifies exact binary content, inserted paths, preserved unrelated files, and the restored project ID.

This addresses the adapter half of #4413. The underlying mixed-schema native projection failure is fixed in companion https://github.com/opral/lix/pull/1752. No dependency version change is included here.

Validation:
- SDK suite: 137 passed across 22 files, 2 skipped, 2 todo; typecheck, build, and targeted ESLint passed.
- Regressions cover original error identity, query isolation, concurrent transactions, managed and controlled terminal failures, and stale lease cleanup.
- The original 171-key Paraglide reproduction with this adapter now exposes the underlying Lix field-count error instead of masking it.
- With the rebuilt Lix fix, Paraglide 2.25.1 compiles the original sorted-key reproduction, the 400-key case, and the 103-key/two-locale case; generated messages return the expected text.
- Independent sub-agent review and controlled-API QA probes passed.
