### PR TITLE
fix: upgrade Lix to 0.16.1 for sorted message imports

### DIFF
--- a/.changeset/fix-sorted-message-imports.md
+++ b/.changeset/fix-sorted-message-imports.md
@@ -1,0 +1,5 @@
+---
+"@inlang/sdk": patch
+---
+
+Upgrade Lix to 0.16.1 to fix importing alphabetically sorted messages when a transaction exceeds 512 tracked-state rows.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -39,7 +39,7 @@
 		"node": ">=20.0.0"
 	},
 	"dependencies": {
-		"@lix-js/sdk": "0.15.1",
+		"@lix-js/sdk": "0.16.1",
 		"@sinclair/typebox": "^0.31.17",
 		"kysely": "^0.28.12",
 		"uuid": "^14.0.0"

--- a/packages/sdk/src/project/loadProjectFromDirectory.test.ts
+++ b/packages/sdk/src/project/loadProjectFromDirectory.test.ts
@@ -422,13 +422,14 @@ describe("it should keep files between the inlang directory and lix in sync", as
 
 		const files = await selectLixFiles(project.lix);
 
-		expect(files.length).toBe(6);
+		expect(files.length).toBe(7);
 
 		const filesByPath = files.reduce((acc, file) => {
 			acc[file.path] = new TextDecoder().decode(file.content);
 			return acc;
 		}, {} as any);
 
+		expect(filesByPath["/.lix/README.md"]).toEqual(expect.any(String));
 		expect(filesByPath["/cache/plugin/29j49j2"]).toBe("cache value");
 		expect(filesByPath["/.gitignore"]).toBe("git value");
 		expect(filesByPath["/.meta.json"]).toBe(
@@ -483,13 +484,14 @@ describe("it should keep files between the inlang directory and lix in sync", as
 
 		const files = await selectLixFiles(project.lix);
 
-		expect(files.length).toBe(6);
+		expect(files.length).toBe(7);
 
 		const filesByPath = files.reduce((acc, file) => {
 			acc[file.path] = new TextDecoder().decode(file.content);
 			return acc;
 		}, {} as any);
 
+		expect(filesByPath["/.lix/README.md"]).toEqual(expect.any(String));
 		expect(filesByPath["/cache/plugin/29j49j2"]).toBe("cache value");
 		expect(filesByPath["/.gitignore"]).toBe("git value");
 		expect(filesByPath["/.meta.json"]).toBe(
@@ -501,7 +503,11 @@ describe("it should keep files between the inlang directory and lix in sync", as
 	});
 
 	test("does not rewrite unchanged files when nodePath.relative returns Windows separators", async () => {
-		const fs = Volume.fromJSON(mockDirectory);
+		const fs = Volume.fromJSON({
+			...mockDirectory,
+			// Lix initializes this file; include it so every synced file already exists.
+			"/project.inlang/.lix/README.md": "existing Lix readme",
+		});
 		const originalRelative = nodePath.relative.bind(nodePath);
 		const relativeSpy = vi
 			.spyOn(nodePath, "relative")

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -840,8 +840,8 @@ importers:
   packages/sdk:
     dependencies:
       '@lix-js/sdk':
-        specifier: 0.15.1
-        version: 0.15.1
+        specifier: 0.16.1
+        version: 0.16.1
       '@sinclair/typebox':
         specifier: ^0.31.17
         version: 0.31.28
@@ -3304,23 +3304,23 @@ packages:
     resolution: {integrity: sha512-B9X3FjD8WmdG7tbA44JuniSO0KdKBWnjfxl8zpgrDCkavrp/GP7U0xxBkc0WgeeoHjQ/pkqq9VqtWB2kS9jIUg==}
     deprecated: use the lix sdk instead https://www.npmjs.com/package/@lix-js/sdk
 
-  '@lix-js/sdk-darwin-arm64@0.15.1':
-    resolution: {integrity: sha512-RTe5hNe8lkF4uZ/ktKQFaXbFtowf617XTLs8Q/lPbAvCN/87A7KkmGyWV2mO8uZyposn/UO8q2NnD2yns8bPPA==}
+  '@lix-js/sdk-darwin-arm64@0.16.1':
+    resolution: {integrity: sha512-BKUerxQ5DV1o9L8n3uxZMTdUyjNGDLyh4zoYCQ1sakeAa2mQbb4aYnhYrpJT8Ob+zA5B/IZMQfphz6zOSrXNcw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@lix-js/sdk-linux-x64@0.15.1':
-    resolution: {integrity: sha512-gCEN5Ql2JvQn4MpwiILpmFxxO3AHAfmoa4mMvBWFwdKUICaJf5Yzr0zUfHEeLYtvcKpXbpu6dxyZ+AOc8I18ng==}
+  '@lix-js/sdk-linux-x64@0.16.1':
+    resolution: {integrity: sha512-xZxSKMiGFWFXbV+QFEfa0K+EBvgE7WIn32imVKQC/ZMfUnPH4SmdN2FbdS7qe2TAKdx38qUdI8mvcnrhNZ8nAw==}
     cpu: [x64]
     os: [linux]
 
-  '@lix-js/sdk-win32-x64@0.15.1':
-    resolution: {integrity: sha512-hyo2Sj67mBwhMZ2DFO1UgN4barByYiHojUnVQI9WGue5Slva5vBusbecQG1XSXrYv6HkVxLpS2zwUrr7DTjWQg==}
+  '@lix-js/sdk-win32-x64@0.16.1':
+    resolution: {integrity: sha512-1H84YqSd6VhzyUl5hdW4106QCnhO0NE9xRfT6ci6JvU/opNC9JWiOyKLboqlJWkupSIW9VlfL5Cwza6fZs5mLw==}
     cpu: [x64]
     os: [win32]
 
-  '@lix-js/sdk@0.15.1':
-    resolution: {integrity: sha512-mgtPwKg1Etx4NLGADesa+0DNkwVYOrSsIFVhv+VaBGJTisFYMVMucgzYXZQ1XHRpA1jxdFaKhheK3x3tArvv8Q==}
+  '@lix-js/sdk@0.16.1':
+    resolution: {integrity: sha512-TphGW47tPJ52n8Umk46j56veeaz/uLoS9m1pWYWs0UnnbItsntu6hW/alxW/OX1WZA7vXk7d1OP6qIbmluc+kA==}
 
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -13693,22 +13693,22 @@ snapshots:
     dependencies:
       typescript: 5.2.2
 
-  '@lix-js/sdk-darwin-arm64@0.15.1':
+  '@lix-js/sdk-darwin-arm64@0.16.1':
     optional: true
 
-  '@lix-js/sdk-linux-x64@0.15.1':
+  '@lix-js/sdk-linux-x64@0.16.1':
     optional: true
 
-  '@lix-js/sdk-win32-x64@0.15.1':
+  '@lix-js/sdk-win32-x64@0.16.1':
     optional: true
 
-  '@lix-js/sdk@0.15.1':
+  '@lix-js/sdk@0.16.1':
     dependencies:
       fflate: 0.8.3
     optionalDependencies:
-      '@lix-js/sdk-darwin-arm64': 0.15.1
-      '@lix-js/sdk-linux-x64': 0.15.1
-      '@lix-js/sdk-win32-x64': 0.15.1
+      '@lix-js/sdk-darwin-arm64': 0.16.1
+      '@lix-js/sdk-linux-x64': 0.16.1
+      '@lix-js/sdk-win32-x64': 0.16.1
 
   '@manypkg/find-root@1.1.0':
     dependencies:


### PR DESCRIPTION
Upgrade the SDK's pinned Lix engine to 0.16.1 so sorted message imports above 512 tracked-state rows compile successfully. This patch ships with the transaction and snapshot-restoration fixes already on main.

Update directory-sync test expectations for Lix's initialized `/.lix/README.md` and add a patch changeset.

Validation: SDK build/typecheck, 137 SDK tests passed, frozen lockfile install. The published Lix package also passed the reproduction matrices for opral/inlang#4413 and opral/paraglide-js#766 with the merged Inlang fixes.
